### PR TITLE
refactor(repositories): repo async methods; improve state/cancel tests

### DIFF
--- a/src/BB84.EntityFrameworkCore.Repositories/GenericRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/GenericRepository.cs
@@ -79,12 +79,26 @@ public abstract class GenericRepository<TEntity>(IDbContext dbContext) : IGeneri
 		=> PrepareQuery(expression).ExecuteDelete();
 
 	/// <inheritdoc/>
-	public async Task DeleteAsync(TEntity entity, CancellationToken token = default)
-		=> await Task.Run(() => DbSet.Remove(entity), token).ConfigureAwait(false);
+	public Task DeleteAsync(TEntity entity, CancellationToken token = default)
+	{
+		if (token.IsCancellationRequested)
+			return Task.FromCanceled(token);
+
+		DbSet.Remove(entity);
+
+		return Task.CompletedTask;
+	}
 
 	/// <inheritdoc/>
-	public async Task DeleteAsync(IEnumerable<TEntity> entities, CancellationToken token = default)
-		=> await Task.Run(() => DbSet.RemoveRange(entities), token).ConfigureAwait(false);
+	public Task DeleteAsync(IEnumerable<TEntity> entities, CancellationToken token = default)
+	{
+		if (token.IsCancellationRequested)
+			return Task.FromCanceled(token);
+
+		DbSet.RemoveRange(entities);
+
+		return Task.CompletedTask;
+	}
 
 	/// <inheritdoc/>
 	public async Task<int> DeleteAsync(Expression<Func<TEntity, bool>> expression, CancellationToken token = default)
@@ -173,12 +187,26 @@ public abstract class GenericRepository<TEntity>(IDbContext dbContext) : IGeneri
 		=> PrepareQuery(expression).ExecuteUpdate(setPropertyCalls);
 
 	/// <inheritdoc/>
-	public async Task UpdateAsync(TEntity entity, CancellationToken token = default)
-		=> await Task.Run(() => DbSet.Update(entity), token).ConfigureAwait(false);
+	public Task UpdateAsync(TEntity entity, CancellationToken token = default)
+	{
+		if (token.IsCancellationRequested)
+			return Task.FromCanceled(token);
+
+		DbSet.Update(entity);
+
+		return Task.CompletedTask;
+	}
 
 	/// <inheritdoc/>
-	public async Task UpdateAsync(IEnumerable<TEntity> entities, CancellationToken token = default)
-		=> await Task.Run(() => DbSet.UpdateRange(entities), token).ConfigureAwait(false);
+	public Task UpdateAsync(IEnumerable<TEntity> entities, CancellationToken token = default)
+	{
+		if (token.IsCancellationRequested)
+			return Task.FromCanceled(token);
+
+		DbSet.UpdateRange(entities);
+
+		return Task.CompletedTask;
+	}
 
 	/// <inheritdoc/>
 	public async Task<int> UpdateAsync(

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonJobTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonJobTests.cs
@@ -7,6 +7,8 @@ using BB84.EntityFrameworkCore.Repositories.Tests.Persistence;
 using BB84.EntityFrameworkCore.Repositories.Tests.Persistence.Entities;
 using BB84.EntityFrameworkCore.Repositories.Tests.Persistence.Repositories;
 
+using Microsoft.EntityFrameworkCore;
+
 namespace BB84.EntityFrameworkCore.Repositories.Tests;
 
 [TestClass]
@@ -136,6 +138,8 @@ public sealed class PersonJobTests : UnitTestBase
 
 		await repository.DeleteAsync(personJob)
 			.ConfigureAwait(false);
+
+		Assert.AreEqual(EntityState.Deleted, dbContext.Entry(personJob).State);
 	}
 
 	[TestMethod]
@@ -148,6 +152,8 @@ public sealed class PersonJobTests : UnitTestBase
 
 		await repository.DeleteAsync(personJobs)
 			.ConfigureAwait(false);
+
+		Assert.AreEqual(EntityState.Deleted, dbContext.Entry(personJobs[0]).State);
 	}
 
 	[TestMethod]
@@ -182,6 +188,8 @@ public sealed class PersonJobTests : UnitTestBase
 
 		await repository.UpdateAsync(personJob)
 			.ConfigureAwait(false);
+
+		Assert.AreEqual(EntityState.Modified, dbContext.Entry(personJob).State);
 	}
 
 	[TestMethod]
@@ -194,5 +202,22 @@ public sealed class PersonJobTests : UnitTestBase
 
 		await repository.UpdateAsync(personJobs)
 			.ConfigureAwait(false);
+
+		Assert.AreEqual(EntityState.Modified, dbContext.Entry(personJobs[0]).State);
+	}
+
+	[TestMethod]
+	public async Task DeleteAsyncCancelledTest()
+	{
+		using TestDbContext dbContext = GetTestContext();
+		PersonJobRepository repository = new(dbContext);
+
+		PersonJobEntity personJob = new() { PersonId = Guid.NewGuid(), JobId = Guid.NewGuid() };
+
+		_ = await Assert.ThrowsExactlyAsync<TaskCanceledException>(
+			() => repository.DeleteAsync(personJob, new CancellationToken(true)))
+			.ConfigureAwait(false);
+
+		Assert.AreEqual(EntityState.Detached, dbContext.Entry(personJob).State);
 	}
 }


### PR DESCRIPTION
**Changes:**

- Refactored `DeleteAsync` and `UpdateAsync` in `GenericRepository` to remove unnecessary `Task.Run` and add cancellation checks.
- Updated tests to assert entity state after operations and added a cancellation test for `DeleteAsync`.
- Added missing using for EF Core in tests.

closes #209