### PR TITLE
Feat: primary keys should be nonclustered by default

### DIFF
--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/AuditedConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/AuditedConfiguration.cs
@@ -21,7 +21,7 @@ public abstract class AuditedConfiguration<TEntity, TKey, TCreated, TModified> :
 	public virtual void Configure(EntityTypeBuilder<TEntity> builder)
 	{
 		builder.HasKey(e => e.Id)
-			.IsClustered();
+			.IsClustered(false);
 
 		builder.Property(e => e.Id)
 			.HasColumnOrder(1)

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/IdentityConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/IdentityConfiguration.cs
@@ -21,7 +21,7 @@ public abstract class IdentityConfiguration<TEntity, TKey> : IEntityTypeConfigur
 	public virtual void Configure(EntityTypeBuilder<TEntity> builder)
 	{
 		builder.HasKey(e => e.Id)
-			.IsClustered();
+			.IsClustered(false);
 
 		builder.Property(e => e.Id)
 			.HasColumnOrder(1)


### PR DESCRIPTION
changes:
- [feat: AuditedConfiguration modifed](https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore/commit/483f5eaf408d9b3a63863693795690f1a788b077)
- [feat: IdentityConfiguration modified](https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore/commit/b98e5565d7c8296ba8eec4f2962e367081c39da0)

closes #40 