### PR TITLE
docs: fix XML comment typos

### DIFF
--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/AuditedConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/AuditedConfiguration.cs
@@ -15,7 +15,7 @@ namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations;
 
 /// <summary>
 /// Represents an abstract base class for configuring the entities of type
-/// <see cref="IAuditedEntity{TKey, TCreator, TEdited}"/> for dentity-related and time audited
+/// <see cref="IAuditedEntity{TKey, TCreator, TEdited}"/> for identity-related and time audited
 /// entities in the Entity Framework Core model.
 /// </summary>
 /// <remarks>

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Extensions/PropertyBuilderExtensions.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Extensions/PropertyBuilderExtensions.cs
@@ -44,7 +44,7 @@ public static class PropertyBuilderExtensions
 	/// Configures the data type of the column to <b>date time</b> when targeting a relational database.
 	/// </summary>
 	/// <param name="builder">The builder for the property being configured.</param>
-	/// <param name="small">Inidactes if <b>small date time</b> should be used.</param>
+	/// <param name="small">Indicates if <b>small date time</b> should be used.</param>
 	/// <returns>The same builder instance so that multiple calls can be chained.</returns>
 	public static PropertyBuilder IsDateTimeColumn(this PropertyBuilder builder, bool small = false)
 		=> builder.HasColumnType(small ? "smalldatetime" : "datetime");
@@ -53,7 +53,7 @@ public static class PropertyBuilderExtensions
 	/// Configures the data type of the column to <b>money</b> when targeting a relational database.
 	/// </summary>
 	/// <param name="builder">The builder for the property being configured.</param>
-	/// <param name="small">Inidactes if <b>small money</b> should be used.</param>
+	/// <param name="small">Indicates if <b>small money</b> should be used.</param>
 	/// <returns>The same builder instance so that multiple calls can be chained.</returns>
 	public static PropertyBuilder IsMoneyColumn(this PropertyBuilder builder, bool small = false)
 		=> builder.HasColumnType(small ? "smallmoney" : "money");


### PR DESCRIPTION
## Summary
- addresses the XML documentation typos reported in #171 and #172
- changes `dentity-related` to `identity-related` in `AuditedConfiguration` docs
- changes two `Inidactes` parameter descriptions to `Indicates` in `PropertyBuilderExtensions` docs

## Validation
- `rg -n "dentity|identity-related|Inidactes|Indicates" src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/AuditedConfiguration.cs src/BB84.EntityFrameworkCore.Repositories.SqlServer/Extensions/PropertyBuilderExtensions.cs -S`
- `git diff --check`

I did not run the full .NET build/test suite because `dotnet` is not installed in my local environment. This change is limited to XML documentation comments and does not alter executable code.