### PR TITLE
fix(ToHistoryTable): add validation and improve docs for `ToHistoryTable` method

### DIFF
--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Extensions/EntityTypeBuilderExtensions.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Extensions/EntityTypeBuilderExtensions.cs
@@ -33,8 +33,16 @@ public static class EntityTypeBuilderExtensions
 	/// <returns>
 	/// The same <see cref="EntityTypeBuilder"/> instance, so that multiple calls can be chained together.
 	/// </returns>
-	public static EntityTypeBuilder ToHistoryTable(this EntityTypeBuilder builder, string? tableName = null, string? tableSchema = "dbo", string historySchema = "history")
+	/// <exception cref="ArgumentNullException">Thrown if the <paramref name="builder"/> is null.</exception>
+	/// <exception cref="ArgumentException">
+	/// Thrown if the <paramref name="tableSchema"/> or <paramref name="historySchema"/> is null, empty, or whitespace.
+	/// </exception>
+	public static EntityTypeBuilder ToHistoryTable(this EntityTypeBuilder builder, string? tableName = null, string tableSchema = "dbo", string historySchema = "history")
 	{
+		ArgumentNullException.ThrowIfNull(builder);
+		ArgumentException.ThrowIfNullOrWhiteSpace(tableSchema);
+		ArgumentException.ThrowIfNullOrWhiteSpace(historySchema);
+
 		tableName ??= builder.Metadata.ClrType.Name;
 
 		return builder.ToTable(tableName, tableSchema, tb


### PR DESCRIPTION
**Changes:**

Updated the `ToHistoryTable` method in `EntityTypeBuilderExtensions`:

- Added `<exception>` tags to document thrown exceptions.
- Changed `tableSchema` from nullable to non-nullable.
- Added validation for `builder`, `tableSchema`, and `historySchema`:
  - Throws `ArgumentNullException` if `builder` is null.
  - Throws `ArgumentException` if `tableSchema` or `historySchema` is null, empty, or whitespace.

These changes enhance robustness and clarify usage.

closes #177 & closes #178 