### PR TITLE
feat(repositories): add streaming query support to generic repository

### DIFF
--- a/src/BB84.EntityFrameworkCore.Repositories.Abstractions/IGenericRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.Abstractions/IGenericRepository.cs
@@ -456,6 +456,156 @@ public interface IGenericRepository<TEntity>
 		CancellationToken token = default);
 
 	/// <summary>
+	/// Streams all entities of type <typeparamref name="TEntity"/> from the data source.
+	/// </summary>
+	/// <remarks>
+	/// In contrast to <see cref="GetAllAsync(bool, bool, CancellationToken)"/> the result set is not
+	/// buffered, the entities are yielded as they are read from the database. The returned sequence is
+	/// lazy and must be enumerated within the lifetime of the underlying database context. Enumerating
+	/// with change tracking enabled makes the change tracker grow with every yielded entity.
+	/// </remarks>
+	/// <param name="ignoreQueryFilters">
+	/// A value indicating whether to ignore any query filters applied to the entity type.
+	/// </param>
+	/// <param name="trackChanges">
+	/// A value indicating whether the streamed entities should be tracked by the context.
+	/// </param>
+	/// <param name="token">The cancellation token to cancel the request.</param>
+	/// <returns>
+	/// An <see cref="IAsyncEnumerable{T}"/> that yields all entities of type <typeparamref name="TEntity"/>.
+	/// </returns>
+	IAsyncEnumerable<TEntity> StreamAll(
+		bool ignoreQueryFilters = false,
+		bool trackChanges = false,
+		CancellationToken token = default);
+
+	/// <summary>
+	/// Streams all entities of type <typeparamref name="TEntity"/> from the data source and projects
+	/// them into a different form using the specified <paramref name="selector"/>.
+	/// </summary>
+	/// <remarks>
+	/// In contrast to <see cref="GetAllAsync{TResult}(Expression{Func{TEntity, TResult}}, Expression{Func{TResult, TResult}}, bool, CancellationToken)"/>
+	/// the result set is not buffered, the projections are yielded as they are read from the database.
+	/// The returned sequence is lazy and must be enumerated within the lifetime of the underlying
+	/// database context.
+	/// </remarks>
+	/// <typeparam name="TResult">The type of the result elements after projection.</typeparam>
+	/// <param name="selector">The expression used to project the entities into the desired form.</param>
+	/// <param name="fieldSelector">The optional expression used to specify which fields to include in the projection.</param>
+	/// <param name="ignoreQueryFilters">
+	/// A value indicating whether to ignore any query filters applied to the entity type.
+	/// </param>
+	/// <param name="token">The cancellation token to cancel the request.</param>
+	/// <returns>
+	/// An <see cref="IAsyncEnumerable{T}"/> that yields the projected <typeparamref name="TResult"/> instances.
+	/// </returns>
+	IAsyncEnumerable<TResult> StreamAll<TResult>(
+		Expression<Func<TEntity, TResult>> selector,
+		Expression<Func<TResult, TResult>>? fieldSelector = null,
+		bool ignoreQueryFilters = false,
+		CancellationToken token = default);
+
+	/// <summary>
+	/// Streams the entities that satisfy the specified query filter, with optional ordering, paging and
+	/// related data inclusion.
+	/// </summary>
+	/// <remarks>
+	/// In contrast to <see cref="GetManyByConditionAsync(Func{IQueryable{TEntity}, IQueryable{TEntity}}, bool, Func{IQueryable{TEntity}, IOrderedQueryable{TEntity}}, int?, int?, bool, CancellationToken, string[])"/>
+	/// the result set is not buffered, the entities are yielded as they are read from the database. The
+	/// returned sequence is lazy and must be enumerated within the lifetime of the underlying database
+	/// context. Enumerating with change tracking enabled makes the change tracker grow with every yielded
+	/// entity.
+	/// </remarks>
+	/// <param name="queryFilter">A function that applies additional filtering to the entity query.</param>
+	/// <param name="ignoreQueryFilters">true to ignore any global query filters applied to the entity type; otherwise, false.</param>
+	/// <param name="orderBy">An optional function to specify the ordering of the streamed entities.</param>
+	/// <param name="skip">The number of entities to skip before starting to yield results.</param>
+	/// <param name="take">The maximum number of entities to yield.</param>
+	/// <param name="trackChanges">true to enable change tracking for the streamed entities; otherwise, false.</param>
+	/// <param name="token">The cancellation token to cancel the request.</param>
+	/// <param name="includeProperties">An array of related entity property names to include in the query results for eager loading.</param>
+	/// <returns>
+	/// An <see cref="IAsyncEnumerable{T}"/> that yields the entities matching the specified conditions.
+	/// </returns>
+	IAsyncEnumerable<TEntity> StreamByCondition(
+		Func<IQueryable<TEntity>, IQueryable<TEntity>> queryFilter,
+		bool ignoreQueryFilters = false,
+		Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
+		int? skip = null,
+		int? take = null,
+		bool trackChanges = false,
+		CancellationToken token = default,
+		params string[] includeProperties);
+
+	/// <summary>
+	/// Streams the entities that satisfy the specified <paramref name="expression"/>, with optional
+	/// ordering, paging and related data inclusion.
+	/// </summary>
+	/// <remarks>
+	/// In contrast to <see cref="GetManyByConditionAsync(Expression{Func{TEntity, bool}}, Func{IQueryable{TEntity}, IQueryable{TEntity}}, bool, Func{IQueryable{TEntity}, IOrderedQueryable{TEntity}}, int?, int?, bool, CancellationToken, string[])"/>
+	/// the result set is not buffered, the entities are yielded as they are read from the database. The
+	/// returned sequence is lazy and must be enumerated within the lifetime of the underlying database
+	/// context. Enumerating with change tracking enabled makes the change tracker grow with every yielded
+	/// entity.
+	/// </remarks>
+	/// <param name="expression">The condition to fulfill to be streamed.</param>
+	/// <param name="queryFilter">The function used to filter the entities.</param>
+	/// <param name="ignoreQueryFilters">Should model-level entity query filters be applied?</param>
+	/// <param name="orderBy">The function used to order the entities.</param>
+	/// <param name="skip">The number of records to skip.</param>
+	/// <param name="take">The number of records to limit the results to.</param>
+	/// <param name="trackChanges">Should the streamed entities be tracked?</param>
+	/// <param name="token">The cancellation token to cancel the request.</param>
+	/// <param name="includeProperties">Any other navigation properties to include when streaming the entities.</param>
+	/// <returns>
+	/// An <see cref="IAsyncEnumerable{T}"/> that yields the entities matching the specified conditions.
+	/// </returns>
+	IAsyncEnumerable<TEntity> StreamByCondition(
+		Expression<Func<TEntity, bool>> expression,
+		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
+		bool ignoreQueryFilters = false,
+		Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
+		int? skip = null,
+		int? take = null,
+		bool trackChanges = false,
+		CancellationToken token = default,
+		params string[] includeProperties);
+
+	/// <summary>
+	/// Streams the entities that satisfy the specified <paramref name="expression"/> and projects them
+	/// into the specified result type, with optional ordering and paging.
+	/// </summary>
+	/// <remarks>
+	/// In contrast to <see cref="GetManyByConditionAsync{TResult}(Expression{Func{TEntity, bool}}, Expression{Func{TEntity, TResult}}, Expression{Func{TResult, TResult}}, Func{IQueryable{TEntity}, IQueryable{TEntity}}, bool, Func{IQueryable{TEntity}, IOrderedQueryable{TEntity}}, int?, int?, CancellationToken)"/>
+	/// the result set is not buffered, the projections are yielded as they are read from the database.
+	/// The returned sequence is lazy and must be enumerated within the lifetime of the underlying
+	/// database context.
+	/// </remarks>
+	/// <typeparam name="TResult">The type of the result returned by the selector expression.</typeparam>
+	/// <param name="expression">An expression that defines the condition entities must satisfy to be streamed.</param>
+	/// <param name="selector">An expression that specifies how to project each matching entity to the result type.</param>
+	/// <param name="fieldSelector">An optional expression that selects specific fields from the projected result.</param>
+	/// <param name="queryFilter">An optional function to apply additional filtering or transformation to the query before execution.</param>
+	/// <param name="ignoreQueryFilters">true to ignore any global query filters applied to the entity type; otherwise, false.</param>
+	/// <param name="orderBy">An optional function to specify the ordering of the results.</param>
+	/// <param name="skip">The number of results to skip before yielding results. If null, no results are skipped.</param>
+	/// <param name="take">The maximum number of results to yield. If null, all matching results are yielded.</param>
+	/// <param name="token">The cancellation token to cancel the request.</param>
+	/// <returns>
+	/// An <see cref="IAsyncEnumerable{T}"/> that yields the projected <typeparamref name="TResult"/> instances.
+	/// </returns>
+	IAsyncEnumerable<TResult> StreamByCondition<TResult>(
+		Expression<Func<TEntity, bool>> expression,
+		Expression<Func<TEntity, TResult>> selector,
+		Expression<Func<TResult, TResult>>? fieldSelector = null,
+		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
+		bool ignoreQueryFilters = false,
+		Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
+		int? skip = null,
+		int? take = null,
+		CancellationToken token = default);
+
+	/// <summary>
 	/// Updates the specified entity in the underlying data store.
 	/// </summary>
 	/// <remarks>

--- a/src/BB84.EntityFrameworkCore.Repositories.Abstractions/README.md
+++ b/src/BB84.EntityFrameworkCore.Repositories.Abstractions/README.md
@@ -47,6 +47,15 @@ The base repository interface. All methods have synchronous and asynchronous var
 - `GetManyByCondition<TResult>(...)` — projected paged/filtered list
 - `CountAll(ignoreQueryFilters)` / `CountByCondition(expression, ...)` — count queries
 
+**Stream** (asynchronous only, returns `IAsyncEnumerable<T>`)
+
+- `StreamAll(ignoreQueryFilters, trackChanges, token)` — streams all entities
+- `StreamAll<TResult>(selector, fieldSelector, ignoreQueryFilters, token)` — streams projected DTOs
+- `StreamByCondition(expression, queryFilter, ignoreQueryFilters, orderBy, skip, take, trackChanges, token, includeProperties)`
+- `StreamByCondition<TResult>(...)` — streams projected results
+
+The parameters mirror the corresponding `GetAllAsync` / `GetManyByConditionAsync` methods; only the return type differs. Unlike those, the result set is **not buffered** — entities are yielded as they are read from the database. The returned sequence is lazy, so it must be enumerated within the lifetime of the `IDbContext` and only one stream may be live per context at a time.
+
 **Update**
 
 - `Update(entity)` / `Update(entities)` — marks entity/entities as `Modified`

--- a/src/BB84.EntityFrameworkCore.Repositories/GenericRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/GenericRepository.cs
@@ -4,6 +4,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 
 using BB84.EntityFrameworkCore.Repositories.Abstractions;
 
@@ -167,6 +168,26 @@ public abstract class GenericRepository<TEntity>(IDbContext dbContext) : IGeneri
 	/// <inheritdoc/>
 	public async Task<IReadOnlyList<TResult>> GetManyByConditionAsync<TResult>(Expression<Func<TEntity, bool>> expression, Expression<Func<TEntity, TResult>> selector, Expression<Func<TResult, TResult>>? fieldSelector = null, Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null, bool ignoreQueryFilters = false, Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null, int? skip = null, int? take = null, CancellationToken token = default)
 		=> await QueryManyAsync(selector: selector, fieldSelector: fieldSelector, expression: expression, queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters, orderBy: orderBy, skip: skip, take: take, token: token).ConfigureAwait(false);
+
+	/// <inheritdoc/>
+	public IAsyncEnumerable<TEntity> StreamAll(bool ignoreQueryFilters = false, bool trackChanges = false, CancellationToken token = default)
+		=> QueryManyStream(ignoreQueryFilters: ignoreQueryFilters, trackChanges: trackChanges, token: token);
+
+	/// <inheritdoc/>
+	public IAsyncEnumerable<TResult> StreamAll<TResult>(Expression<Func<TEntity, TResult>> selector, Expression<Func<TResult, TResult>>? fieldSelector = null, bool ignoreQueryFilters = false, CancellationToken token = default)
+		=> QueryManyStream(selector: selector, fieldSelector: fieldSelector, ignoreQueryFilters: ignoreQueryFilters, token: token);
+
+	/// <inheritdoc/>
+	public IAsyncEnumerable<TEntity> StreamByCondition(Func<IQueryable<TEntity>, IQueryable<TEntity>> queryFilter, bool ignoreQueryFilters = false, Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null, int? skip = null, int? take = null, bool trackChanges = false, CancellationToken token = default, params string[] includeProperties)
+		=> QueryManyStream(queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters, orderBy: orderBy, skip: skip, take: take, trackChanges: trackChanges, token: token, includeProperties: includeProperties);
+
+	/// <inheritdoc/>
+	public IAsyncEnumerable<TEntity> StreamByCondition(Expression<Func<TEntity, bool>> expression, Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null, bool ignoreQueryFilters = false, Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null, int? skip = null, int? take = null, bool trackChanges = false, CancellationToken token = default, params string[] includeProperties)
+		=> QueryManyStream(expression: expression, queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters, orderBy: orderBy, skip: skip, take: take, trackChanges: trackChanges, token: token, includeProperties: includeProperties);
+
+	/// <inheritdoc/>
+	public IAsyncEnumerable<TResult> StreamByCondition<TResult>(Expression<Func<TEntity, bool>> expression, Expression<Func<TEntity, TResult>> selector, Expression<Func<TResult, TResult>>? fieldSelector = null, Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null, bool ignoreQueryFilters = false, Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null, int? skip = null, int? take = null, CancellationToken token = default)
+		=> QueryManyStream(selector: selector, fieldSelector: fieldSelector, expression: expression, queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters, orderBy: orderBy, skip: skip, take: take, token: token);
 
 	/// <inheritdoc/>
 	public void Update(TEntity entity)
@@ -479,6 +500,93 @@ public abstract class GenericRepository<TEntity>(IDbContext dbContext) : IGeneri
 		return await ApplyProjection(query, selector, fieldSelector)
 			.ToListAsync(token)
 			.ConfigureAwait(false);
+	}
+
+	/// <summary>
+	/// Streams the collection of <typeparamref name="TEntity"/> that matches the provided criteria.
+	/// </summary>
+	/// <remarks>
+	/// The result set is not buffered, the entities are yielded as they are read from the database.
+	/// The returned sequence is lazy and must be enumerated within the lifetime of the underlying
+	/// database context.
+	/// </remarks>
+	/// <param name="expression">The condition to fulfill to be returned.</param>
+	/// <param name="queryFilter">The function used to filter the entities.</param>
+	/// <param name="ignoreQueryFilters">Should model-level entity query filters be applied?</param>
+	/// <param name="orderBy">The function used to order the entities.</param>
+	/// <param name="skip">The number of records to skip.</param>
+	/// <param name="take">The number of records to limit the results to.</param>
+	/// <param name="trackChanges">Should the fetched entities be tracked?</param>
+	/// <param name="token">The cancellation token to cancel the request.</param>
+	/// <param name="includeProperties">Any other navigation properties to include when returning the collection.</param>
+	/// <returns>An asynchronous sequence of <typeparamref name="TEntity"/>.</returns>
+	protected async IAsyncEnumerable<TEntity> QueryManyStream(
+		Expression<Func<TEntity, bool>>? expression = null,
+		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
+		bool ignoreQueryFilters = false,
+		Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
+		int? skip = null,
+		int? take = null,
+		bool trackChanges = false,
+		[EnumeratorCancellation] CancellationToken token = default,
+		params string[] includeProperties)
+	{
+		IQueryable<TEntity> query = PrepareQuery(
+			expression: expression,
+			queryFilter: queryFilter,
+			ignoreQueryFilters: ignoreQueryFilters,
+			orderBy: orderBy,
+			skip: skip,
+			take: take,
+			trackChanges: trackChanges,
+			includeProperties: includeProperties
+			);
+
+		await foreach (TEntity entity in query.AsAsyncEnumerable().WithCancellation(token).ConfigureAwait(false))
+			yield return entity;
+	}
+
+	/// <summary>
+	/// Streams the collection of <typeparamref name="TResult"/> projections that match the provided criteria.
+	/// </summary>
+	/// <remarks>
+	/// The result set is not buffered, the projections are yielded as they are read from the database.
+	/// The returned sequence is lazy and must be enumerated within the lifetime of the underlying
+	/// database context.
+	/// </remarks>
+	/// <typeparam name="TResult">The type of the result elements after projection.</typeparam>
+	/// <param name="selector">The expression that defines the projection from the entity to the result type.</param>
+	/// <param name="fieldSelector">The optional expression that further projects the result type.</param>
+	/// <param name="expression">The condition to fulfill to be returned.</param>
+	/// <param name="queryFilter">The function used to filter the entities.</param>
+	/// <param name="ignoreQueryFilters">Should model-level entity query filters be applied?</param>
+	/// <param name="orderBy">The function used to order the entities.</param>
+	/// <param name="skip">The number of records to skip.</param>
+	/// <param name="take">The number of records to limit the results to.</param>
+	/// <param name="token">The cancellation token to cancel the request.</param>
+	/// <returns>An asynchronous sequence of <typeparamref name="TResult"/>.</returns>
+	protected async IAsyncEnumerable<TResult> QueryManyStream<TResult>(
+		Expression<Func<TEntity, TResult>> selector,
+		Expression<Func<TResult, TResult>>? fieldSelector = null,
+		Expression<Func<TEntity, bool>>? expression = null,
+		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
+		bool ignoreQueryFilters = false,
+		Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
+		int? skip = null,
+		int? take = null,
+		[EnumeratorCancellation] CancellationToken token = default)
+	{
+		IQueryable<TEntity> query = PrepareQuery(
+			expression: expression,
+			queryFilter: queryFilter,
+			ignoreQueryFilters: ignoreQueryFilters,
+			orderBy: orderBy,
+			skip: skip,
+			take: take
+			);
+
+		await foreach (TResult result in ApplyProjection(query, selector, fieldSelector).AsAsyncEnumerable().WithCancellation(token).ConfigureAwait(false))
+			yield return result;
 	}
 
 	/// <summary>

--- a/src/BB84.EntityFrameworkCore.Repositories/README.md
+++ b/src/BB84.EntityFrameworkCore.Repositories/README.md
@@ -18,6 +18,27 @@ dotnet add package BB84.EntityFrameworkCore.Repositories
 
 Abstract base for all repositories. Accepts `IDbContext` as a constructor parameter. All query methods delegate to `PrepareQuery(...)`, which composes `Where`, `IgnoreQueryFilters`, `Include`, `OrderBy`, `Skip`, `Take`, and `AsNoTracking` into a single `IQueryable<TEntity>`. Projection overloads use the protected `ApplyProjection(query, selector, fieldSelector)` helper.
 
+#### Streaming reads
+
+`StreamAll` and `StreamByCondition` return `IAsyncEnumerable<T>` instead of `IReadOnlyList<T>`. They take the same parameters as their `GetAllAsync` / `GetManyByConditionAsync` counterparts and go through the same `PrepareQuery(...)` composition, but the result set is not buffered — rows are yielded as they arrive. Use them for exports, batch jobs and other unbounded reads:
+
+```csharp
+await foreach (Product product in repository.StreamByCondition(
+    p => p.IsActive,
+    orderBy: q => q.OrderBy(p => p.Name),
+    token: token))
+{
+    await writer.WriteAsync(product, token);
+}
+```
+
+Two things to keep in mind:
+
+- The sequence is lazy. It must be enumerated within the lifetime of the `IDbContext`, and EF Core allows only one active stream per context at a time.
+- `trackChanges` defaults to `false` and should stay that way for large reads — with tracking enabled the change tracker grows with every yielded entity, which defeats the purpose of streaming.
+
+Subclasses can build their own streaming methods on the `protected QueryManyStream(...)` helpers, which mirror `QueryMany` / `QueryManyAsync` in both the entity and the projection flavour.
+
 ### `IdentityRepository<TEntity, TKey>` / `IdentityRepository<TEntity>`
 
 Extends `GenericRepository<TEntity>` with key-based `GetById`, `GetByIds`, and bulk `Delete`/`Update` by ID. The non-generic overload defaults `TKey` to `Guid`.

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonTests.cs
@@ -144,4 +144,34 @@ public sealed class PersonTests : UnitTestBase
 
 		Assert.IsFalse(persons.Any());
 	}
+
+	[TestMethod]
+	public async Task StreamAllTest()
+	{
+		PersonRepository repository = new(DbContext);
+		int count = 0;
+
+		await foreach (PersonEntity person in repository.StreamAll(true, true).ConfigureAwait(false))
+			count++;
+
+		Assert.AreEqual(0, count);
+	}
+
+	[TestMethod]
+	public async Task StreamByConditionTest()
+	{
+		PersonRepository repository = new(DbContext);
+		int count = 0;
+
+		IAsyncEnumerable<PersonEntity> persons = repository.StreamByCondition(
+			x => x.Id.Equals(Guid.Empty),
+			x => x.Where(x => x.Id.Equals(Guid.Empty)),
+			false, x => x.OrderBy(x => x.Id), 1, 1, false
+			);
+
+		await foreach (PersonEntity person in persons.ConfigureAwait(false))
+			count++;
+
+		Assert.AreEqual(0, count);
+	}
 }

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/RepositoryOverloadTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/RepositoryOverloadTests.cs
@@ -392,6 +392,121 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 		}
 	}
 
+	[TestMethod]
+	public async Task StreamOverloadsAsyncTest()
+	{
+		PersonTypeRepository repository = new(DbContext);
+
+		List<PersonTypeEntity> all = [];
+		await foreach (PersonTypeEntity entity in repository
+			.StreamAll(ignoreQueryFilters: true, token: _cancellationToken)
+			.ConfigureAwait(false))
+		{
+			all.Add(entity);
+		}
+
+		List<PersonTypeEntity> byQueryFilter = [];
+		await foreach (PersonTypeEntity entity in repository
+			.StreamByCondition(
+				queryFilter: query => query.Where(x => x.Name.Contains("e")),
+				ignoreQueryFilters: true,
+				orderBy: query => query.OrderBy(x => x.Name),
+				skip: 1,
+				take: 1,
+				token: _cancellationToken)
+			.ConfigureAwait(false))
+		{
+			byQueryFilter.Add(entity);
+		}
+
+		List<PersonTypeEntity> byExpression = [];
+		await foreach (PersonTypeEntity entity in repository
+			.StreamByCondition(
+				expression: x => x.Id > 1,
+				ignoreQueryFilters: true,
+				orderBy: query => query.OrderBy(x => x.Id),
+				token: _cancellationToken)
+			.ConfigureAwait(false))
+		{
+			byExpression.Add(entity);
+		}
+
+		List<PersonTypeProjection> projected = [];
+		await foreach (PersonTypeProjection projection in repository
+			.StreamByCondition(
+				expression: x => x.Id > 1,
+				selector: x => new PersonTypeProjection
+				{
+					Id = x.Id,
+					Name = x.Name,
+					Description = x.Description
+				},
+				fieldSelector: x => new PersonTypeProjection
+				{
+					Id = x.Id,
+					Name = x.Name.ToUpperInvariant(),
+					Description = null
+				},
+				ignoreQueryFilters: true,
+				orderBy: query => query.OrderBy(x => x.Id),
+				token: _cancellationToken)
+			.ConfigureAwait(false))
+		{
+			projected.Add(projection);
+		}
+
+		Assert.HasCount(3, all);
+
+		Assert.HasCount(1, byQueryFilter);
+		Assert.AreEqual("Female", byQueryFilter.Single().Name);
+
+		Assert.HasCount(2, byExpression);
+		Assert.AreEqual(2, byExpression[0].Id);
+		Assert.AreEqual(3, byExpression[1].Id);
+
+		Assert.HasCount(2, projected);
+		Assert.IsTrue(projected.All(x => x.Description is null));
+		Assert.AreEqual("MALE", projected[0].Name);
+	}
+
+	[TestMethod]
+	public async Task StreamHonorsCancellationTest()
+	{
+		PersonTypeRepository repository = new(DbContext);
+		using CancellationTokenSource tokenSource = new();
+		await tokenSource.CancelAsync().ConfigureAwait(false);
+
+		await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+		{
+			await foreach (PersonTypeEntity entity in repository
+				.StreamAll(ignoreQueryFilters: true, token: tokenSource.Token)
+				.ConfigureAwait(false))
+			{
+				Assert.IsNotNull(entity);
+			}
+		}).ConfigureAwait(false);
+	}
+
+	[TestMethod]
+	public async Task StreamYieldsEntitiesIncrementallyTest()
+	{
+		PersonTypeRepository repository = new(DbContext);
+		List<int> trackedAfterEachEntity = [];
+
+		await foreach (PersonTypeEntity entity in repository
+			.StreamAll(ignoreQueryFilters: true, trackChanges: true, token: _cancellationToken)
+			.ConfigureAwait(false))
+		{
+			Assert.IsNotNull(entity);
+			trackedAfterEachEntity.Add(DbContext.ChangeTracker.Entries<PersonTypeEntity>().Count());
+		}
+
+		List<int> expectedTrackedCounts = [1, 2, 3];
+
+		Assert.HasCount(3, trackedAfterEachEntity);
+		CollectionAssert.AreEqual(expectedTrackedCounts, trackedAfterEachEntity);
+	}
+
 	private sealed class PersonTypeProjection
 	{
 		public int Id { get; init; }


### PR DESCRIPTION
**Changes:**

- Introduced `IAsyncEnumerable`-based streaming methods (`StreamAll`, `StreamByCondition`, and projection overloads) to `IGenericRepository` and `GenericRepository` for unbuffered, incremental data access.
- Updated `README` with usage and guidance.
- Added protected streaming helpers and comprehensive unit tests covering all scenarios.

closes #211 