### PR TITLE
feat(extensions): add `IsDateTimeOffsetColumn` extension for `PropertyBuilder`

### DIFF
--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Extensions/PropertyBuilderExtensions.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Extensions/PropertyBuilderExtensions.cs
@@ -50,6 +50,19 @@ public static class PropertyBuilderExtensions
 		=> builder.HasColumnType(small ? "smalldatetime" : "datetime");
 
 	/// <summary>
+	/// Configures the data type of the column to <c>datetimeoffset</c> when targeting a relational database.
+	/// </summary>
+	/// <param name="builder">The builder for the property being configured.</param>
+	/// <param name="precision">The optional type parameter fractional seconds precision specifies the number
+	/// of digits for the fractional part of the seconds.</param>
+	/// <returns>The same builder instance so that multiple calls can be chained.</returns>
+	/// <exception cref="ArgumentOutOfRangeException"></exception>
+	public static PropertyBuilder IsDateTimeOffsetColumn(this PropertyBuilder builder, int precision = 7)
+		=> precision is < 0 or > 7
+			? throw new ArgumentOutOfRangeException(nameof(precision), "Must be between 0 and 7.")
+			: builder.HasColumnType($"datetimeoffset({precision})");
+
+	/// <summary>
 	/// Configures the data type of the column to <b>money</b> when targeting a relational database.
 	/// </summary>
 	/// <param name="builder">The builder for the property being configured.</param>

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/Persistence/Configurations/PersonConfiguration.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/Persistence/Configurations/PersonConfiguration.cs
@@ -23,6 +23,9 @@ internal sealed class PersonConfiguration : AuditedConfiguration<PersonEntity>
 		builder.Property(x => x.DateOfBirth)
 			.IsDateColumn();
 
+		builder.Property(p=>p.StartDate)
+			.IsDateTimeOffsetColumn();
+
 		builder.Property(x => x.Salary)
 			.IsMoneyColumn(true);
 

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/Persistence/Entities/PersonEntity.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/Persistence/Entities/PersonEntity.cs
@@ -15,6 +15,7 @@ public sealed class PersonEntity : AuditedEntity
 	public DateTime? DateOfBirth { get; set; }
 	public decimal Salary { get; set; }
 	public string? Settings { get; set; }
+	public DateTimeOffset StartDate { get; set; }
 
 	public PersonTypeEntity Type { get; set; } = default!;
 	public ICollection<PersonJobEntity>? PersonJobs { get; set; }


### PR DESCRIPTION
**Changes:**

- Introduce `IsDateTimeOffsetColumn` method to configure properties as SQL Server datetimeoffset columns with optional precision (0-7).
- Includes XML docs and validation for precision range.

closes #181 