### PR TITLE
fix(repositories): remove unused `SqlExpressions` using directive

### DIFF
--- a/src/BB84.EntityFrameworkCore.Repositories/GenericRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/GenericRepository.cs
@@ -9,7 +9,6 @@ using BB84.EntityFrameworkCore.Repositories.Abstractions;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
-using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
 namespace BB84.EntityFrameworkCore.Repositories;
 


### PR DESCRIPTION
**Changes:**

- Removed the unnecessary `Microsoft.EntityFrameworkCore.Query.SqlExpressions` using directive from `GenericRepository.cs` to clean up unused references.

closes #173 