### PR TITLE
fix(interceptors): use `DateTimeOffset.UtcNow` for audit timestamps

### DIFF
--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Interceptors/TimeAuditedInterceptor.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Interceptors/TimeAuditedInterceptor.cs
@@ -55,10 +55,10 @@ public sealed class TimeAuditedInterceptor : SaveChangesInterceptor
 				switch (entityEntry.State)
 				{
 					case EntityState.Added:
-						entityEntry.Entity.CreatedAt = DateTime.UtcNow;
+						entityEntry.Entity.CreatedAt = DateTimeOffset.UtcNow;
 						continue;
 					case EntityState.Modified:
-						entityEntry.Entity.EditedAt = DateTime.UtcNow;
+						entityEntry.Entity.EditedAt = DateTimeOffset.UtcNow;
 						continue;
 					case EntityState.Detached:
 					case EntityState.Unchanged:


### PR DESCRIPTION
**Changes:**

- Updated `CreatedAt` and `EditedAt` assignments in `ITimeAudited` entities to use `DateTimeOffset.UtcNow` instead of `DateTime.UtcNow`.
- This change ensures timestamps include offset information for improved time zone consistency.

closes #167 