### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   publish:
+    permissions:
+      contents: write
+      packages: write
     runs-on: windows-latest
 
     steps:
@@ -26,6 +29,8 @@ jobs:
         dotnet-releaser run --nuget-token "${{secrets.NUGET_TOKEN}}" --github-token "${{secrets.GITHUB_TOKEN}}" dotnet-releaser.toml
 
   docs:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore/security/code-scanning/3](https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore/security/code-scanning/3)

To fix the problem, we should explicitly set the `permissions` block in the workflow. The best approach is to add a `permissions` block at the job level for each job, specifying only the permissions required for that job. For most jobs, `contents: read` is sufficient, but jobs that deploy or publish (such as `publish` and `docs`) may require `contents: write` or other specific permissions. In this workflow:

- The `publish` job likely needs to create releases or push packages, so it may require `contents: write` and possibly `packages: write`.
- The `docs` job uses `peaceiris/actions-gh-pages@v4` to deploy documentation, which requires `contents: write` to push to the `gh-pages` branch.

Therefore, add the following to each job:
- Under `publish`:  
  ```yaml
  permissions:
    contents: write
    packages: write
  ```
- Under `docs`:  
  ```yaml
  permissions:
    contents: write
  ```

Add these blocks directly under each job name (i.e., after `publish:` and `docs:`).