### PR TITLE
fix(entities): fix incorrect `<inheritdoc>` reference in `IIdentity` interface

### DIFF
--- a/src/BB84.EntityFrameworkCore.Entities.Abstractions/Components/IIdentity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities.Abstractions/Components/IIdentity.cs
@@ -17,6 +17,6 @@ public interface IIdentity<TKey> where TKey : IEquatable<TKey>
 	TKey Id { get; set; }
 }
 
-/// <inheritdoc cref="IIdentityEntity{TKey}"/>
+/// <inheritdoc cref="IIdentity{TKey}"/>
 public interface IIdentity : IIdentity<Guid>
 { }


### PR DESCRIPTION
**Changes:**

- The XML documentation comment for the `IIdentity` interface was updated to reference the correct interface.
- It previously referenced `IIdentityEntity{TKey}` but was corrected to reference `IIdentity{TKey}`.
- This ensures proper inheritance of documentation and aligns with the intended interface structure.

closes #169 