### PR TITLE
feat(extensions): add generic `EntityTypeBuilder<TEntity>` overload for `ToHistoryTable`

### DIFF
--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Extensions/EntityTypeBuilderExtensions.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Extensions/EntityTypeBuilderExtensions.cs
@@ -30,25 +30,71 @@ public static class EntityTypeBuilderExtensions
 	/// <param name="tableName">The name of the database table.</param>
 	/// <param name="tableSchema">The schema of the database table.</param>
 	/// <param name="historyTableName">The name of the database history table.</param>
-	/// <param name="historySchema">The schema of the database history table.</param>
+	/// <param name="historyTableSchema">The schema of the database history table.</param>
 	/// <returns>
 	/// The same <see cref="EntityTypeBuilder"/> instance, so that multiple calls can be chained together.
 	/// </returns>
 	/// <exception cref="ArgumentNullException">Thrown if the <paramref name="builder"/> is null.</exception>
 	/// <exception cref="ArgumentException">
-	/// Thrown if the <paramref name="tableSchema"/> or <paramref name="historySchema"/> is null, empty, or whitespace.
+	/// Thrown if the <paramref name="tableSchema"/> or <paramref name="historyTableSchema"/> is null, empty, or whitespace.
 	/// </exception>
-	public static EntityTypeBuilder ToHistoryTable(this EntityTypeBuilder builder, string? tableName = null, string tableSchema = "dbo", string? historyTableName = null, string historySchema = "history")
+	public static EntityTypeBuilder ToHistoryTable(
+		this EntityTypeBuilder builder,
+		string? tableName = null,
+		string tableSchema = "dbo",
+		string? historyTableName = null,
+		string historyTableSchema = "history")
 	{
 		ArgumentNullException.ThrowIfNull(builder);
 		ArgumentException.ThrowIfNullOrWhiteSpace(tableSchema);
-		ArgumentException.ThrowIfNullOrWhiteSpace(historySchema);
+		ArgumentException.ThrowIfNullOrWhiteSpace(historyTableSchema);
 
 		tableName ??= builder.Metadata.ClrType.Name;
 		historyTableName ??= tableName;
 
-		return builder.ToTable(tableName, tableSchema, tb
-			=> tb.IsTemporal(ttb
-				=> ttb.UseHistoryTable(historyTableName, historySchema)));
+		return builder.ToTable(tableName, tableSchema, tableBuilder
+			=> tableBuilder.IsTemporal(temporalTableBuilder
+				=> temporalTableBuilder.UseHistoryTable(historyTableName, historyTableSchema)));
+	}
+
+	/// <summary>
+	/// Configures the entity to use a temporal table with a history table for tracking changes over time.
+	/// </summary>
+	/// <remarks>
+	/// This method configures the entity to use SQL Server temporal tables, which automatically track 
+	/// historical changes to the data. The history table is created in the specified schema and is used
+	/// to store historical versions of the data.
+	/// </remarks>
+	/// <typeparam name="TEntity"></typeparam>
+	/// <param name="builder">The <see cref="EntityTypeBuilder{TEntity}"/> used to configure the entity type.</param>
+	/// <param name="tableName">The name of the database table.</param>
+	/// <param name="tableSchema">The schema of the database table.</param>
+	/// <param name="historyTableName">The name of the database history table.</param>
+	/// <param name="historyTableSchema">The schema of the database history table.</param>
+	/// <returns>
+	/// The same <see cref="EntityTypeBuilder{TEntity}"/> instance, so that multiple calls can be chained together.
+	/// </returns>
+	/// <exception cref="ArgumentNullException">Thrown if the <paramref name="builder"/> is null.</exception>
+	/// <exception cref="ArgumentException">
+	/// Thrown if the <paramref name="tableSchema"/> or <paramref name="historyTableSchema"/> is null, empty, or whitespace.
+	/// </exception>
+	public static EntityTypeBuilder<TEntity> ToHistoryTable<TEntity>(
+		this EntityTypeBuilder<TEntity> builder,
+		string? tableName = null,
+		string tableSchema = "dbo",
+		string? historyTableName = null,
+		string historyTableSchema = "history")
+		where TEntity : class
+	{
+		ArgumentNullException.ThrowIfNull(builder);
+		ArgumentException.ThrowIfNullOrWhiteSpace(tableSchema);
+		ArgumentException.ThrowIfNullOrWhiteSpace(historyTableSchema);
+
+		tableName ??= builder.Metadata.ClrType.Name;
+		historyTableName ??= tableName;
+
+		return builder.ToTable(tableName, tableSchema, tableBuilder
+			=> tableBuilder.IsTemporal(temporalTableBuilder
+				=> temporalTableBuilder.UseHistoryTable(historyTableName, historyTableSchema)));
 	}
 }

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/Persistence/Configurations/JobConfiguration.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/Persistence/Configurations/JobConfiguration.cs
@@ -4,9 +4,9 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 using BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations;
+using BB84.EntityFrameworkCore.Repositories.SqlServer.Extensions;
 using BB84.EntityFrameworkCore.Repositories.Tests.Persistence.Entities;
 
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace BB84.EntityFrameworkCore.Repositories.Tests.Persistence.Configurations;
@@ -15,7 +15,7 @@ internal sealed class JobConfiguration : IdentityConfiguration<JobEntity>
 {
 	public override void Configure(EntityTypeBuilder<JobEntity> builder)
 	{
-		builder.ToTable("Jobs");
+		builder.ToHistoryTable("Jobs", "tab", "OldJobs", "hist");
 
 		base.Configure(builder);
 	}


### PR DESCRIPTION
**Changes:**

- Added a generic overload to preserve type safety when chaining calls inside `IEntityTypeConfiguration<T>.Configure()`.
- Renamed `historySchema` to `historyTableSchema` in `ToHistoryTable` for clarity.
- Updated `JobConfiguration` to use `ToHistoryTable` with custom table and schema names.

closes #184 