### PR TITLE
feat: refactor tests to share `DbContext` via `UnitTestBase`

### DIFF
--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/AuditedCompositeConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/AuditedCompositeConfiguration.cs
@@ -27,7 +27,6 @@ namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations;
 /// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
 /// <typeparam name="TCreator">The type representing the creator of the entity.</typeparam>
 /// <typeparam name="TEdited">The type representing the editor of the entity.</typeparam>
-/// <inheritdoc cref="IEntityTypeConfiguration{TEntity}"/>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
 public abstract class AuditedCompositeConfiguration<TEntity, TCreator, TEdited> : IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IAuditedCompositeEntity<TCreator, TEdited>

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/AuditedConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/AuditedConfiguration.cs
@@ -27,7 +27,6 @@ namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations;
 /// <typeparam name="TKey">The type of the primary key for the entity.</typeparam>
 /// <typeparam name="TCreator">The type representing the creator of the entity.</typeparam>
 /// <typeparam name="TEdited">The type representing the editor of the entity.</typeparam>
-/// <inheritdoc cref="IEntityTypeConfiguration{TEntity}"/>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
 public abstract class AuditedConfiguration<TEntity, TKey, TCreator, TEdited> : IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IAuditedEntity<TKey, TCreator, TEdited>

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/EnumeratorConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/EnumeratorConfiguration.cs
@@ -21,7 +21,6 @@ namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations;
 /// concurrency tokens, property constraints and indexing.</remarks>
 /// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
 /// <typeparam name="TKey">The type of the key for the entity.</typeparam>
-/// <inheritdoc cref="IEntityTypeConfiguration{TEntity}"/>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
 public abstract class EnumeratorConfiguration<TEntity, TKey> : IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IEnumeratorEntity<TKey>

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/IdentityConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/IdentityConfiguration.cs
@@ -23,7 +23,6 @@ namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations;
 /// </remarks>
 /// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
 /// <typeparam name="TKey">The type of the primary key for the entity.</typeparam>
-/// <inheritdoc cref="IEntityTypeConfiguration{TEntity}"/>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
 public abstract class IdentityConfiguration<TEntity, TKey> : IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IIdentityEntity<TKey>

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/DatabaseFacadeExtensionsTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/DatabaseFacadeExtensionsTests.cs
@@ -82,11 +82,9 @@ public sealed class DatabaseFacadeExtensionsTests : UnitTestBase
 	[TestMethod]
 	public void ExecuteScalarFunctionTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-
 		IEnumerable<SqlParameter> sqlParameters = [new("@Input", SqlDbType.Int) { Value = 5 }];
 
-		int result = dbContext.Database
+		int result = DbContext.Database
 			.ExecuteScalarFunction<int>(Schema, GetScalarValueFunctionName, sqlParameters);
 
 		Assert.AreEqual(10, result);
@@ -95,11 +93,9 @@ public sealed class DatabaseFacadeExtensionsTests : UnitTestBase
 	[TestMethod]
 	public async Task ExecuteScalarFunctionAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-
 		IEnumerable<SqlParameter> sqlParameters = [new("@Input", SqlDbType.Int) { Value = 7 }];
 
-		int result = await dbContext.Database
+		int result = await DbContext.Database
 			.ExecuteScalarFunctionAsync<int>(Schema, GetScalarValueFunctionName, sqlParameters, _testToken)
 			.ConfigureAwait(false);
 
@@ -109,11 +105,9 @@ public sealed class DatabaseFacadeExtensionsTests : UnitTestBase
 	[TestMethod]
 	public void ExecuteTableFunctionTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-
 		IEnumerable<SqlParameter> sqlParameters = [new("@Count", SqlDbType.Int) { Value = 3 }];
 
-		IReadOnlyList<int> result = dbContext.Database
+		IReadOnlyList<int> result = DbContext.Database
 			.ExecuteTableFunction<int>(Schema, GetTableValuesFunctionName, sqlParameters);
 
 		Assert.HasCount(3, result);
@@ -122,11 +116,9 @@ public sealed class DatabaseFacadeExtensionsTests : UnitTestBase
 	[TestMethod]
 	public async Task ExecuteTableFunctionAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-
 		IEnumerable<SqlParameter> sqlParameters = [new("@Count", SqlDbType.Int) { Value = 2 }];
 
-		IReadOnlyList<int> result = await dbContext.Database
+		IReadOnlyList<int> result = await DbContext.Database
 			.ExecuteTableFunctionAsync<int>(Schema, GetTableValuesFunctionName, sqlParameters, _testToken)
 			.ConfigureAwait(false);
 
@@ -136,11 +128,9 @@ public sealed class DatabaseFacadeExtensionsTests : UnitTestBase
 	[TestMethod]
 	public void ExecuteProcedureWithResultTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-
 		SqlParameter input = new("@Input", SqlDbType.Int) { Value = 42 };
 
-		IReadOnlyList<int> result = dbContext.Database
+		IReadOnlyList<int> result = DbContext.Database
 			.ExecuteProcedure<int>(Schema, GetValuesProcedureName, [input]);
 
 		Assert.HasCount(1, result);
@@ -150,11 +140,9 @@ public sealed class DatabaseFacadeExtensionsTests : UnitTestBase
 	[TestMethod]
 	public async Task ExecuteProcedureWithResultAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-
 		SqlParameter input = new("@Input", SqlDbType.Int) { Value = 99 };
 
-		IReadOnlyList<int> result = await dbContext.Database
+		IReadOnlyList<int> result = await DbContext.Database
 			.ExecuteProcedureAsync<int>(Schema, GetValuesProcedureName, [input], cancellationToken: _testToken)
 			.ConfigureAwait(false);
 
@@ -165,12 +153,10 @@ public sealed class DatabaseFacadeExtensionsTests : UnitTestBase
 	[TestMethod]
 	public void ExecuteProcedureWithOutputParameterTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-
 		SqlParameter input = new("@Input", SqlDbType.Int) { Value = 4 };
 		SqlParameter output = new("@Output", SqlDbType.Int) { Direction = ParameterDirection.Output };
 
-		IReadOnlyList<int> result = dbContext.Database
+		IReadOnlyList<int> result = DbContext.Database
 			.ExecuteProcedure<int>(Schema, SetValueProcedureName, [input, output]);
 
 		Assert.AreEqual(12, output.Value);
@@ -179,12 +165,10 @@ public sealed class DatabaseFacadeExtensionsTests : UnitTestBase
 	[TestMethod]
 	public async Task ExecuteProcedureWithOutputParameterAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-
 		SqlParameter input = new("@Input", SqlDbType.Int) { Value = 5 };
 		SqlParameter output = new("@Output", SqlDbType.Int) { Direction = ParameterDirection.Output };
 
-		IReadOnlyList<int> result = await dbContext.Database
+		IReadOnlyList<int> result = await DbContext.Database
 			.ExecuteProcedureAsync<int>(Schema, SetValueProcedureName, [input, output], _testToken)
 			.ConfigureAwait(false);
 
@@ -194,11 +178,9 @@ public sealed class DatabaseFacadeExtensionsTests : UnitTestBase
 	[TestMethod]
 	public void ExecuteProcedureNonQueryTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-
 		SqlParameter input = new("@Input", SqlDbType.Int) { Value = 1 };
 
-		int rowsAffected = dbContext.Database
+		int rowsAffected = DbContext.Database
 			.ExecuteProcedure(Schema, GetValuesProcedureName, [input]);
 
 		Assert.AreEqual(-1, rowsAffected);
@@ -207,11 +189,9 @@ public sealed class DatabaseFacadeExtensionsTests : UnitTestBase
 	[TestMethod]
 	public async Task ExecuteProcedureNonQueryAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-
 		SqlParameter input = new("@Input", SqlDbType.Int) { Value = 1 };
 
-		int rowsAffected = await dbContext.Database
+		int rowsAffected = await DbContext.Database
 			.ExecuteProcedureAsync(Schema, GetValuesProcedureName, [input], _testToken)
 			.ConfigureAwait(false);
 

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/JobTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/JobTests.cs
@@ -14,8 +14,7 @@ public sealed class JobTests : UnitTestBase
 	[TestMethod]
 	public void UpdateByIdTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		JobRepository repository = new(dbContext);
+		JobRepository repository = new(DbContext);
 
 		int updated = repository.Update(Guid.NewGuid(), s => s.SetProperty(p => p.Name, "Tester"));
 
@@ -25,8 +24,7 @@ public sealed class JobTests : UnitTestBase
 	[TestMethod]
 	public void UpdateByIdsTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		JobRepository repository = new(dbContext);
+		JobRepository repository = new(DbContext);
 
 		int updated = repository.Update([Guid.NewGuid(), Guid.NewGuid()], s => s.SetProperty(p => p.Name, "Tester"));
 
@@ -36,8 +34,7 @@ public sealed class JobTests : UnitTestBase
 	[TestMethod]
 	public async Task UpdateByIdAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		JobRepository repository = new(dbContext);
+		JobRepository repository = new(DbContext);
 
 		int updated = await repository.UpdateAsync(Guid.NewGuid(), s => s.SetProperty(p => p.Name, "Tester"))
 			.ConfigureAwait(false);
@@ -48,8 +45,7 @@ public sealed class JobTests : UnitTestBase
 	[TestMethod]
 	public async Task UpdateByIdsAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		JobRepository repository = new(dbContext);
+		JobRepository repository = new(DbContext);
 
 		int updated = await repository.UpdateAsync([Guid.NewGuid(), Guid.NewGuid()], s => s.SetProperty(p => p.Name, "Tester"))
 			.ConfigureAwait(false);

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonJobTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonJobTests.cs
@@ -17,8 +17,7 @@ public sealed class PersonJobTests : UnitTestBase
 	[TestMethod]
 	public void CreateTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonJobRepository repository = new(dbContext);
+		PersonJobRepository repository = new(DbContext);
 
 		PersonJobEntity personJob = new();
 
@@ -28,8 +27,7 @@ public sealed class PersonJobTests : UnitTestBase
 	[TestMethod]
 	public void CreateRangeTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonJobRepository repository = new(dbContext);
+		PersonJobRepository repository = new(DbContext);
 
 		List<PersonJobEntity> personJobs = [new(), new()];
 
@@ -39,8 +37,7 @@ public sealed class PersonJobTests : UnitTestBase
 	[TestMethod]
 	public async Task CreateAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonJobRepository repository = new(dbContext);
+		PersonJobRepository repository = new(DbContext);
 
 		PersonJobEntity personJob = new();
 
@@ -51,8 +48,7 @@ public sealed class PersonJobTests : UnitTestBase
 	[TestMethod]
 	public async Task CreateRangeAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonJobRepository repository = new(dbContext);
+		PersonJobRepository repository = new(DbContext);
 
 		List<PersonJobEntity> personJobs = [new(), new()];
 
@@ -63,8 +59,7 @@ public sealed class PersonJobTests : UnitTestBase
 	[TestMethod]
 	public void CountAllTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonJobRepository repository = new(dbContext);
+		PersonJobRepository repository = new(DbContext);
 
 		int count = repository.CountAll(false);
 
@@ -74,8 +69,7 @@ public sealed class PersonJobTests : UnitTestBase
 	[TestMethod]
 	public void CountByConditionTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonJobRepository repository = new(dbContext);
+		PersonJobRepository repository = new(DbContext);
 
 		int count = repository.CountByCondition(x => x.PersonId.Equals(Guid.Empty));
 
@@ -85,8 +79,7 @@ public sealed class PersonJobTests : UnitTestBase
 	[TestMethod]
 	public async Task CountAllAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonJobRepository repository = new(dbContext);
+		PersonJobRepository repository = new(DbContext);
 
 		int count = await repository.CountAllAsync(false)
 			.ConfigureAwait(false);
@@ -97,8 +90,7 @@ public sealed class PersonJobTests : UnitTestBase
 	[TestMethod]
 	public async Task CountByConditionAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonJobRepository repository = new(dbContext);
+		PersonJobRepository repository = new(DbContext);
 
 		int count = await repository.CountByConditionAsync(expression: x => x.PersonId.Equals(Guid.Empty))
 			.ConfigureAwait(false);
@@ -109,8 +101,7 @@ public sealed class PersonJobTests : UnitTestBase
 	[TestMethod]
 	public void DeleteTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonJobRepository repository = new(dbContext);
+		PersonJobRepository repository = new(DbContext);
 
 		PersonJobEntity personJob = new() { PersonId = Guid.NewGuid(), JobId = Guid.NewGuid() };
 
@@ -120,8 +111,7 @@ public sealed class PersonJobTests : UnitTestBase
 	[TestMethod]
 	public void DeleteRangeTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonJobRepository repository = new(dbContext);
+		PersonJobRepository repository = new(DbContext);
 
 		List<PersonJobEntity> personJobs = [new() { PersonId = Guid.NewGuid(), JobId = Guid.NewGuid() }];
 
@@ -131,36 +121,33 @@ public sealed class PersonJobTests : UnitTestBase
 	[TestMethod]
 	public async Task DeleteAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonJobRepository repository = new(dbContext);
+		PersonJobRepository repository = new(DbContext);
 
 		PersonJobEntity personJob = new() { PersonId = Guid.NewGuid(), JobId = Guid.NewGuid() };
 
 		await repository.DeleteAsync(personJob)
 			.ConfigureAwait(false);
 
-		Assert.AreEqual(EntityState.Deleted, dbContext.Entry(personJob).State);
+		Assert.AreEqual(EntityState.Deleted, DbContext.Entry(personJob).State);
 	}
 
 	[TestMethod]
 	public async Task DeleteRangeAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonJobRepository repository = new(dbContext);
+		PersonJobRepository repository = new(DbContext);
 
 		List<PersonJobEntity> personJobs = [new() { PersonId = Guid.NewGuid(), JobId = Guid.NewGuid() }];
 
 		await repository.DeleteAsync(personJobs)
 			.ConfigureAwait(false);
 
-		Assert.AreEqual(EntityState.Deleted, dbContext.Entry(personJobs[0]).State);
+		Assert.AreEqual(EntityState.Deleted, DbContext.Entry(personJobs[0]).State);
 	}
 
 	[TestMethod]
 	public void UpdateTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonJobRepository repository = new(dbContext);
+		PersonJobRepository repository = new(DbContext);
 
 		PersonJobEntity personJob = new() { PersonId = Guid.NewGuid(), JobId = Guid.NewGuid() };
 
@@ -170,8 +157,7 @@ public sealed class PersonJobTests : UnitTestBase
 	[TestMethod]
 	public void UpdateRangeTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonJobRepository repository = new(dbContext);
+		PersonJobRepository repository = new(DbContext);
 
 		List<PersonJobEntity> personJobs = [new() { PersonId = Guid.NewGuid(), JobId = Guid.NewGuid() }];
 
@@ -181,36 +167,33 @@ public sealed class PersonJobTests : UnitTestBase
 	[TestMethod]
 	public async Task UpdateAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonJobRepository repository = new(dbContext);
+		PersonJobRepository repository = new(DbContext);
 
 		PersonJobEntity personJob = new() { PersonId = Guid.NewGuid(), JobId = Guid.NewGuid() };
 
 		await repository.UpdateAsync(personJob)
 			.ConfigureAwait(false);
 
-		Assert.AreEqual(EntityState.Modified, dbContext.Entry(personJob).State);
+		Assert.AreEqual(EntityState.Modified, DbContext.Entry(personJob).State);
 	}
 
 	[TestMethod]
 	public async Task UpdateRangeAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonJobRepository repository = new(dbContext);
+		PersonJobRepository repository = new(DbContext);
 
 		List<PersonJobEntity> personJobs = [new() { PersonId = Guid.NewGuid(), JobId = Guid.NewGuid() }];
 
 		await repository.UpdateAsync(personJobs)
 			.ConfigureAwait(false);
 
-		Assert.AreEqual(EntityState.Modified, dbContext.Entry(personJobs[0]).State);
+		Assert.AreEqual(EntityState.Modified, DbContext.Entry(personJobs[0]).State);
 	}
 
 	[TestMethod]
 	public async Task DeleteAsyncCancelledTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonJobRepository repository = new(dbContext);
+		PersonJobRepository repository = new(DbContext);
 
 		PersonJobEntity personJob = new() { PersonId = Guid.NewGuid(), JobId = Guid.NewGuid() };
 
@@ -218,6 +201,6 @@ public sealed class PersonJobTests : UnitTestBase
 			() => repository.DeleteAsync(personJob, new CancellationToken(true)))
 			.ConfigureAwait(false);
 
-		Assert.AreEqual(EntityState.Detached, dbContext.Entry(personJob).State);
+		Assert.AreEqual(EntityState.Detached, DbContext.Entry(personJob).State);
 	}
 }

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonTests.cs
@@ -15,8 +15,7 @@ public sealed class PersonTests : UnitTestBase
 	[TestMethod]
 	public void DeleteByIdTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonRepository repository = new(dbContext);
+		PersonRepository repository = new(DbContext);
 
 		int deleted = repository.Delete(Guid.NewGuid());
 
@@ -26,8 +25,7 @@ public sealed class PersonTests : UnitTestBase
 	[TestMethod]
 	public void DeleteByIdsTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonRepository repository = new(dbContext);
+		PersonRepository repository = new(DbContext);
 
 		int deleted = repository.Delete([Guid.NewGuid(), Guid.NewGuid()]);
 
@@ -37,8 +35,7 @@ public sealed class PersonTests : UnitTestBase
 	[TestMethod]
 	public async Task DeleteByIdAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonRepository repository = new(dbContext);
+		PersonRepository repository = new(DbContext);
 
 		int deleted = await repository.DeleteAsync(Guid.NewGuid())
 			.ConfigureAwait(false);
@@ -49,8 +46,7 @@ public sealed class PersonTests : UnitTestBase
 	[TestMethod]
 	public async Task DeleteByIdsAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonRepository repository = new(dbContext);
+		PersonRepository repository = new(DbContext);
 
 		int deleted = await repository.DeleteAsync([Guid.NewGuid(), Guid.NewGuid()])
 			.ConfigureAwait(false);
@@ -61,8 +57,7 @@ public sealed class PersonTests : UnitTestBase
 	[TestMethod]
 	public void GetByIdTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonRepository repository = new(dbContext);
+		PersonRepository repository = new(DbContext);
 
 		PersonEntity? person = repository.GetById(Guid.Empty);
 
@@ -72,8 +67,7 @@ public sealed class PersonTests : UnitTestBase
 	[TestMethod]
 	public void GetByIdsTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonRepository repository = new(dbContext);
+		PersonRepository repository = new(DbContext);
 
 		IEnumerable<PersonEntity> persons = repository.GetByIds([Guid.NewGuid(), Guid.NewGuid()]);
 
@@ -83,8 +77,7 @@ public sealed class PersonTests : UnitTestBase
 	[TestMethod]
 	public async Task GetByIdAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonRepository repository = new(dbContext);
+		PersonRepository repository = new(DbContext);
 
 		PersonEntity? person = await repository.GetByIdAsync(Guid.Empty)
 			.ConfigureAwait(false);
@@ -95,8 +88,7 @@ public sealed class PersonTests : UnitTestBase
 	[TestMethod]
 	public async Task GetByIdsAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonRepository repository = new(dbContext);
+		PersonRepository repository = new(DbContext);
 
 		IEnumerable<PersonEntity> persons = await repository.GetByIdsAsync([Guid.NewGuid(), Guid.NewGuid()])
 			.ConfigureAwait(false);
@@ -107,8 +99,7 @@ public sealed class PersonTests : UnitTestBase
 	[TestMethod]
 	public void GetAllTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonRepository repository = new(dbContext);
+		PersonRepository repository = new(DbContext);
 
 		IEnumerable<PersonEntity> persons = repository.GetAll(true, true);
 
@@ -118,8 +109,7 @@ public sealed class PersonTests : UnitTestBase
 	[TestMethod]
 	public async Task GetAllAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonRepository repository = new(dbContext);
+		PersonRepository repository = new(DbContext);
 
 		IEnumerable<PersonEntity> persons = await repository.GetAllAsync(true, true)
 			.ConfigureAwait(false);
@@ -130,8 +120,7 @@ public sealed class PersonTests : UnitTestBase
 	[TestMethod]
 	public void GetManyByConditionTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonRepository repository = new(dbContext);
+		PersonRepository repository = new(DbContext);
 
 		IEnumerable<PersonEntity> persons = repository.GetManyByCondition(
 			x => x.Id.Equals(Guid.Empty),
@@ -145,8 +134,7 @@ public sealed class PersonTests : UnitTestBase
 	[TestMethod]
 	public async Task GetManyByConditionAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonRepository repository = new(dbContext);
+		PersonRepository repository = new(DbContext);
 
 		IEnumerable<PersonEntity> persons = await repository.GetManyByConditionAsync(
 			x => x.Id.Equals(Guid.Empty),

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonTypeTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonTypeTests.cs
@@ -15,8 +15,7 @@ public sealed class PersonTypeTests : UnitTestBase
 	[TestMethod]
 	public void GetByNameTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonTypeRepository repository = new(dbContext);
+		PersonTypeRepository repository = new(DbContext);
 
 		PersonTypeEntity? result = repository.GetByName("Male");
 
@@ -26,8 +25,7 @@ public sealed class PersonTypeTests : UnitTestBase
 	[TestMethod]
 	public void GetByNamesTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonTypeRepository repository = new(dbContext);
+		PersonTypeRepository repository = new(DbContext);
 
 		IEnumerable<PersonTypeEntity> result = repository.GetByNames(["Male", "Female"]);
 
@@ -38,8 +36,7 @@ public sealed class PersonTypeTests : UnitTestBase
 	[TestMethod]
 	public async Task GetByNameAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonTypeRepository repository = new(dbContext);
+		PersonTypeRepository repository = new(DbContext);
 
 		PersonTypeEntity? result = await repository.GetByNameAsync("Male")
 			.ConfigureAwait(false);
@@ -50,8 +47,7 @@ public sealed class PersonTypeTests : UnitTestBase
 	[TestMethod]
 	public async Task GetByNamesAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonTypeRepository repository = new(dbContext);
+		PersonTypeRepository repository = new(DbContext);
 
 		IEnumerable<PersonTypeEntity> result = await repository.GetByNamesAsync(["Male", "Female"])
 			.ConfigureAwait(false);
@@ -63,8 +59,7 @@ public sealed class PersonTypeTests : UnitTestBase
 	[TestMethod]
 	public void GetByConditionTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonRepository repository = new(dbContext);
+		PersonRepository repository = new(DbContext);
 
 		PersonEntity? person = repository.GetByCondition(
 			expression: x => x.Id.Equals(Guid.Empty),
@@ -77,8 +72,7 @@ public sealed class PersonTypeTests : UnitTestBase
 	[TestMethod]
 	public async Task GetByConditionAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonRepository repository = new(dbContext);
+		PersonRepository repository = new(DbContext);
 
 		PersonEntity? person = await repository.GetByConditionAsync(
 			expression: x => x.Id.Equals(Guid.Empty),
@@ -91,28 +85,26 @@ public sealed class PersonTypeTests : UnitTestBase
 	[TestMethod]
 	public void SoftDeleteTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonTypeRepository repository = new(dbContext);
+		PersonTypeRepository repository = new(DbContext);
 
 		PersonTypeEntity? result = repository.GetById(1, false, true);
 		Assert.IsNotNull(result);
 
 		repository.Delete(result);
-		_ = dbContext.SaveChanges();
+		_ = DbContext.SaveChanges();
 		Assert.IsTrue(result.IsDeleted);
 	}
 
 	[TestMethod]
 	public async Task SoftDeleteAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonTypeRepository repository = new(dbContext);
+		PersonTypeRepository repository = new(DbContext);
 
 		PersonTypeEntity? result = await repository.GetByIdAsync(2, false, true);
 		Assert.IsNotNull(result);
 
 		await repository.DeleteAsync(result);
-		_ = await dbContext.SaveChangesAsync();
+		_ = await DbContext.SaveChangesAsync();
 		Assert.IsTrue(result.IsDeleted);
 	}
 }

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/RepositoryOverloadTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/RepositoryOverloadTests.cs
@@ -21,8 +21,7 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 	[TestMethod]
 	public void QueryFilterOverloadsSyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonTypeRepository repository = new(dbContext);
+		PersonTypeRepository repository = new(DbContext);
 
 		int count = repository
 			.CountByCondition(
@@ -52,8 +51,7 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 	[TestMethod]
 	public async Task QueryFilterOverloadsAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonTypeRepository repository = new(dbContext);
+		PersonTypeRepository repository = new(DbContext);
 
 		int count = await repository
 			.CountByConditionAsync(
@@ -88,8 +86,7 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 	[TestMethod]
 	public void ProjectionOverloadsSyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonTypeRepository repository = new(dbContext);
+		PersonTypeRepository repository = new(DbContext);
 
 		IReadOnlyList<PersonTypeProjection> all = repository
 			.GetAll(
@@ -197,8 +194,7 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 	[TestMethod]
 	public async Task ProjectionOverloadsAsyncTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		PersonTypeRepository repository = new(dbContext);
+		PersonTypeRepository repository = new(DbContext);
 
 		IReadOnlyList<PersonTypeProjection> all = await repository
 			.GetAllAsync(
@@ -309,8 +305,7 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 	[TestMethod]
 	public void DeleteByConditionRemovesMatchingEntitiesTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		SkillRepository repository = new(dbContext);
+		SkillRepository repository = new(DbContext);
 		string uniqueName = $"Skill-{Guid.NewGuid():N}";
 
 		SkillEntity entity = new()
@@ -322,7 +317,7 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 		};
 
 		repository.Create(entity);
-		_ = dbContext.SaveChanges();
+		_ = DbContext.SaveChanges();
 
 		try
 		{
@@ -337,7 +332,7 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 		}
 		finally
 		{
-			_ = dbContext.Set<SkillEntity>()
+			_ = DbContext.Set<SkillEntity>()
 				.Where(x => x.Name == uniqueName)
 				.ExecuteDelete();
 		}
@@ -346,8 +341,7 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 	[TestMethod]
 	public void UpdateByConditionAndIdsModifyMatchingEntitiesTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		JobRepository repository = new(dbContext);
+		JobRepository repository = new(DbContext);
 		string uniquePrefix = $"Job-{Guid.NewGuid():N}";
 
 		JobEntity first = new()
@@ -365,7 +359,7 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 		};
 
 		repository.Create([first, second]);
-		_ = dbContext.SaveChanges();
+		_ = DbContext.SaveChanges();
 
 		try
 		{
@@ -392,7 +386,7 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 		}
 		finally
 		{
-			_ = dbContext.Set<JobEntity>()
+			_ = DbContext.Set<JobEntity>()
 				.Where(x => x.Id == first.Id || x.Id == second.Id)
 				.ExecuteDelete();
 		}

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/SkillTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/SkillTests.cs
@@ -15,8 +15,7 @@ public sealed class SkillTests : UnitTestBase
 	[TestMethod]
 	public void SkillCreateTest()
 	{
-		using TestDbContext context = GetTestContext();
-		SkillRepository repository = new(context);
+		SkillRepository repository = new(DbContext);
 		SkillEntity newSkill = new()
 		{
 			Name = "FancySkill",
@@ -25,7 +24,7 @@ public sealed class SkillTests : UnitTestBase
 		};
 
 		repository.Create(newSkill);
-		int result = context.SaveChanges();
+		int result = DbContext.SaveChanges();
 		Assert.AreEqual(1, result);
 
 		SkillEntity? dbSkill = repository.GetByCondition(x => x.Name == newSkill.Name, trackChanges: true);
@@ -33,7 +32,7 @@ public sealed class SkillTests : UnitTestBase
 		Assert.AreNotEqual(DateTimeOffset.MinValue, dbSkill.CreatedAt);
 
 		dbSkill.IsCritical = false;
-		result = context.SaveChanges();
+		result = DbContext.SaveChanges();
 		Assert.AreEqual(1, result);
 
 		dbSkill = repository.GetByCondition(x => x.Name == newSkill.Name, trackChanges: true);

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/UnitTestBase.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/UnitTestBase.cs
@@ -33,11 +33,28 @@ public abstract class UnitTestBase
 		dbContext.Database.EnsureDeleted();
 	}
 
+	/// <summary>
+	/// The database context for the currently running test.
+	/// </summary>
+	/// <remarks>
+	/// A fresh context is created before each test and disposed afterwards. Static members
+	/// such as <c>[ClassInitialize]</c> run outside of that lifetime and must keep calling
+	/// <see cref="GetTestContext"/> themselves.
+	/// </remarks>
+	protected TestDbContext DbContext { get; private set; } = default!;
+
+	[TestInitialize]
+	public void TestInitialize()
+		=> DbContext = GetTestContext();
+
+	[TestCleanup]
+	public void TestCleanup()
+		=> DbContext.Dispose();
+
 	[TestMethod]
 	public void GenerateCreateScriptTest()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		string sqlScript = dbContext.Database.GenerateCreateScript();
+		string sqlScript = DbContext.Database.GenerateCreateScript();
 		File.WriteAllText("CreateScript.sql", sqlScript);
 	}
 


### PR DESCRIPTION
**Changes:**

- Refactored all test classes to use a shared `DbContext` property on `UnitTestBase`, managed with `TestInitialize` and `TestCleanup`.
- Updated all repository and context usages in tests to use this property, removed redundant context creation, and adjusted assertions and `SaveChanges` calls accordingly.
- No production code changes.

closes #210 