### PR TITLE
Refactor: use IEnumerable<DbParameter> for all function/proc APIs

### DIFF
--- a/src/BB84.EntityFrameworkCore.Repositories/Extensions/DatabaseFacadeExtensions.Functions.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Extensions/DatabaseFacadeExtensions.Functions.cs
@@ -25,13 +25,13 @@ public static partial class DatabaseFacadeExtensions
 		this DatabaseFacade databaseFacade,
 		string schema,
 		string name,
-		params DbParameter[] parameters)
+		IEnumerable<DbParameter> parameters)
 	{
 		ArgumentNullException.ThrowIfNull(databaseFacade);
 
 		string sql = CreateTableFunctionCommand(schema, name, parameters);
 
-		return [.. databaseFacade.SqlQueryRaw<T>(sql, parameters)];
+		return [.. databaseFacade.SqlQueryRaw<T>(sql, [.. parameters])];
 	}
 
 	/// <summary>
@@ -41,22 +41,22 @@ public static partial class DatabaseFacadeExtensions
 	/// <param name="databaseFacade">The database facade to execute the table-valued function on.</param>
 	/// <param name="schema">The schema of the table-valued function.</param>
 	/// <param name="name">The name of the table-valued function.</param>
-	/// <param name="cancellationToken">The cancellation token to cancel the operation if needed.</param>
 	/// <param name="parameters">The parameters to pass to the table-valued function.</param>
-	/// <returns></returns>
+	/// <param name="cancellationToken">The cancellation token to cancel the operation if needed.</param>
+	/// <returns>The result of the table-valued function.</returns>
 	public static async Task<IReadOnlyList<T>> ExecuteTableFunctionAsync<T>(
 		this DatabaseFacade databaseFacade,
 		string schema,
 		string name,
-		CancellationToken cancellationToken = default,
-		params DbParameter[] parameters)
+		IEnumerable<DbParameter> parameters,
+		CancellationToken cancellationToken = default)
 	{
 		ArgumentNullException.ThrowIfNull(databaseFacade);
 
 		string sql = CreateTableFunctionCommand(schema, name, parameters);
 
 		return await databaseFacade
-			.SqlQueryRaw<T>(sql, parameters)
+			.SqlQueryRaw<T>(sql, [.. parameters])
 			.ToListAsync(cancellationToken)
 			.ConfigureAwait(false);
 	}
@@ -74,14 +74,14 @@ public static partial class DatabaseFacadeExtensions
 		this DatabaseFacade databaseFacade,
 		string schema,
 		string name,
-		params DbParameter[] parameters)
+		IEnumerable<DbParameter> parameters)
 	{
 		ArgumentNullException.ThrowIfNull(databaseFacade);
 
 		string sql = CreateScalarFunctionCommand(schema, name, parameters);
 
 		return databaseFacade
-			.SqlQueryRaw<T>(sql, parameters)
+			.SqlQueryRaw<T>(sql, [.. parameters])
 			.SingleOrDefault();
 	}
 
@@ -92,27 +92,27 @@ public static partial class DatabaseFacadeExtensions
 	/// <param name="databaseFacade">The database facade to execute the scalar-valued function on.</param>
 	/// <param name="schema">The schema of the scalar-valued function.</param>
 	/// <param name="name">The name of the scalar-valued function.</param>
-	/// <param name="cancellationToken">The cancellation token to cancel the operation if needed.</param>
 	/// <param name="parameters">The parameters to pass to the scalar-valued function.</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the operation if needed.</param>
 	/// <returns>The scalar result of the function.</returns>
 	public static async Task<T?> ExecuteScalarFunctionAsync<T>(
 		this DatabaseFacade databaseFacade,
 		string schema,
 		string name,
-		CancellationToken cancellationToken = default,
-		params DbParameter[] parameters)
+		IEnumerable<DbParameter> parameters,
+		CancellationToken cancellationToken = default)
 	{
 		ArgumentNullException.ThrowIfNull(databaseFacade);
 
 		string sql = CreateScalarFunctionCommand(schema, name, parameters);
 
 		return await databaseFacade
-			.SqlQueryRaw<T>(sql, parameters)
+			.SqlQueryRaw<T>(sql, [.. parameters])
 			.SingleOrDefaultAsync(cancellationToken)
 			.ConfigureAwait(false);
 	}
 
-	private static string CreateScalarFunctionCommand(string schema, string name, DbParameter[] parameters)
+	private static string CreateScalarFunctionCommand(string schema, string name, IEnumerable<DbParameter> parameters)
 	{
 		ArgumentNullException.ThrowIfNull(parameters);
 
@@ -121,7 +121,7 @@ public static partial class DatabaseFacadeExtensions
 		return $"SELECT [Value] = {GetObjectToken(schema, name)}({parameterPlaceholders})";
 	}
 
-	private static string CreateTableFunctionCommand(string schema, string name, DbParameter[] parameters)
+	private static string CreateTableFunctionCommand(string schema, string name, IEnumerable<DbParameter> parameters)
 	{
 		ArgumentNullException.ThrowIfNull(parameters);
 

--- a/src/BB84.EntityFrameworkCore.Repositories/Extensions/DatabaseFacadeExtensions.Procedures.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Extensions/DatabaseFacadeExtensions.Procedures.cs
@@ -21,19 +21,16 @@ public static partial class DatabaseFacadeExtensions
 	/// <param name="schema">The schema of the stored procedure.</param>
 	/// <param name="name">The name of the stored procedure.</param>
 	/// <param name="parameters">The parameters to pass to the stored procedure.</param>
-	/// <param name="outputParameter">An optional output parameter to capture the value returned by the stored procedure.</param>
 	/// <returns>A list of results returned by the stored procedure.</returns>
 	public static IReadOnlyList<T> ExecuteProcedure<T>(
 		this DatabaseFacade databaseFacade,
 		string schema,
 		string name,
-		DbParameter[] parameters,
-		DbParameter? outputParameter = null
-		)
+		IEnumerable<DbParameter> parameters)
 	{
 		ArgumentNullException.ThrowIfNull(databaseFacade);
 
-		(string sql, object[] sqlParameters) = CreateProcedureCommand(schema, name, parameters, outputParameter);
+		(string sql, object[] sqlParameters) = CreateProcedureCommand(schema, name, parameters);
 
 		return [.. databaseFacade.SqlQueryRaw<T>(sql, sqlParameters)];
 	}
@@ -46,20 +43,18 @@ public static partial class DatabaseFacadeExtensions
 	/// <param name="schema">The schema of the stored procedure.</param>
 	/// <param name="name">The name of the stored procedure.</param>
 	/// <param name="parameters">The parameters to pass to the stored procedure.</param>
-	/// <param name="outputParameter">An optional output parameter to capture the value returned by the stored procedure.</param>
 	/// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
 	/// <returns>A list of results returned by the stored procedure.</returns>
 	public static async Task<IReadOnlyList<T>> ExecuteProcedureAsync<T>(
 		this DatabaseFacade databaseFacade,
 		string schema,
 		string name,
-		DbParameter[] parameters,
-		DbParameter? outputParameter = null,
+		IEnumerable<DbParameter> parameters,
 		CancellationToken cancellationToken = default)
 	{
 		ArgumentNullException.ThrowIfNull(databaseFacade);
 
-		(string sql, object[] sqlParameters) = CreateProcedureCommand(schema, name, parameters, outputParameter);
+		(string sql, object[] sqlParameters) = CreateProcedureCommand(schema, name, parameters);
 
 		return await databaseFacade
 			.SqlQueryRaw<T>(sql, sqlParameters)
@@ -79,7 +74,7 @@ public static partial class DatabaseFacadeExtensions
 		this DatabaseFacade databaseFacade,
 		string schema,
 		string name,
-		DbParameter[] parameters)
+		IEnumerable<DbParameter> parameters)
 	{
 		ArgumentNullException.ThrowIfNull(databaseFacade);
 
@@ -101,8 +96,8 @@ public static partial class DatabaseFacadeExtensions
 		this DatabaseFacade databaseFacade,
 		string schema,
 		string name,
-		DbParameter[] parameters,
-		CancellationToken cancellationToken)
+		IEnumerable<DbParameter> parameters,
+		CancellationToken cancellationToken = default)
 	{
 		ArgumentNullException.ThrowIfNull(databaseFacade);
 
@@ -116,22 +111,13 @@ public static partial class DatabaseFacadeExtensions
 	private static (string Sql, object[] Parameters) CreateProcedureCommand(
 		string schema,
 		string name,
-		DbParameter[] parameters,
-		DbParameter? outputParameter = null)
+		IEnumerable<DbParameter> parameters)
 	{
 		ArgumentNullException.ThrowIfNull(parameters);
 
-		List<DbParameter> commandParameters = [.. parameters];
-
-		if (outputParameter is not null && commandParameters.Any(p => string.Equals(p.ParameterName, outputParameter.ParameterName, StringComparison.OrdinalIgnoreCase)))
-			throw new ArgumentException("The output parameter is already included in the parameters array.", nameof(outputParameter));
-
-		if (outputParameter is not null)
-			commandParameters.Add(outputParameter);
-
 		List<string> assignments = [];
 
-		foreach (DbParameter parameter in commandParameters)
+		foreach (DbParameter parameter in parameters)
 		{
 			string token = GetParameterToken(parameter);
 			bool isOutput = parameter.Direction is ParameterDirection.Output or ParameterDirection.InputOutput;
@@ -146,6 +132,6 @@ public static partial class DatabaseFacadeExtensions
 		if (assignments.Count > 0)
 			sql = $"{sql} {string.Join(", ", assignments)}";
 
-		return (sql, [.. commandParameters]);
+		return (sql, [.. parameters]);
 	}
 }

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/DatabaseFacadeExtensionsTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/DatabaseFacadeExtensionsTests.cs
@@ -84,9 +84,10 @@ public sealed class DatabaseFacadeExtensionsTests : UnitTestBase
 	{
 		using TestDbContext dbContext = GetTestContext();
 
-		SqlParameter input = new("@Input", SqlDbType.Int) { Value = 5 };
+		IEnumerable<SqlParameter> sqlParameters = [new("@Input", SqlDbType.Int) { Value = 5 }];
 
-		int? result = dbContext.Database.ExecuteScalarFunction<int>(Schema, GetScalarValueFunctionName, input);
+		int result = dbContext.Database
+			.ExecuteScalarFunction<int>(Schema, GetScalarValueFunctionName, sqlParameters);
 
 		Assert.AreEqual(10, result);
 	}
@@ -96,10 +97,10 @@ public sealed class DatabaseFacadeExtensionsTests : UnitTestBase
 	{
 		using TestDbContext dbContext = GetTestContext();
 
-		SqlParameter input = new("@Input", SqlDbType.Int) { Value = 7 };
+		IEnumerable<SqlParameter> sqlParameters = [new("@Input", SqlDbType.Int) { Value = 7 }];
 
-		int? result = await dbContext.Database
-			.ExecuteScalarFunctionAsync<int>(Schema, GetScalarValueFunctionName, _testToken, input)
+		int result = await dbContext.Database
+			.ExecuteScalarFunctionAsync<int>(Schema, GetScalarValueFunctionName, sqlParameters, _testToken)
 			.ConfigureAwait(false);
 
 		Assert.AreEqual(14, result);
@@ -110,9 +111,10 @@ public sealed class DatabaseFacadeExtensionsTests : UnitTestBase
 	{
 		using TestDbContext dbContext = GetTestContext();
 
-		SqlParameter count = new("@Count", SqlDbType.Int) { Value = 3 };
+		IEnumerable<SqlParameter> sqlParameters = [new("@Count", SqlDbType.Int) { Value = 3 }];
 
-		IReadOnlyList<int> result = dbContext.Database.ExecuteTableFunction<int>(Schema, GetTableValuesFunctionName, count);
+		IReadOnlyList<int> result = dbContext.Database
+			.ExecuteTableFunction<int>(Schema, GetTableValuesFunctionName, sqlParameters);
 
 		Assert.HasCount(3, result);
 	}
@@ -122,10 +124,10 @@ public sealed class DatabaseFacadeExtensionsTests : UnitTestBase
 	{
 		using TestDbContext dbContext = GetTestContext();
 
-		SqlParameter count = new("@Count", SqlDbType.Int) { Value = 2 };
+		IEnumerable<SqlParameter> sqlParameters = [new("@Count", SqlDbType.Int) { Value = 2 }];
 
 		IReadOnlyList<int> result = await dbContext.Database
-			.ExecuteTableFunctionAsync<int>(Schema, GetTableValuesFunctionName, _testToken, count)
+			.ExecuteTableFunctionAsync<int>(Schema, GetTableValuesFunctionName, sqlParameters, _testToken)
 			.ConfigureAwait(false);
 
 		Assert.HasCount(2, result);
@@ -138,7 +140,8 @@ public sealed class DatabaseFacadeExtensionsTests : UnitTestBase
 
 		SqlParameter input = new("@Input", SqlDbType.Int) { Value = 42 };
 
-		IReadOnlyList<int> result = dbContext.Database.ExecuteProcedure<int>(Schema, GetValuesProcedureName, [input]);
+		IReadOnlyList<int> result = dbContext.Database
+			.ExecuteProcedure<int>(Schema, GetValuesProcedureName, [input]);
 
 		Assert.HasCount(1, result);
 		Assert.AreEqual(42, result[0]);
@@ -167,7 +170,8 @@ public sealed class DatabaseFacadeExtensionsTests : UnitTestBase
 		SqlParameter input = new("@Input", SqlDbType.Int) { Value = 4 };
 		SqlParameter output = new("@Output", SqlDbType.Int) { Direction = ParameterDirection.Output };
 
-		IReadOnlyList<int> result = dbContext.Database.ExecuteProcedure<int>(Schema, SetValueProcedureName, [input], output);
+		IReadOnlyList<int> result = dbContext.Database
+			.ExecuteProcedure<int>(Schema, SetValueProcedureName, [input, output]);
 
 		Assert.AreEqual(12, output.Value);
 	}
@@ -181,7 +185,7 @@ public sealed class DatabaseFacadeExtensionsTests : UnitTestBase
 		SqlParameter output = new("@Output", SqlDbType.Int) { Direction = ParameterDirection.Output };
 
 		IReadOnlyList<int> result = await dbContext.Database
-			.ExecuteProcedureAsync<int>(Schema, SetValueProcedureName, [input], output, _testToken)
+			.ExecuteProcedureAsync<int>(Schema, SetValueProcedureName, [input, output], _testToken)
 			.ConfigureAwait(false);
 
 		Assert.AreEqual(15, output.Value);
@@ -194,7 +198,8 @@ public sealed class DatabaseFacadeExtensionsTests : UnitTestBase
 
 		SqlParameter input = new("@Input", SqlDbType.Int) { Value = 1 };
 
-		int rowsAffected = dbContext.Database.ExecuteProcedure(Schema, GetValuesProcedureName, [input]);
+		int rowsAffected = dbContext.Database
+			.ExecuteProcedure(Schema, GetValuesProcedureName, [input]);
 
 		Assert.AreEqual(-1, rowsAffected);
 	}
@@ -207,7 +212,7 @@ public sealed class DatabaseFacadeExtensionsTests : UnitTestBase
 		SqlParameter input = new("@Input", SqlDbType.Int) { Value = 1 };
 
 		int rowsAffected = await dbContext.Database
-			.ExecuteProcedureAsync(Schema, GetValuesProcedureName, [input], default)
+			.ExecuteProcedureAsync(Schema, GetValuesProcedureName, [input], _testToken)
 			.ConfigureAwait(false);
 
 		Assert.AreEqual(-1, rowsAffected);


### PR DESCRIPTION
**Changes:**

- Update `DatabaseFacadeExtensions` to accept `IEnumerable<DbParameter>` instead of params arrays for all function and procedure execution methods (sync and async).
- Simplify output parameter handling by requiring all parameters (including output) in the enumerable.
- Update tests and documentation accordingly for improved API consistency and flexibility.