### PR TITLE
fix: remove duplicate word 'entities' in CompositeEntity XML docs

### DIFF
--- a/src/BB84.EntityFrameworkCore.Entities/CompositeEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities/CompositeEntity.cs
@@ -8,7 +8,7 @@ using BB84.EntityFrameworkCore.Entities.Abstractions;
 namespace BB84.EntityFrameworkCore.Entities;
 
 /// <summary>
-/// This abstract class provides a base implementation for entities entities that are
+/// This abstract class provides a base implementation for entities that are
 /// composed of multiple related components.
 /// </summary>
 public abstract class CompositeEntity : ICompositeEntity


### PR DESCRIPTION
## Summary
Remove duplicate word 'entities' in the XML documentation summary for the CompositeEntity class.

## Issue
Fixes #170

## Change
- src/BB84.EntityFrameworkCore.Entities/CompositeEntity.cs line 11: corrected 'entities entities that are' to 'entities that are'

## Testing
- Verified XML documentation parses correctly