### PR TITLE
feat(docs): rewrite and reorganize of all package and repository `README` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,741 +14,79 @@
 [![RepoSize](https://img.shields.io/github/repo-size/BoBoBaSs84/BB84.EntityFrameworkCore)](https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore)
 [![Release](https://img.shields.io/github/v/release/BoBoBaSs84/BB84.EntityFrameworkCore)](https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore/releases/latest)
 
-## 🧭 Overview
+## 🔎 Overview
 
-**BB84.EntityFrameworkCore** is a comprehensive .NET 8.0 & .NET 10.0 library that provides a reusable repository pattern implementation for ASP.NET Core applications. The library offers commonly used entity abstractions, their default implementations, and repository abstractions with their corresponding implementations, specifically designed to work seamlessly with Entity Framework Core.
+**BB84.EntityFrameworkCore** is a .NET 8.0 & .NET 10.0 library collection that provides a reusable repository pattern implementation for Entity Framework Core applications. It ships as five focused NuGet packages that can be adopted incrementally.
 
-### Key Features
+## 📦 Packages
 
-- **Generic Repository Pattern**: Complete implementation of the repository pattern with CRUD operations
-- **Entity Abstractions**: Pre-built interfaces for common entity types (Identity, Audited, Composite, etc.)
-- **SQL Server Integration**: Specialized configurations and extensions for SQL Server
-- **Auditing Support**: Built-in support for creation and modification tracking
-- **Soft Delete**: Integrated soft delete functionality
-- **Concurrency Control**: Built-in optimistic concurrency support
-- **Type Safety**: Strongly typed implementations with generic constraints
+| Package                                                                                                                | Description                                                       |
+| ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| [BB84.EntityFrameworkCore.Entities.Abstractions](src/BB84.EntityFrameworkCore.Entities.Abstractions/README.md)         | Core entity interface definitions — no dependencies               |
+| [BB84.EntityFrameworkCore.Entities](src/BB84.EntityFrameworkCore.Entities/README.md)                                   | Default implementations of the entity abstractions                |
+| [BB84.EntityFrameworkCore.Repositories.Abstractions](src/BB84.EntityFrameworkCore.Repositories.Abstractions/README.md) | Repository interface definitions                                  |
+| [BB84.EntityFrameworkCore.Repositories](src/BB84.EntityFrameworkCore.Repositories/README.md)                           | Default repository implementations and `DatabaseFacadeExtensions` |
+| [BB84.EntityFrameworkCore.Repositories.SqlServer](src/BB84.EntityFrameworkCore.Repositories.SqlServer/README.md)       | SQL Server entity configurations, interceptors, and extensions    |
 
-### Target Framework
-
-- **.NET 8.0** - LTS support until November 2026
-- **.NET 10.0** - Latest LTS version of .NET
-
-## 🏗 Project Structure
-
-```
-BB84.EntityFrameworkCore/
-├── src/                                                    # Source code
-│   ├── BB84.EntityFrameworkCore.Entities.Abstractions/     # Entity interfaces
-│   ├── BB84.EntityFrameworkCore.Entities/                  # Entity implementations
-│   ├── BB84.EntityFrameworkCore.Repositories.Abstractions/ # Repository interfaces
-│   ├── BB84.EntityFrameworkCore.Repositories/              # Repository implementations
-│   └── BB84.EntityFrameworkCore.Repositories.SqlServer/    # SQL Server specific features
-├── tests/                                                  # Unit tests
-│   ├── BB84.EntityFrameworkCore.Entities.Tests/
-│   └── BB84.EntityFrameworkCore.Repositories.Tests/
-├── docs/                                                   # Documentation
-├── Directory.Build.props                                   # Build configuration
-├── Directory.Packages.props                                # Package management
-└── BB84.EntityFrameworkCore.sln                            # Solution file
-```
-
-## 📦 Package Architecture
-
-The project is organized into five distinct NuGet packages, each serving a specific purpose:
-
-### BB84.EntityFrameworkCore.Entities.Abstractions
-
-**Purpose**: Core entity interface definitions
-**Dependencies**: None
-
-This package contains the fundamental interfaces that define the contract for different types of entities:
-
-- `IIdentityEntity<TKey>` - Entities with unique identifiers
-- `IAuditedEntity<TKey, TCreator, TEdited>` - Entities with creation/modification tracking
-- `IFullAuditedEntity<TKey, TCreator, TEdited>` - Entities with full audit trails including soft delete
-- `ICompositeEntity` - Entities with composite keys
-- `IEnumeratorEntity<TKey>` - Entities representing enumeration values
-
-**Component Interfaces**:
-
-- `IIdentity<TKey>` - Provides unique identification
-- `IConcurrency` - Provides optimistic concurrency control
-- `ITimeAudited` - Tracks creation and modification timestamps
-- `IUserAudited<TCreator, TEdited>` - Tracks user information for auditing
-- `ISoftDeletable` - Provides soft delete functionality
-
-### BB84.EntityFrameworkCore.Entities
-
-**Purpose**: Default implementations of entity abstractions
-**Dependencies**: BB84.EntityFrameworkCore.Entities.Abstractions
-
-Provides concrete implementations of the entity interfaces:
-
-- `IdentityEntity<TKey>` - Base class for entities with identity
-- `AuditedEntity<TKey, TCreator, TEdited>` - Base class for audited entities
-- `FullAuditedEntity<TKey, TCreator, TEdited>` - Base class for fully audited entities
-- `CompositeEntity` - Base class for composite key entities
-- `EnumeratorEntity<TKey>` - Base class for enumeration entities
-
-### BB84.EntityFrameworkCore.Repositories.Abstractions
-
-**Purpose**: Repository interface definitions
-**Dependencies**:
-
-- BB84.EntityFrameworkCore.Entities.Abstractions
-- Microsoft.EntityFrameworkCore.Relational (9.0.6)
-
-Core repository interfaces:
-
-- `IDbContext` - Database context abstraction
-- `IGenericRepository<TEntity>` - Generic CRUD operations
-- `IIdentityRepository<TEntity, TKey>` - Repository for identity-based entities
-- `IEnumeratorRepository<TEntity, TKey>` - Repository for enumeration entities
-
-### BB84.EntityFrameworkCore.Repositories
-
-**Purpose**: Default repository implementations
-**Dependencies**:
-
-- BB84.EntityFrameworkCore.Entities
-- BB84.EntityFrameworkCore.Repositories.Abstractions
-
-Concrete repository implementations:
-
-- `GenericRepository<TEntity>` - Base repository with common operations
-- `IdentityRepository<TEntity, TKey>` - Repository for identity entities
-- `EnumeratorRepository<TEntity, TKey>` - Repository for enumerator entities
-
-### BB84.EntityFrameworkCore.Repositories.SqlServer
-
-**Purpose**: SQL Server specific configurations and extensions
-**Dependencies**: BB84.EntityFrameworkCore.Repositories
-
-SQL Server specific features:
-
-- **Configurations**: Entity type configurations for different entity types
-- **Extensions**: Extension methods for Entity Framework configurations
-- **Interceptors**: Database interceptors for auditing and soft delete
-
-## 💭 Core Concepts
-
-### Entity Hierarchy
-
-The library follows a hierarchical approach to entity design:
-
-```
-IIdentityEntity<TKey>
-├── IAuditedEntity<TKey, TCreator, TEdited>
-│   └── IFullAuditedEntity<TKey, TCreator, TEdited>
-├── ICompositeEntity
-│   └── IAuditedCompositeEntity<TCreator, TEdited>
-└── IEnumeratorEntity<TKey>
-```
-
-### Repository Pattern
-
-The repository pattern implementation provides:
-
-- **Separation of Concerns**: Business logic separated from data access
-- **Testability**: Easy mocking and unit testing
-- **Consistency**: Standardized data access patterns
-- **Flexibility**: Support for different entity types and requirements
-
-## ✨ Entity Abstractions
-
-### Identity Entities
-
-Identity entities represent the most basic entity type with a unique identifier and concurrency control.
-
-```csharp
-public interface IIdentityEntity<TKey> : IIdentity<TKey>, IConcurrency
-    where TKey : IEquatable<TKey>
-{
-    // Inherits:
-    // TKey Id { get; set; }           // From IIdentity<TKey>
-    // byte[]? Timestamp { get; set; } // From IConcurrency
-}
-
-// Default implementation with Guid
-public interface IIdentityEntity : IIdentityEntity<Guid>
-```
-
-**Key Features**:
-
-- Unique identifier of specified type
-- Optimistic concurrency control via timestamp
-- Base interface for all other entity types
-
-### Audited Entities
-
-Audited entities extend identity entities with creation and modification tracking.
-
-```csharp
-public interface IAuditedEntity<TKey, TCreator, TEdited> :
-    IIdentityEntity<TKey>, IUserAudited<TCreator, TEdited>
-    where TKey : IEquatable<TKey>
-    where TCreator : notnull
-{
-    // Inherits from IIdentityEntity<TKey>:
-    // TKey Id { get; set; }
-    // byte[]? Timestamp { get; set; }
-
-    // Inherits from IUserAudited<TCreator, TEdited>:
-    // TCreator CreatedBy { get; set; }
-    // TEdited? EditedBy { get; set; }
-    // DateTimeOffset CreatedAt { get; set; }
-    // DateTimeOffset? EditedAt { get; set; }
-}
-```
-
-**Convenience Overloads**:
-
-```csharp
-// Default string-based user types
-public interface IAuditedEntity<TKey> : IAuditedEntity<TKey, string, string?>
-
-// Default Guid key with string users
-public interface IAuditedEntity : IAuditedEntity<Guid, string, string?>
-```
-
-### Full Audited Entities
-
-Full audited entities include soft delete capabilities in addition to standard auditing.
-
-```csharp
-public interface IFullAuditedEntity<TKey, TCreator, TEdited> :
-    IAuditedEntity<TKey, TCreator, TEdited>, ISoftDeletable
-    where TKey : IEquatable<TKey>
-    where TCreator : notnull
-{
-    // Inherits all from IAuditedEntity plus:
-    // bool IsDeleted { get; set; }      // From ISoftDeletable
-}
-```
-
-### Composite Entities
-
-Composite entities are designed for entities with composite primary keys.
-
-```csharp
-public interface ICompositeEntity : IConcurrency
-{
-    // byte[]? Timestamp { get; set; } // From IConcurrency
-}
-
-public interface IAuditedCompositeEntity<TCreator, TEdited> :
-    ICompositeEntity, IUserAudited<TCreator, TEdited>
-    where TCreator : notnull
-```
-
-### Enumerator Entities
-
-Enumerator entities represent lookup/reference data with additional descriptive properties.
-
-```csharp
-public interface IEnumeratorEntity<TKey> : IIdentityEntity<TKey>
-    where TKey : IEquatable<TKey>
-{
-    // Inherits from IIdentityEntity<TKey> plus:
-    string Name { get; set; }
-    string? Description { get; set; }
-}
-```
-
-## ⚡ Repository Pattern
-
-### Generic Repository
-
-The `IGenericRepository<TEntity>` provides standard CRUD operations, just to name a few:
-
-```csharp
-public interface IGenericRepository<TEntity> where TEntity : class
-{
-    // Create operations
-    void Create(TEntity entity);
-    void Create(IEnumerable<TEntity> entities);
-    Task CreateAsync(TEntity entity, CancellationToken cancellationToken = default);
-    Task CreateAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
-
-    // Read operations
-    IReadOnlyList<TEntity> GetAll(bool ignoreQueryFilters = false, bool trackChanges = false);
-    Task<IReadOnlyList<TEntity>> GetAllAsync(bool ignoreQueryFilters = false, bool trackChanges = false, CancellationToken token = default);
-
-    // Update operations
-    void Update(TEntity entity);
-    void Update(IEnumerable<TEntity> entities);
-    Task UpdateAsync(TEntity entity);
-    Task UpdateAsync(IEnumerable<TEntity> entities);
-
-    // Delete operations
-    void Delete(TEntity entity);
-    void Delete(IEnumerable<TEntity> entities);
-    Task DeleteAsync(TEntity entity);
-    Task DeleteAsync(IEnumerable<TEntity> entities);
-
-    // Query operations
-    int CountAll(bool ignoreQueryFilters = false);
-    Task<int> CountAllAsync(bool ignoreQueryFilters = false, CancellationToken token = default);
-}
-```
-
-### Identity Repository
-
-Specialized repository for identity-based entities:
-
-```csharp
-public interface IIdentityRepository<TEntity, TKey> : IGenericRepository<TEntity>
-    where TEntity : class, IIdentityEntity<TKey>
-    where TKey : IEquatable<TKey>
-{
-    // Strongly-typed ID operations
-    TEntity? GetById(TKey id);
-    Task<TEntity?> GetByIdAsync(TKey id, CancellationToken cancellationToken = default);
-    void Delete(TKey id);
-    Task DeleteAsync(TKey id, CancellationToken cancellationToken = default);
-}
-```
-
-## ⭐ Configuration Classes
-
-The SQL Server package provides base configuration classes for Entity Framework Core entity type configurations.
-
-### Identity Configuration
-
-```csharp
-public abstract class IdentityConfiguration<TEntity, TKey> : IEntityTypeConfiguration<TEntity>
-    where TEntity : class, IIdentityEntity<TKey>
-    where TKey : IEquatable<TKey>
-{
-    public virtual void Configure(EntityTypeBuilder<TEntity> builder)
-    {
-        // Configures primary key, timestamps, and common properties
-    }
-}
-```
-
-### Audited Configuration
-
-```csharp
-public abstract class AuditedConfiguration<TEntity, TKey, TCreator, TEdited> : IEntityTypeConfiguration<TEntity>
-    where TEntity : class, IAuditedEntity<TKey, TCreator, TEdited>
-    where TKey : IEquatable<TKey>
-    where TCreator : notnull
-{
-    public virtual void Configure(EntityTypeBuilder<TEntity> builder)
-    {
-        // Configures auditing fields, required properties, and indexes
-    }
-}
-```
-
-### Full Audited Configuration
-
-```csharp
-public abstract class FullAuditedConfiguration<TEntity, TKey, TCreator, TEdited> : IEntityTypeConfiguration<TEntity>
-    where TEntity : class, IFullAuditedEntity<TKey, TCreator, TEdited>
-    where TKey : IEquatable<TKey>
-    where TCreator : notnull
-{
-    public virtual void Configure(EntityTypeBuilder<TEntity> builder)
-    {
-        // Configures full auditing including soft delete capabilities
-    }
-}
-```
-
-## 🔮 Interceptors
-
-The library provides Entity Framework Core interceptors for automatic handling of common scenarios.
-
-### Time Audited Interceptor
-
-Automatically sets `Created` and `Edited` timestamps:
-
-```csharp
-public class TimeAuditedInterceptor : SaveChangesInterceptor
-{
-    // Automatically updates timestamps on save operations
-}
-```
-
-### Soft Deletable Interceptor
-
-Handles soft delete operations by setting `IsDeleted`:
-
-```csharp
-public class SoftDeletableInterceptor : SaveChangesInterceptor
-{
-    // Converts hard deletes to soft deletes for applicable entities
-}
-```
-
-## 💻 Getting Started
-
-### Installation
-
-Install the packages via NuGet Package Manager or .NET CLI:
+## 💾 Installation
 
 ```powershell
-# For entity abstractions only
 dotnet add package BB84.EntityFrameworkCore.Entities.Abstractions
-
-# For entity implementations
 dotnet add package BB84.EntityFrameworkCore.Entities
-
-# For repository abstractions
 dotnet add package BB84.EntityFrameworkCore.Repositories.Abstractions
-
-# For repository implementations
 dotnet add package BB84.EntityFrameworkCore.Repositories
-
-# For SQL Server specific features
 dotnet add package BB84.EntityFrameworkCore.Repositories.SqlServer
 ```
 
-### Basic Setup
-
-1. **Define your entities**:
-
-```csharp
-public class User : AuditedEntity
-{
-    public string FirstName { get; set; } = string.Empty;
-    public string LastName { get; set; } = string.Empty;
-    public string Email { get; set; } = string.Empty;
-}
-
-public class Product : FullAuditedEntity
-{
-    public string Name { get; set; } = string.Empty;
-    public decimal Price { get; set; }
-    public string? Description { get; set; }
-}
-```
-
-2. **Create repository interfaces**:
-
-```csharp
-public interface IUserRepository : IIdentityRepository<User>
-{
-    Task<User?> GetByEmailAsync(string email, CancellationToken cancellationToken = default);
-}
-
-public interface IProductRepository : IIdentityRepository<Product>
-{
-    Task<IReadOnlyList<Product>> GetActiveProductsAsync(CancellationToken cancellationToken = default);
-}
-```
-
-3. **Implement repositories**:
-
-```csharp
-public class UserRepository : IdentityRepository<User>, IUserRepository
-{
-    public UserRepository(IDbContext dbContext) : base(dbContext) { }
-
-    public async Task<User?> GetByEmailAsync(string email, CancellationToken cancellationToken = default)
-    {
-        return await GetByConditionAsync(u => u.Email == email, token: cancellationToken);
-    }
-}
-
-public class ProductRepository : IdentityRepository<Product>, IProductRepository
-{
-    public ProductRepository(IDbContext dbContext) : base(dbContext) { }
-
-    public async Task<IReadOnlyList<Product>> GetActiveProductsAsync(CancellationToken cancellationToken = default)
-    {
-        return await GetManyByConditionAsync(p => !p.IsDeleted, token: cancellationToken);
-    }
-}
-```
-
-4. **Configure Entity Framework**:
-
-```csharp
-public class ApplicationDbContext : DbContext, IDbContext
-{
-    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options) { }
-
-    public DbSet<User> Users { get; set; }
-    public DbSet<Product> Products { get; set; }
-
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        base.OnModelCreating(modelBuilder);
-        modelBuilder.ApplyConfigurationsFromAssembly(typeof(ApplicationDbContext).Assembly);
-    }
-}
-
-// Entity configurations
-public class UserConfiguration : AuditedConfiguration<User>
-{
-    public override void Configure(EntityTypeBuilder<User> builder)
-    {
-        builder.Property(u => u.Email).IsRequired().HasMaxLength(255);
-        builder.HasIndex(u => u.Email).IsUnique();
-
-        base.Configure(builder);
-    }
-}
-
-public class ProductConfiguration : FullAuditedConfiguration<Product>
-{
-    public override void Configure(EntityTypeBuilder<Product> builder)
-    {
-        builder.Property(p => p.Name).IsRequired().HasMaxLength(200);
-        builder.Property(p => p.Price).HasPrecision(18, 2);
-
-        base.Configure(builder);
-    }
-}
-```
-
-5. **Register services**:
-
-```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-    services.AddDbContext<ApplicationDbContext>(options =>
-        options.UseSqlServer(connectionString));
-
-    services.AddScoped<IDbContext>(provider => provider.GetService<ApplicationDbContext>());
-    services.AddScoped<IUserRepository, UserRepository>();
-    services.AddScoped<IProductRepository, ProductRepository>();
-
-    // Register interceptors
-    services.AddScoped<TimeAuditedInterceptor>();
-    services.AddScoped<SoftDeletableInterceptor>();
-}
-```
-
-## 🧰 Usage Examples
-
-### Basic CRUD Operations
-
-```csharp
-public class UserService
-{
-    private readonly IUserRepository _userRepository;
-    private readonly IDbContext _dbContext;
-
-    public UserService(IUserRepository userRepository, IDbContext dbContext)
-    {
-        _userRepository = userRepository;
-        _dbContext = dbContext;
-    }
-
-    public async Task<User> CreateUserAsync(string firstName, string lastName, string email)
-    {
-        var user = new User
-        {
-            FirstName = firstName,
-            LastName = lastName,
-            Email = email,
-            CreatedBy = "system" // Will be set automatically by interceptor
-        };
-
-        await _userRepository.CreateAsync(user);
-        await _dbContext.SaveChangesAsync();
-
-        return user;
-    }
-
-    public async Task<User?> GetUserByEmailAsync(string email)
-    {
-        return await _userRepository.GetByEmailAsync(email);
-    }
-
-    public async Task UpdateUserAsync(User user)
-    {
-        _userRepository.Update(user);
-        await _dbContext.SaveChangesAsync();
-    }
-
-    public async Task DeleteUserAsync(Guid userId)
-    {
-        await _userRepository.DeleteByIdAsync(userId);
-        await _dbContext.SaveChangesAsync();
-    }
-}
-```
-
-### Advanced Querying
-
-```csharp
-public class ProductService
-{
-    private readonly IProductRepository _productRepository;
-
-    public ProductService(IProductRepository productRepository)
-    {
-        _productRepository = productRepository;
-    }
-
-    public async Task<IReadOnlyList<Product>> SearchProductsAsync(string searchTerm, decimal? minPrice = null)
-    {
-        return await _productRepository.GetManyByConditionAsync(p =>
-            !p.IsDeleted &&
-            p.Name.Contains(searchTerm) &&
-            (minPrice == null || p.Price >= minPrice));
-    }
-}
-```
-
-## 🩺 Testing
-
-The project includes comprehensive unit tests for all components:
-
-### Test Projects
-
-- **BB84.EntityFrameworkCore.Entities.Tests**: Tests for entity implementations
-- **BB84.EntityFrameworkCore.Repositories.Tests**: Tests for repository implementations
-
-### Test Coverage Areas
-
-1. **Entity Tests**: Verify entity behavior and property assignments
-2. **Repository Tests**: Test CRUD operations and query functionality
-3. **Configuration Tests**: Validate Entity Framework configurations
-4. **Interceptor Tests**: Test automatic auditing and soft delete behavior
-
-### Example Test
-
-```csharp
-[TestClass]
-public sealed class IdentityEntityTests
-{
-    [TestMethod]
-    public void IdentityEntityTest()
-    {
-        IIdentityEntity? entity;
-        Guid id = Guid.NewGuid();
-
-        entity = new TestClass()
-        {
-            Id = id
-        };
-
-        Assert.IsNotNull(entity);
-        Assert.AreEqual(id, entity.Id);
-        Assert.IsNull(entity.Timestamp);
-    }
-
-    private sealed class TestClass : IdentityEntity
-    { }
-}
-```
-
-### Running Tests
+## 🚧 Build and test
 
 ```powershell
+# Build the solution
+dotnet build
+
 # Run all tests
 dotnet test
 
-# Run tests with coverage
-dotnet test --collect:"XPlat Code Coverage"
-
-# Run specific test project
-dotnet test tests/BB84.EntityFrameworkCore.Entities.Tests/
+# Run tests
+dotnet test
 ```
 
-## 🛠 Build and Deployment
-
-### Build Configuration
-
-The project uses MSBuild properties defined in `Directory.Build.props`:
-
-- **Target Framework**: .NET 8.0 & .NET 10.0
-- **Language Version**: Latest C#
-- **Nullable**: Enabled
-- **Implicit Usings**: Enabled
-- **Documentation**: Generated for all projects
-
-### Version Management
-
-Versions are automatically generated based on:
-
-- Major: 4
-- Minor: 3
-- Patch: Current date (MMDD format)
-- Revision: Current hour
-
-### Package Information
-
-- **Author**: BoBoBaSs84
-- **License**: MIT
-- **Repository**: https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore
-
-### Build Commands
-
-```powershell
-# Restore packages
-dotnet restore
-
-# Build solution
-dotnet build
-
-# Build release
-dotnet build --configuration Release
-
-# Pack NuGet packages
-dotnet pack --configuration Release
-```
-
-### CI/CD Pipeline
-
-The project uses GitHub Actions for:
-
-- **Continuous Integration (CI)**: Automated building and testing
-- **Continuous Deployment (CD)**: Automated package publishing
-- **Code Analysis**: CodeQL security scanning
-- **Dependency Updates**: Dependabot automated updates
-
-## 📚 API Documentation
-
-Complete API documentation is available [here](https://bobobass84.github.io/BB84.EntityFrameworkCore).
-
-The documentation is generated using DocFX and includes:
-
-- Complete API reference for all public types
-- Code examples and usage patterns
-- Cross-references between related types
-- Inheritance hierarchies
-
-### Documentation Structure
+## 🏗️ Project structure
 
 ```
-docs/
-├── docfx.json   # DocFX configuration
-├── index.md     # Documentation homepage
-├── toc.yml      # Table of contents
-└── api/
-    └── index.md # API reference index
+BB84.EntityFrameworkCore/
+├── src/
+│   ├── BB84.EntityFrameworkCore.Entities.Abstractions/   # Entity interface definitions
+│   ├── BB84.EntityFrameworkCore.Entities/                # Entity implementations
+│   ├── BB84.EntityFrameworkCore.Repositories.Abstractions/ # Repository interface definitions
+│   ├── BB84.EntityFrameworkCore.Repositories/            # Repository implementations
+│   └── BB84.EntityFrameworkCore.Repositories.SqlServer/  # SQL Server configurations and extensions
+├── tests/
+│   ├── BB84.EntityFrameworkCore.Entities.Tests/          # Entity unit tests
+│   └── BB84.EntityFrameworkCore.Repositories.Tests/      # Repository integration tests (requires LocalDB)
+└── docs/                                                 # DocFX documentation source
 ```
 
 ## 🤝 Contributing
 
-### Development Guidelines
+1. Fork the repository and create a feature branch from `main`.
+2. Follow the existing code style (see `.editorconfig`).
+3. Add XML documentation for all public APIs.
+4. Add unit tests for every new method.
+5. Ensure all tests pass across all target frameworks.
+6. Open a pull request describing your changes.
 
-1. **Code Style**: Follow Microsoft C# coding conventions
-2. **Documentation**: All public APIs must be documented with XML comments
-3. **Testing**: All new features must include corresponding unit tests
-4. **Breaking Changes**: Follow semantic versioning principles
+## 📖 API Documentation
 
-### Contribution Process
+Complete API reference: <https://bobobass84.github.io/BB84.EntityFrameworkCore>
 
-1. Fork the repository
-2. Create a feature branch
-3. Implement changes with tests
-4. Update documentation as needed
-5. Submit a pull request
+To build the documentation locally:
 
-### Code of Conduct
+```powershell
+dotnet tool install -g docfx
+docfx docs/docfx.json --serve
+```
 
-This project adheres to the Contributor Covenant Code of Conduct. See the [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md) file for details.
+## ⚖️ License
 
-## ⚖ License
-
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
-
----
+This project is licensed under the **MIT License** — see the [LICENSE](LICENSE) file for details.

--- a/src/BB84.EntityFrameworkCore.Entities.Abstractions/README.md
+++ b/src/BB84.EntityFrameworkCore.Entities.Abstractions/README.md
@@ -1,3 +1,107 @@
+[![net80](https://img.shields.io/badge/net8.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
+[![net100](https://img.shields.io/badge/net10.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
+[![NuGet](https://img.shields.io/nuget/v/BB84.Extensions.svg?logo=nuget&logoColor=white)](https://www.nuget.org/packages/BB84.EntityFrameworkCore.Entities.Abstractions)
+
 # BB84.EntityFrameworkCore.Entities.Abstractions
 
-This package only contains the entity abstractions.
+This package provides the core entity interface definitions. It has no external dependencies.
+
+## Installation
+
+```powershell
+dotnet add package BB84.EntityFrameworkCore.Entities.Abstractions
+```
+
+## Component interfaces
+
+These fine-grained interfaces are the building blocks composed by the entity-level interfaces below.
+
+| Interface                         | Members                                                |
+| --------------------------------- | ------------------------------------------------------ |
+| `IIdentity<TKey>`                 | `TKey Id`                                              |
+| `IConcurrency`                    | `byte[]? Timestamp` (rowversion)                       |
+| `ITimeAudited`                    | `DateTimeOffset CreatedAt`, `DateTimeOffset? EditedAt` |
+| `IUserAudited<TCreator, TEditor>` | `TCreator CreatedBy`, `TEditor EditedBy`               |
+| `IUserAudited`                    | Shorthand: `IUserAudited<string, string?>`             |
+| `ISoftDeletable`                  | `bool IsDeleted`                                       |
+| `IEnumerator`                     | `string Name`, `string? Description`                   |
+
+## Entity interfaces
+
+Each entity interface composes the component interfaces above. Convenience overloads default `TKey` to `Guid` and `TCreator`/`TEditor` to `string`/`string?`.
+
+### `IIdentityEntity<TKey>` / `IIdentityEntity`
+
+Inherits `IIdentity<TKey>` and `IConcurrency`. The base for all identity-keyed entities. The non-generic overload defaults `TKey` to `Guid`.
+
+```csharp
+public interface IIdentityEntity<TKey> : IIdentity<TKey>, IConcurrency
+    where TKey : IEquatable<TKey>
+```
+
+### `IAuditedEntity<TKey, TCreator, TEditor>` and overloads
+
+Extends `IIdentityEntity<TKey>` with `IUserAudited<TCreator, TEditor>`.
+
+```csharp
+// Full generic form
+public interface IAuditedEntity<TKey, TCreator, TEditor> : IIdentityEntity<TKey>, IUserAudited<TCreator, TEditor>
+
+// Defaults TCreator/TEditor to string/string?
+public interface IAuditedEntity<TKey> : IAuditedEntity<TKey, string, string?>
+
+// Defaults TKey to Guid, TCreator/TEditor to string/string?
+public interface IAuditedEntity : IAuditedEntity<Guid, string, string?>
+```
+
+### `IFullAuditedEntity<TKey, TCreator, TEditor>` and overloads
+
+Extends `IIdentityEntity<TKey>` with both `IUserAudited` and `ITimeAudited`.
+
+```csharp
+// Full generic form
+public interface IFullAuditedEntity<TKey, TCreator, TEditor> : IIdentityEntity<TKey>, IUserAudited<TCreator, TEditor>, ITimeAudited
+
+// Convenience overloads mirror the same pattern as IAuditedEntity
+public interface IFullAuditedEntity<TKey> : IFullAuditedEntity<TKey, string, string?>
+public interface IFullAuditedEntity : IFullAuditedEntity<Guid, string, string?>
+```
+
+### `ICompositeEntity`
+
+For entities with composite primary keys — inherits only `IConcurrency`.
+
+```csharp
+public interface ICompositeEntity : IConcurrency
+```
+
+### `IAuditedCompositeEntity<TCreator, TEditor>` / `IAuditedCompositeEntity`
+
+Extends `ICompositeEntity` with `IUserAudited`. The non-generic overload defaults to `string`/`string?`.
+
+### `IEnumeratorEntity<TKey>` / `IEnumeratorEntity`
+
+Lookup/reference data. Extends `IIdentityEntity<TKey>` with `IEnumerator` and `ISoftDeletable`. The non-generic overload defaults `TKey` to `int`.
+
+```csharp
+public interface IEnumeratorEntity<TKey> : IIdentityEntity<TKey>, IEnumerator, ISoftDeletable
+    where TKey : IEquatable<TKey>
+```
+
+## Usage
+
+Implement these interfaces directly on your domain entities, or use them as constraints in repository and service abstractions:
+
+```csharp
+// Custom entity interface
+public interface IOrderEntity : IAuditedEntity
+{
+    decimal TotalAmount { get; set; }
+}
+
+// Custom repository interface constrained to the abstraction
+public interface IOrderRepository : IIdentityRepository<IOrderEntity>
+{
+    Task<IReadOnlyList<IOrderEntity>> GetByCustomerAsync(Guid customerId, CancellationToken token = default);
+}
+```

--- a/src/BB84.EntityFrameworkCore.Entities/README.md
+++ b/src/BB84.EntityFrameworkCore.Entities/README.md
@@ -1,3 +1,81 @@
+[![net80](https://img.shields.io/badge/net8.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
+[![net100](https://img.shields.io/badge/net10.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
+[![NuGet](https://img.shields.io/nuget/v/BB84.Extensions.svg?logo=nuget&logoColor=white)](https://www.nuget.org/packages/BB84.EntityFrameworkCore.Entities)
+
 # BB84.EntityFrameworkCore.Entities
 
-This package contains the standard implementation of the entity abstractions.
+This package provides the default concrete implementations of the entity abstractions defined in `BB84.EntityFrameworkCore.Entities.Abstractions`.
+
+## Installation
+
+```powershell
+dotnet add package BB84.EntityFrameworkCore.Entities
+```
+
+## Implementations
+
+Each abstract class mirrors the interface hierarchy. Convenience overloads follow the same defaulting pattern as the interfaces (`TKey` → `Guid`, `TCreator`/`TEdited` → `string`/`string?`).
+
+| Abstract class                               | Implements                                    | Notes                                     |
+| -------------------------------------------- | --------------------------------------------- | ----------------------------------------- |
+| `IdentityEntity<TKey>`                       | `IIdentityEntity<TKey>`                       |                                           |
+| `IdentityEntity`                             | `IIdentityEntity`                             | `TKey` = `Guid`                           |
+| `AuditedEntity<TKey, TCreator, TEdited>`     | `IAuditedEntity<TKey, TCreator, TEdited>`     |                                           |
+| `AuditedEntity<TKey>`                        | `IAuditedEntity<TKey>`                        | `TCreator`/`TEdited` = `string`/`string?` |
+| `AuditedEntity`                              | `IAuditedEntity`                              | `TKey` = `Guid`                           |
+| `FullAuditedEntity<TKey, TCreator, TEdited>` | `IFullAuditedEntity<TKey, TCreator, TEdited>` | Adds `CreatedAt`, `EditedAt`              |
+| `FullAuditedEntity<TKey>`                    | `IFullAuditedEntity<TKey>`                    |                                           |
+| `FullAuditedEntity`                          | `IFullAuditedEntity`                          | `TKey` = `Guid`                           |
+| `CompositeEntity`                            | `ICompositeEntity`                            |                                           |
+| `AuditedCompositeEntity<TCreator, TEdited>`  | `IAuditedCompositeEntity<TCreator, TEdited>`  |                                           |
+| `AuditedCompositeEntity`                     | `IAuditedCompositeEntity`                     | `TCreator`/`TEdited` = `string`/`string?` |
+| `EnumeratorEntity<TKey>`                     | `IEnumeratorEntity<TKey>`                     |                                           |
+| `EnumeratorEntity`                           | `IEnumeratorEntity`                           | `TKey` = `int`                            |
+
+## Usage
+
+Inherit from the appropriate base class and add your domain properties:
+
+```csharp
+// Simple entity identified by Guid with concurrency token
+public class Product : IdentityEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public decimal Price { get; set; }
+}
+
+// Audited entity — tracks who created/edited, but not when
+public class Order : AuditedEntity
+{
+    public decimal TotalAmount { get; set; }
+}
+
+// Fully audited entity — tracks who and when, plus supports soft delete
+public class Invoice : FullAuditedEntity
+{
+    public string Number { get; set; } = string.Empty;
+    public DateOnly IssueDate { get; set; }
+}
+
+// Composite-key entity
+public class OrderItem : CompositeEntity
+{
+    public Guid OrderId { get; set; }
+    public Guid ProductId { get; set; }
+    public int Quantity { get; set; }
+}
+
+// Lookup table (int PK, Name unique, soft-deletable)
+public class ProductCategory : EnumeratorEntity
+{
+    // Name and Description come from IEnumerator via EnumeratorEntity
+}
+
+// Custom key type
+public class LedgerEntry : IdentityEntity<long>
+{
+    public decimal Amount { get; set; }
+}
+```
+
+> **Note:** `FullAuditedEntity` adds time auditing (`CreatedAt`/`EditedAt`) to the identity and user-audit features. Soft delete (`IsDeleted`) is a separate concern — it is provided by `IEnumeratorEntity` (and thus `EnumeratorEntity`), not by `FullAuditedEntity`. Add `ISoftDeletable` manually to your entity if you need soft delete combined with full auditing.

--- a/src/BB84.EntityFrameworkCore.Repositories.Abstractions/README.md
+++ b/src/BB84.EntityFrameworkCore.Repositories.Abstractions/README.md
@@ -1,3 +1,102 @@
+[![net80](https://img.shields.io/badge/net8.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
+[![net100](https://img.shields.io/badge/net10.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
+[![NuGet](https://img.shields.io/nuget/v/BB84.Extensions.svg?logo=nuget&logoColor=white)](https://www.nuget.org/packages/BB84.EntityFrameworkCore.Repositories.Abstractions)
+
 # BB84.EntityFrameworkCore.Repositories.Abstractions
 
-This package contains the standard repository abstractions.
+This package provides the repository interface definitions and the `IDbContext` abstraction.
+
+## Installation
+
+```powershell
+dotnet add package BB84.EntityFrameworkCore.Repositories.Abstractions
+```
+
+## `IDbContext`
+
+A thin abstraction over `DbContext` that exposes only what repositories need: `Set<TEntity>()`, `SaveChanges`, `SaveChangesAsync`, `ChangeTracker`, `Database`, and the save-events. Your application `DbContext` should implement this interface so repositories remain decoupled from the concrete EF context type.
+
+```csharp
+public class AppDbContext : DbContext, IDbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
+    // DbSet properties ...
+}
+
+// DI registration
+services.AddDbContext<AppDbContext>(...);
+services.AddScoped<IDbContext>(sp => sp.GetRequiredService<AppDbContext>());
+```
+
+## `IGenericRepository<TEntity>`
+
+The base repository interface. All methods have synchronous and asynchronous variants.
+
+**Create**
+
+- `Create(entity)` / `Create(entities)` — marks entity/entities as `Added`
+- `CreateAsync(entity)` / `CreateAsync(entities)`
+
+**Read**
+
+- `GetAll(ignoreQueryFilters, trackChanges)` — returns all entities
+- `GetAll<TResult>(selector, fieldSelector, ignoreQueryFilters)` — returns projected DTO list
+- `GetByCondition(expression, queryFilter, ignoreQueryFilters, trackChanges, includeProperties)` — returns single or null
+- `GetByCondition<TResult>(expression, selector, fieldSelector, ...)` — projected single
+- `GetManyByCondition(expression, queryFilter, ignoreQueryFilters, orderBy, skip, take, trackChanges, includeProperties)` — paged/filtered list
+- `GetManyByCondition<TResult>(...)` — projected paged/filtered list
+- `CountAll(ignoreQueryFilters)` / `CountByCondition(expression, ...)` — count queries
+
+**Update**
+
+- `Update(entity)` / `Update(entities)` — marks entity/entities as `Modified`
+- `Update(expression, setPropertyCalls)` — bulk `ExecuteUpdate` (bypasses change tracker)
+
+**Delete**
+
+- `Delete(entity)` / `Delete(entities)` — marks entity/entities as `Deleted`
+- `Delete(expression)` — bulk `ExecuteDelete` (bypasses change tracker)
+
+All `Async` variants accept an optional `CancellationToken`.
+
+## `IIdentityRepository<TEntity, TKey>` / `IIdentityRepository<TEntity>`
+
+Extends `IGenericRepository<TEntity>` with ID-based operations. The non-generic overload defaults `TKey` to `Guid`.
+
+**Additional read methods**
+
+- `GetById(id, ignoreQueryFilters, trackChanges, includeProperties)`
+- `GetById<TResult>(id, selector, fieldSelector, ignoreQueryFilters)` — projected
+- `GetByIds(ids, ...)` / `GetByIdsAsync(ids, ...)`
+
+**Additional delete methods**
+
+- `Delete(id)` / `Delete(ids)` — bulk `ExecuteDelete` by key(s)
+
+**Additional update methods**
+
+- `Update(id, setPropertyCalls)` / `Update(ids, setPropertyCalls)` — bulk `ExecuteUpdate` by key(s)
+
+## `IEnumeratorRepository<TEntity, TKey>` / `IEnumeratorRepository<TEntity>`
+
+Extends `IIdentityRepository` with name-based lookups. The non-generic overload defaults `TKey` to `int`.
+
+- `GetByName(name, ignoreQueryFilters, trackChanges)`
+- `GetByNames(names, ignoreQueryFilters, trackChanges)`
+- Async variants of both
+
+## Usage
+
+Define custom repository interfaces against these abstractions:
+
+```csharp
+public interface IProductRepository : IIdentityRepository<Product>
+{
+    Task<IReadOnlyList<Product>> GetByCategoryAsync(int categoryId, CancellationToken token = default);
+}
+
+public interface ICategoryRepository : IEnumeratorRepository<ProductCategory>
+{
+    // GetByName / GetByNames already provided
+}
+```

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/README.md
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/README.md
@@ -1,3 +1,163 @@
+[![net80](https://img.shields.io/badge/net8.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
+[![net100](https://img.shields.io/badge/net10.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
+[![NuGet](https://img.shields.io/nuget/v/BB84.Extensions.svg?logo=nuget&logoColor=white)](https://www.nuget.org/packages/BB84.EntityFrameworkCore.Repositories.SqlServer)
+
 # BB84.EntityFrameworkCore.Repositories.SqlServer
 
-This package contains frequently used sql server configuration base classes and various extension methods.
+This package provides SQL Server–specific entity type configuration base classes, `SaveChangesInterceptor` implementations for auditing and soft delete, and `EntityTypeBuilderExtensions` for temporal table support.
+
+## Installation
+
+```powershell
+dotnet add package BB84.EntityFrameworkCore.Repositories.SqlServer
+```
+
+## Configuration base classes
+
+Inherit from these in your `IEntityTypeConfiguration<TEntity>` implementations and call `base.Configure(builder)` to apply the standard column order, constraints, concurrency tokens, and indexes. Override before or after the base call to add entity-specific configuration.
+
+| Configuration class                                          | For entity type                               | What `base.Configure` applies                                                                                                                                        |
+| ------------------------------------------------------------ | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `IdentityConfiguration<TEntity, TKey>`                       | `IIdentityEntity<TKey>`                       | Non-clustered PK, `Id` (`ValueGeneratedOnAdd`), `Timestamp` as concurrency token                                                                                     |
+| `AuditedConfiguration<TEntity, TKey, TCreator, TEdited>`     | `IAuditedEntity<TKey, TCreator, TEdited>`     | Above + `CreatedBy` (required), `EditedBy` (optional); `string` overload maps both as `sysname`                                                                      |
+| `FullAuditedConfiguration<TEntity, TKey, TCreator, TEdited>` | `IFullAuditedEntity<TKey, TCreator, TEdited>` | Above + `CreatedAt` (required), `EditedAt` (optional); `Guid` overload adds `NEWID()` default                                                                        |
+| `CompositeConfiguration<TEntity>`                            | `ICompositeEntity`                            | `Timestamp` as concurrency token                                                                                                                                     |
+| `AuditedCompositeConfiguration<TEntity, TCreator, TEdited>`  | `IAuditedCompositeEntity<TCreator, TEdited>`  | Above + audit user columns                                                                                                                                           |
+| `EnumeratorConfiguration<TEntity, TKey>`                     | `IEnumeratorEntity<TKey>`                     | Non-clustered PK, `Name` (`nvarchar(64)`, unique index, non-unicode), `Description` (`nvarchar(256)`), `IsDeleted` default `false`; `int` overload uses clustered PK |
+
+```csharp
+public class ProductConfiguration : IdentityConfiguration<Product>
+{
+    public override void Configure(EntityTypeBuilder<Product> builder)
+    {
+        base.Configure(builder);
+
+        builder.ToTable("Products", "catalog");
+        builder.Property(p => p.Name).IsRequired().HasMaxLength(200);
+        builder.Property(p => p.Price).IsDecimalColumn(10, 2);
+    }
+}
+
+public class InvoiceConfiguration : FullAuditedConfiguration<Invoice>
+{
+    public override void Configure(EntityTypeBuilder<Invoice> builder)
+    {
+        base.Configure(builder); // applies NEWID() default, sysname for audit columns
+
+        builder.ToTable("Invoices", "billing");
+        builder.Property(i => i.Number).IsRequired().HasMaxLength(50);
+    }
+}
+
+public class ProductCategoryConfiguration : EnumeratorConfiguration<ProductCategory>
+{
+    public override void Configure(EntityTypeBuilder<ProductCategory> builder)
+    {
+        base.Configure(builder); // clustered int PK, Name unique index, IsDeleted default false
+        builder.ToTable("ProductCategories", "catalog");
+    }
+}
+```
+
+Apply configurations via `ApplyConfigurationsFromAssembly` in `OnModelCreating`:
+
+```csharp
+protected override void OnModelCreating(ModelBuilder modelBuilder)
+{
+    modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
+}
+```
+
+## `PropertyBuilderExtensions`
+
+Extension methods on `PropertyBuilder` that set the SQL Server column type in one call. All methods return the same `PropertyBuilder` for chaining.
+
+| Method                              | SQL Server type                   | Parameters                                                       |
+| ----------------------------------- | --------------------------------- | ---------------------------------------------------------------- |
+| `IsBinaryColumn(precision)`         | `binary(n)`                       | `precision`: 1–8000 (default 8000)                               |
+| `IsDateColumn()`                    | `date`                            | —                                                                |
+| `IsDateTimeColumn(small)`           | `datetime` / `smalldatetime`      | `small: false` → `datetime`                                      |
+| `IsDateTime2Column(precision)`      | `datetime2(n)`                    | `precision`: 0–7 (default 7)                                     |
+| `IsDateTimeOffsetColumn(precision)` | `datetimeoffset(n)`               | `precision`: 0–7 (default 7)                                     |
+| `IsDecimalColumn(precision, scale)` | `decimal(p,s)`                    | `precision`: 1–38 (default 18), `scale`: 0–precision (default 2) |
+| `IsMoneyColumn(small)`              | `money` / `smallmoney`            | `small: false` → `money`                                         |
+| `IsSysNameColumn()`                 | `sysname`                         | —                                                                |
+| `IsTimeColumn(precision)`           | `time(n)`                         | `precision`: 0–7 (default 7)                                     |
+| `IsUniqueIdentifierColumn()`        | `uniqueidentifier`                | —                                                                |
+| `IsVarbinaryColumn(precision)`      | `varbinary(n)` / `varbinary(max)` | `precision`: 0–8000; 0 → `varbinary(max)` (default 0)            |
+| `IsXmlColumn()`                     | `xml`                             | —                                                                |
+
+Methods with a precision parameter throw `ArgumentOutOfRangeException` when the value is outside the valid range.
+
+```csharp
+public class OrderConfiguration : IdentityConfiguration<Order>
+{
+    public override void Configure(EntityTypeBuilder<Order> builder)
+    {
+        base.Configure(builder);
+
+        builder.ToTable("Orders", "sales");
+
+        builder.Property(o => o.TotalAmount)
+            .IsDecimalColumn(precision: 18, scale: 4);
+
+        builder.Property(o => o.PlacedAt)
+            .IsDateTimeOffsetColumn(precision: 3);
+
+        builder.Property(o => o.DueDate)
+            .IsDateColumn();
+
+        builder.Property(o => o.Notes)
+            .IsXmlColumn();
+
+        builder.Property(o => o.Attachment)
+            .IsVarbinaryColumn(); // varbinary(max)
+    }
+}
+```
+
+## `EntityTypeBuilderExtensions`
+
+### `ToHistoryTable`
+
+One-line setup for SQL Server temporal tables with a separate history schema:
+
+```csharp
+builder.ToHistoryTable(
+    tableName: "Orders",          // defaults to entity class name
+    tableSchema: "sales",         // defaults to "dbo"
+    historyTableName: "Orders",   // defaults to tableName
+    historyTableSchema: "history" // defaults to "history"
+);
+```
+
+## Interceptors
+
+Register interceptors on the `DbContextOptionsBuilder`:
+
+```csharp
+services.AddSingleton<SoftDeletableInterceptor>();
+services.AddSingleton<TimeAuditedInterceptor>();
+
+services.AddDbContext<AppDbContext>((sp, options) =>
+{
+    options
+        .UseSqlServer(connectionString)
+        .AddInterceptors(
+            sp.GetRequiredService<SoftDeletableInterceptor>(),
+            sp.GetRequiredService<TimeAuditedInterceptor>());
+});
+```
+
+### `SoftDeletableInterceptor`
+
+Fires on `SavingChanges`/`SavingChangesAsync`. For every entity tracked as `Deleted` that implements `ISoftDeletable`, it sets `IsDeleted = true` and changes the state to `Modified` — preventing a physical `DELETE` from being issued.
+
+### `TimeAuditedInterceptor`
+
+Fires on `SavingChanges`/`SavingChangesAsync`. For every entity implementing `ITimeAudited`:
+
+- `EntityState.Added` → sets `CreatedAt = DateTimeOffset.UtcNow`
+- `EntityState.Modified` → sets `EditedAt = DateTimeOffset.UtcNow`
+
+`CreatedBy` / `EditedBy` are **not** set automatically by this interceptor — implement a custom `SaveChangesInterceptor` for user auditing and register it alongside the built-in ones.

--- a/src/BB84.EntityFrameworkCore.Repositories/README.md
+++ b/src/BB84.EntityFrameworkCore.Repositories/README.md
@@ -1,3 +1,115 @@
+[![net80](https://img.shields.io/badge/net8.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
+[![net100](https://img.shields.io/badge/net10.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
+[![NuGet](https://img.shields.io/nuget/v/BB84.Extensions.svg?logo=nuget&logoColor=white)](https://www.nuget.org/packages/BB84.EntityFrameworkCore.Repositories)
+
 # BB84.EntityFrameworkCore.Repositories
 
-This package contains the standard repository implementations of the corresponding abstractions.
+This package provides the default repository implementations and `DatabaseFacadeExtensions` for calling stored procedures and SQL functions.
+
+## Installation
+
+```powershell
+dotnet add package BB84.EntityFrameworkCore.Repositories
+```
+
+## Repository implementations
+
+### `GenericRepository<TEntity>`
+
+Abstract base for all repositories. Accepts `IDbContext` as a constructor parameter. All query methods delegate to `PrepareQuery(...)`, which composes `Where`, `IgnoreQueryFilters`, `Include`, `OrderBy`, `Skip`, `Take`, and `AsNoTracking` into a single `IQueryable<TEntity>`. Projection overloads use the protected `ApplyProjection(query, selector, fieldSelector)` helper.
+
+### `IdentityRepository<TEntity, TKey>` / `IdentityRepository<TEntity>`
+
+Extends `GenericRepository<TEntity>` with key-based `GetById`, `GetByIds`, and bulk `Delete`/`Update` by ID. The non-generic overload defaults `TKey` to `Guid`.
+
+### `EnumeratorRepository<TEntity, TKey>` / `EnumeratorRepository<TEntity>`
+
+Extends `IdentityRepository` with `GetByName` and `GetByNames`. The non-generic overload defaults `TKey` to `int`.
+
+## Usage
+
+Inherit from the appropriate base class and inject `IDbContext`:
+
+```csharp
+public class ProductRepository : IdentityRepository<Product>, IProductRepository
+{
+    public ProductRepository(IDbContext dbContext) : base(dbContext) { }
+
+    public async Task<IReadOnlyList<Product>> GetByCategoryAsync(
+        int categoryId, CancellationToken token = default)
+        => await GetManyByConditionAsync(
+            p => p.CategoryId == categoryId,
+            orderBy: q => q.OrderBy(p => p.Name),
+            token: token);
+}
+
+public class CategoryRepository : EnumeratorRepository<ProductCategory>, ICategoryRepository
+{
+    public CategoryRepository(IDbContext dbContext) : base(dbContext) { }
+    // GetByName / GetByNames inherited
+}
+```
+
+DI registration:
+
+```csharp
+services.AddScoped<IProductRepository, ProductRepository>();
+services.AddScoped<ICategoryRepository, CategoryRepository>();
+```
+
+Calling save changes is the responsibility of the caller (unit-of-work pattern):
+
+```csharp
+repository.Create(entity);
+await dbContext.SaveChangesAsync(token);
+```
+
+## `DatabaseFacadeExtensions`
+
+Extension methods on `DatabaseFacade` (`context.Database`) for calling SQL Server stored procedures and functions safely with parameterized SQL.
+
+### Stored procedures
+
+```csharp
+// Returns rows as IReadOnlyList<T>
+IReadOnlyList<ReportRow> rows = context.Database.ExecuteProcedure<ReportRow>(
+    schema: "dbo",
+    name: "usp_GetReport",
+    parameters: [new SqlParameter("@FromDate", fromDate)]);
+
+// Non-generic overload returns rows-affected count
+int affected = context.Database.ExecuteProcedure(
+    schema: "dbo",
+    name: "usp_ArchiveOrders",
+    parameters: [new SqlParameter("@CutoffDate", cutoff)]);
+
+// Async variants
+await context.Database.ExecuteProcedureAsync<ReportRow>(..., cancellationToken);
+await context.Database.ExecuteProcedureAsync(..., cancellationToken);
+```
+
+Output parameters are supported — parameters with `Direction = ParameterDirection.Output` are emitted as `@param = @param OUTPUT` in the generated SQL.
+
+### Table-valued functions
+
+```csharp
+IReadOnlyList<ProductDto> results = context.Database.ExecuteTableFunction<ProductDto>(
+    schema: "dbo",
+    name: "fn_GetActiveProducts",
+    parameters: [new SqlParameter("@CategoryId", categoryId)]);
+
+await context.Database.ExecuteTableFunctionAsync<ProductDto>(..., cancellationToken);
+```
+
+### Scalar-valued functions
+
+```csharp
+decimal? total = context.Database.ExecuteScalarFunction<decimal>(
+    schema: "dbo",
+    name: "fn_GetOrderTotal",
+    parameters: [new SqlParameter("@OrderId", orderId)]);
+
+await context.Database.ExecuteScalarFunctionAsync<decimal>(..., cancellationToken);
+```
+
+All methods sanitize schema/name inputs and use parameterized SQL to prevent injection.


### PR DESCRIPTION
**Changes:**

- Rewrote and split `README` files for all five NuGet packages, each with badges, install instructions, interface/class tables, and usage examples
- Restructured main solution `README`: clarified overview, package table, project structure, and contribution guidelines; improved documentation and API reference sections
- Added new `README` files for Entities.Abstractions, Entities, Repositories.Abstractions, Repositories, and Repositories.SqlServer
- Standardized documentation of entity/repository hierarchy, configuration base classes, and SQL Server features
- Updated build/test/project structure docs to match current layout and contributor best practices

closes #201