### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore/security/code-scanning/2](https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow file `.github/workflows/ci.yml`. The block can be added at the root level (before `jobs:`) to apply to all jobs in the workflow, or at the job level if different jobs require different permissions. In this case, since the workflow only runs build and test steps and does not appear to require write access to repository contents, the minimal permission required is `contents: read`. This change should be made at the top level of the workflow file, immediately after the `name:` and before `jobs:`. No additional imports or definitions are required.