### PR TITLE
Feat: default sql value when identity key guid

### DIFF
--- a/src/BB84.EntityFrameworkCore.Models.Abstractions/IAuditedCompositeModel.cs
+++ b/src/BB84.EntityFrameworkCore.Models.Abstractions/IAuditedCompositeModel.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using BB84.EntityFrameworkCore.Models.Abstractions.Components;
+﻿using BB84.EntityFrameworkCore.Models.Abstractions.Components;
 
 namespace BB84.EntityFrameworkCore.Models.Abstractions;
 

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/AuditedCompositeConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/AuditedCompositeConfiguration.cs
@@ -35,6 +35,18 @@ public abstract class AuditedCompositeConfiguration<TEntity, TCreated, TModified
 }
 
 /// <inheritdoc/>
+[SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
 public abstract class AuditedCompositeConfiguration<TEntity> : AuditedCompositeConfiguration<TEntity, string, string?>, IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IAuditedCompositeModel
-{ }
+{
+	public override void Configure(EntityTypeBuilder<TEntity> builder)
+	{
+		base.Configure(builder);
+
+		builder.Property(e => e.CreatedBy)
+			.HasColumnType("sysname");
+
+		builder.Property(e => e.ModifiedBy)
+			.HasColumnType("sysname");
+	}
+}

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/AuditedConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/AuditedConfiguration.cs
@@ -43,6 +43,22 @@ public abstract class AuditedConfiguration<TEntity, TKey, TCreated, TModified> :
 }
 
 /// <inheritdoc/>
+[SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
 public abstract class AuditedConfiguration<TEntity> : AuditedConfiguration<TEntity, Guid, string, string?>,
 	IEntityTypeConfiguration<TEntity> where TEntity : class, IAuditedModel
-{ }
+{
+	/// <inheritdoc/>
+	public override void Configure(EntityTypeBuilder<TEntity> builder)
+	{
+		base.Configure(builder);
+
+		builder.Property(p => p.Id)
+			.HasDefaultValueSql("NEWID()");
+
+		builder.Property(e => e.CreatedBy)
+			.HasColumnType("sysname");
+
+		builder.Property(e => e.ModifiedBy)
+			.HasColumnType("sysname");
+	}
+}

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/IdentityConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/IdentityConfiguration.cs
@@ -35,6 +35,16 @@ public abstract class IdentityConfiguration<TEntity, TKey> : IEntityTypeConfigur
 }
 
 /// <inheritdoc/>
+[SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
 public abstract class IdentityConfiguration<TEntity> : IdentityConfiguration<TEntity, Guid>,
 	IEntityTypeConfiguration<TEntity> where TEntity : class, IIdentityModel
-{ }
+{
+	/// <inheritdoc/>
+	public override void Configure(EntityTypeBuilder<TEntity> builder)
+	{
+		base.Configure(builder);
+
+		builder.Property(p => p.Id)
+			.HasDefaultValueSql("NEWID()");
+	}
+}

--- a/tests/BB84.EntityFrameworkCore.RepositoriesTests/Persistence/Configurations/JobTypeConfiguration.cs
+++ b/tests/BB84.EntityFrameworkCore.RepositoriesTests/Persistence/Configurations/JobTypeConfiguration.cs
@@ -10,6 +10,6 @@ internal sealed class JobTypeConfiguration : CompositeConfiguration<JobType>
 	{
 		base.Configure(builder);
 
-		builder.HasNoKey();
+		_ = builder.HasNoKey();
 	}
 }

--- a/tests/BB84.EntityFrameworkCore.RepositoriesTests/Persistence/Configurations/PersonConfiguration.cs
+++ b/tests/BB84.EntityFrameworkCore.RepositoriesTests/Persistence/Configurations/PersonConfiguration.cs
@@ -12,6 +12,6 @@ internal sealed class PersonConfiguration : AuditedConfiguration<Person>
 	{
 		base.Configure(builder);
 
-		builder.ToHistoryTable();
+		_ = builder.ToHistoryTable();
 	}
 }

--- a/tests/BB84.EntityFrameworkCore.RepositoriesTests/Persistence/Configurations/PersonJobConfiguration.cs
+++ b/tests/BB84.EntityFrameworkCore.RepositoriesTests/Persistence/Configurations/PersonJobConfiguration.cs
@@ -12,7 +12,7 @@ internal sealed class PersonJobConfiguration : AuditedCompositeConfiguration<Per
 	{
 		base.Configure(builder);
 
-		builder.HasKey(e => new { e.PersonId, e.JobId })
+		_ = builder.HasKey(e => new { e.PersonId, e.JobId })
 			.IsClustered();
 	}
 }

--- a/tests/BB84.EntityFrameworkCore.RepositoriesTests/Persistence/Configurations/PersonTypeConfiguration.cs
+++ b/tests/BB84.EntityFrameworkCore.RepositoriesTests/Persistence/Configurations/PersonTypeConfiguration.cs
@@ -9,7 +9,7 @@ internal sealed class PersonTypeConfiguration : EnumeratorConfiguration<PersonTy
 {
 	public override void Configure(EntityTypeBuilder<PersonType> builder)
 	{
-		builder.HasData(new List<PersonType>()
+		_ = builder.HasData(new List<PersonType>()
 		{
 			new()
 			{

--- a/tests/BB84.EntityFrameworkCore.RepositoriesTests/Persistence/Repositories/PersonJobRepository.cs
+++ b/tests/BB84.EntityFrameworkCore.RepositoriesTests/Persistence/Repositories/PersonJobRepository.cs
@@ -2,8 +2,6 @@
 using BB84.EntityFrameworkCore.RepositoriesTests.Abstractions;
 using BB84.EntityFrameworkCore.RepositoriesTests.Persistence.Models;
 
-using Microsoft.EntityFrameworkCore;
-
 namespace BB84.EntityFrameworkCore.RepositoriesTests.Persistence.Repositories;
 
 internal sealed class PersonJobRepository(ITestDbContext testContext) : GenericRepository<PersonJob>(testContext)

--- a/tests/BB84.EntityFrameworkCore.RepositoriesTests/PersonJobTests.cs
+++ b/tests/BB84.EntityFrameworkCore.RepositoriesTests/PersonJobTests.cs
@@ -59,7 +59,7 @@ public sealed class PersonJobTests : UnitTestBase
 		using TestDbContext dbContext = GetTestContext();
 		PersonJobRepository repository = new(dbContext);
 
-		var count = repository.CountAll(false);
+		int count = repository.CountAll(false);
 
 		Assert.AreEqual(0, count);
 	}
@@ -70,7 +70,7 @@ public sealed class PersonJobTests : UnitTestBase
 		using TestDbContext dbContext = GetTestContext();
 		PersonJobRepository repository = new(dbContext);
 
-		var count = repository.Count(x => x.PersonId.Equals(Guid.Empty));
+		int count = repository.Count(x => x.PersonId.Equals(Guid.Empty));
 
 		Assert.AreEqual(0, count);
 	}
@@ -81,7 +81,7 @@ public sealed class PersonJobTests : UnitTestBase
 		using TestDbContext dbContext = GetTestContext();
 		PersonJobRepository repository = new(dbContext);
 
-		var count = await repository.CountAllAsync(false)
+		int count = await repository.CountAllAsync(false)
 			.ConfigureAwait(false);
 
 		Assert.AreEqual(0, count);
@@ -93,7 +93,7 @@ public sealed class PersonJobTests : UnitTestBase
 		using TestDbContext dbContext = GetTestContext();
 		PersonJobRepository repository = new(dbContext);
 
-		var count = await repository.CountAsync(expression: x => x.PersonId.Equals(Guid.Empty))
+		int count = await repository.CountAsync(expression: x => x.PersonId.Equals(Guid.Empty))
 			.ConfigureAwait(false);
 
 		Assert.AreEqual(0, count);

--- a/tests/BB84.EntityFrameworkCore.RepositoriesTests/PersonTypeTests.cs
+++ b/tests/BB84.EntityFrameworkCore.RepositoriesTests/PersonTypeTests.cs
@@ -93,7 +93,7 @@ public sealed class PersonTypeTests : UnitTestBase
 		Assert.IsNotNull(result);
 
 		repository.Delete(result);
-		dbContext.SaveChanges();
+		_ = dbContext.SaveChanges();
 		Assert.IsTrue(result.IsDeleted);
 	}
 
@@ -107,7 +107,7 @@ public sealed class PersonTypeTests : UnitTestBase
 		Assert.IsNotNull(result);
 
 		await repository.DeleteAsync(result);
-		await dbContext.SaveChangesAsync();
+		_ = await dbContext.SaveChangesAsync();
 		Assert.IsTrue(result.IsDeleted);
 	}
 }

--- a/tests/BB84.EntityFrameworkCore.RepositoriesTests/UnitTestBase.cs
+++ b/tests/BB84.EntityFrameworkCore.RepositoriesTests/UnitTestBase.cs
@@ -15,7 +15,7 @@ public abstract class UnitTestBase
 	{
 		using TestDbContext dbContext = new(GetContextOptions(), Interceptor);
 
-		dbContext.Database.EnsureCreated();
+		_ = dbContext.Database.EnsureCreated();
 	}
 
 	[AssemblyCleanup]
@@ -23,7 +23,7 @@ public abstract class UnitTestBase
 	{
 		using TestDbContext dbContext = new(GetContextOptions(), Interceptor);
 
-		dbContext.Database.EnsureDeleted();
+		_ = dbContext.Database.EnsureDeleted();
 	}
 
 	public static DbContextOptions<TestDbContext> GetContextOptions()


### PR DESCRIPTION
changes:
- [feat: default sql value when identity key guid](https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore/commit/4910d15a9e432f6b1400066f00cbd6df7c61a35f)
- [feat: using sysname as default when auditing columns are of type `s…](https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore/commit/7aaa652ce7d6e70d5b66035571456af44d5e5774)
- [fix: small fixes to unit testing](https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore/commit/69c06d3be3393b503a20d3a7bb3f8fbc959e8582)

closes #45, #46