### PR TITLE
fix(entities): fix typo in `IEnumerator` interface documentation

### DIFF
--- a/src/BB84.EntityFrameworkCore.Entities.Abstractions/Components/IEnumerator.cs
+++ b/src/BB84.EntityFrameworkCore.Entities.Abstractions/Components/IEnumerator.cs
@@ -10,7 +10,7 @@ namespace BB84.EntityFrameworkCore.Entities.Abstractions.Components;
 /// </summary>
 /// <remarks>
 /// The <see cref="IEnumerator"/> interface is designed to provide a standardized way to
-/// efine enumerators within entities. It includes properties for the name and description
+/// define enumerators within entities. It includes properties for the name and description
 /// so that each enumerator can be clearly identified and documented.
 /// </remarks>
 public interface IEnumerator


### PR DESCRIPTION
**Changes:**

- Corrected a typographical error in the XML documentation for the `IEnumerator` interface.
- The word "efine" was updated to "define" to improve clarity and ensure accurate documentation.

closes #168