### PR TITLE
feat(tfm): retarget to `net10.0` and drop the `net8.0` fork

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,7 @@
 		<LangVersion>latest</LangVersion>
 		<NeutralLanguage>en-US</NeutralLanguage>
 		<Nullable>enable</Nullable>
-		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,9 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="MSTest" Version="4.3.3" />
-    <PackageVersion Condition="$(TargetFramework) == 'net8.0'" Include="Microsoft.EntityFrameworkCore.Relational" Version="[9.0.18, 10.0.0)" />
-    <PackageVersion Condition="$(TargetFramework) == 'net8.0'" Include="Microsoft.EntityFrameworkCore.SqlServer" Version="[9.0.18, 10.0.0)" />
-    <PackageVersion Condition="$(TargetFramework) == 'net10.0'" Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.10" />
-    <PackageVersion Condition="$(TargetFramework) == 'net10.0'" Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@
 [![CodeQL](https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore/actions/workflows/github-code-scanning/codeql/badge.svg?branch=main)](https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore/actions/workflows/github-code-scanning/codeql)
 [![Dependabot](https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore/actions/workflows/dependabot/dependabot-updates/badge.svg?branch=main)](https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore/actions/workflows/dependabot/dependabot-updates)
 
-[![.NET](https://img.shields.io/badge/net8.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore)
 [![.NET](https://img.shields.io/badge/net10.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore)
-[![C#](https://img.shields.io/badge/C%23-13.0-239120)](https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore)
+[![C#](https://img.shields.io/badge/C%23-14.0-239120)](https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore)
 [![Issues](https://img.shields.io/github/issues/BoBoBaSs84/BB84.EntityFrameworkCore)](https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore/issues)
 [![Commit](https://img.shields.io/github/last-commit/BoBoBaSs84/BB84.EntityFrameworkCore)](https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore/commit/main)
 [![License](https://img.shields.io/github/license/BoBoBaSs84/BB84.EntityFrameworkCore)](https://github.com/BoBoBaSs84/BB84.EntityFrameworkCore/blob/main/LICENSE)
@@ -16,7 +15,7 @@
 
 ## 🔎 Overview
 
-**BB84.EntityFrameworkCore** is a .NET 8.0 & .NET 10.0 library collection that provides a reusable repository pattern implementation for Entity Framework Core applications. It ships as five focused NuGet packages that can be adopted incrementally.
+**BB84.EntityFrameworkCore** is a .NET 10.0 library collection that provides a reusable repository pattern implementation for Entity Framework Core applications. It ships as five focused NuGet packages that can be adopted incrementally.
 
 ## 📦 Packages
 
@@ -73,7 +72,7 @@ BB84.EntityFrameworkCore/
 2. Follow the existing code style (see `.editorconfig`).
 3. Add XML documentation for all public APIs.
 4. Add unit tests for every new method.
-5. Ensure all tests pass across all target frameworks.
+5. Ensure all tests pass.
 6. Open a pull request describing your changes.
 
 ## 📖 API Documentation

--- a/src/BB84.EntityFrameworkCore.Entities.Abstractions/README.md
+++ b/src/BB84.EntityFrameworkCore.Entities.Abstractions/README.md
@@ -1,4 +1,3 @@
-[![net80](https://img.shields.io/badge/net8.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
 [![net100](https://img.shields.io/badge/net10.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
 [![NuGet](https://img.shields.io/nuget/v/BB84.EntityFrameworkCore.Entities.Abstractions.svg?logo=nuget&logoColor=white)](https://www.nuget.org/packages/BB84.EntityFrameworkCore.Entities.Abstractions)
 

--- a/src/BB84.EntityFrameworkCore.Entities/README.md
+++ b/src/BB84.EntityFrameworkCore.Entities/README.md
@@ -1,4 +1,3 @@
-[![net80](https://img.shields.io/badge/net8.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
 [![net100](https://img.shields.io/badge/net10.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
 [![NuGet](https://img.shields.io/nuget/v/BB84.EntityFrameworkCore.Entities.svg?logo=nuget&logoColor=white)](https://www.nuget.org/packages/BB84.EntityFrameworkCore.Entities)
 

--- a/src/BB84.EntityFrameworkCore.Repositories.Abstractions/IGenericRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.Abstractions/IGenericRepository.cs
@@ -640,11 +640,7 @@ public interface IGenericRepository<TEntity>
 	/// <returns>The total number of rows updated in the database.</returns>
 	int Update(
 		Expression<Func<TEntity, bool>> expression,
-#if NET8_0
-		Expression<Func<SetPropertyCalls<TEntity>, SetPropertyCalls<TEntity>>> setPropertyCalls);
-#else
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls);
-#endif
 
 	/// <inheritdoc cref="Update(TEntity)"/>
 	/// <param name="token">The cancellation token to cancel the request.</param>
@@ -660,19 +656,10 @@ public interface IGenericRepository<TEntity>
 		IEnumerable<TEntity> entities,
 		CancellationToken token = default);
 
-#if NET8_0
-	/// <inheritdoc cref="Update(Expression{Func{TEntity, bool}}, Expression{Func{SetPropertyCalls{TEntity}, SetPropertyCalls{TEntity}}})"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-#else
 	/// <inheritdoc cref="Update(Expression{Func{TEntity, bool}}, Action{UpdateSettersBuilder{TEntity}})"/>
 	/// <param name="token">The cancellation token to cancel the request.</param>
-#endif
 	Task<int> UpdateAsync(
 		Expression<Func<TEntity, bool>> expression,
-#if NET8_0
-		Expression<Func<SetPropertyCalls<TEntity>, SetPropertyCalls<TEntity>>> setPropertyCalls,
-#else
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls,
-#endif
 		CancellationToken token = default);
 }

--- a/src/BB84.EntityFrameworkCore.Repositories.Abstractions/IIdentityRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.Abstractions/IIdentityRepository.cs
@@ -212,11 +212,7 @@ public interface IIdentityRepository<TEntity, TKey> : IGenericRepository<TEntity
 	/// </returns>
 	int Update(
 		TKey id,
-#if NET8_0
-		Expression<Func<SetPropertyCalls<TEntity>, SetPropertyCalls<TEntity>>> setPropertyCalls);
-#else
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls);
-#endif
 
 	/// <summary>
 	/// Updates the entities identified by the specified identifiers with the provided property changes.
@@ -235,42 +231,20 @@ public interface IIdentityRepository<TEntity, TKey> : IGenericRepository<TEntity
 	/// </returns>
 	int Update(
 		IEnumerable<TKey> ids,
-#if NET8_0
-		Expression<Func<SetPropertyCalls<TEntity>, SetPropertyCalls<TEntity>>> setPropertyCalls);
-#else
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls);
-#endif
 
-#if NET8_0
-	/// <inheritdoc cref="Update(TKey, Expression{Func{SetPropertyCalls{TEntity}, SetPropertyCalls{TEntity}}})"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-#else
 	/// <inheritdoc cref="Update(TKey, Action{UpdateSettersBuilder{TEntity}})"/>
 	/// <param name="token">The cancellation token to cancel the request.</param>
-#endif
 	Task<int> UpdateAsync(
 		TKey id,
-#if NET8_0
-		Expression<Func<SetPropertyCalls<TEntity>, SetPropertyCalls<TEntity>>> setPropertyCalls,
-#else
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls,
-#endif
 		CancellationToken token = default);
 
-#if NET8_0
-	/// <inheritdoc cref="Update(IEnumerable{TKey}, Expression{Func{SetPropertyCalls{TEntity}, SetPropertyCalls{TEntity}}})"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-#else
 	/// <inheritdoc cref="Update(IEnumerable{TKey}, Action{UpdateSettersBuilder{TEntity}})"/>
 	/// <param name="token">The cancellation token to cancel the request.</param>
-#endif
 	Task<int> UpdateAsync(
 		IEnumerable<TKey> ids,
-#if NET8_0
-		Expression<Func<SetPropertyCalls<TEntity>, SetPropertyCalls<TEntity>>> setPropertyCalls,
-#else
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls,
-#endif
 		CancellationToken token = default);
 }
 

--- a/src/BB84.EntityFrameworkCore.Repositories.Abstractions/README.md
+++ b/src/BB84.EntityFrameworkCore.Repositories.Abstractions/README.md
@@ -1,4 +1,3 @@
-[![net80](https://img.shields.io/badge/net8.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
 [![net100](https://img.shields.io/badge/net10.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
 [![NuGet](https://img.shields.io/nuget/v/BB84.EntityFrameworkCore.Repositories.Abstractions.svg?logo=nuget&logoColor=white)](https://www.nuget.org/packages/BB84.EntityFrameworkCore.Repositories.Abstractions)
 

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/README.md
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/README.md
@@ -1,4 +1,3 @@
-[![net80](https://img.shields.io/badge/net8.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
 [![net100](https://img.shields.io/badge/net10.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
 [![NuGet](https://img.shields.io/nuget/v/BB84.EntityFrameworkCore.Repositories.SqlServer.svg?logo=nuget&logoColor=white)](https://www.nuget.org/packages/BB84.EntityFrameworkCore.Repositories.SqlServer)
 

--- a/src/BB84.EntityFrameworkCore.Repositories/GenericRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/GenericRepository.cs
@@ -200,11 +200,7 @@ public abstract class GenericRepository<TEntity>(IDbContext dbContext) : IGeneri
 	/// <inheritdoc/>
 	public int Update(
 		Expression<Func<TEntity, bool>> expression,
-#if NET8_0
-		Expression<Func<SetPropertyCalls<TEntity>, SetPropertyCalls<TEntity>>> setPropertyCalls)
-#else
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls)
-#endif
 		=> PrepareQuery(expression).ExecuteUpdate(setPropertyCalls);
 
 	/// <inheritdoc/>
@@ -232,11 +228,7 @@ public abstract class GenericRepository<TEntity>(IDbContext dbContext) : IGeneri
 	/// <inheritdoc/>
 	public async Task<int> UpdateAsync(
 		Expression<Func<TEntity, bool>> expression,
-#if NET8_0
-		Expression<Func<SetPropertyCalls<TEntity>, SetPropertyCalls<TEntity>>> setPropertyCalls,
-#else
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls,
-#endif
 		CancellationToken token = default)
 		=> await PrepareQuery(expression).ExecuteUpdateAsync(setPropertyCalls, token).ConfigureAwait(false);
 

--- a/src/BB84.EntityFrameworkCore.Repositories/IdentityRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/IdentityRepository.cs
@@ -78,42 +78,26 @@ public abstract class IdentityRepository<TEntity, TKey>(IDbContext dbContext) : 
 	/// <inheritdoc/>
 	public int Update(
 		TKey id,
-#if NET8_0
-		Expression<Func<SetPropertyCalls<TEntity>, SetPropertyCalls<TEntity>>> setPropertyCalls)
-#else
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls)
-#endif
 		=> Update(ById(id), setPropertyCalls);
 
 	/// <inheritdoc/>
 	public int Update(
 		IEnumerable<TKey> ids,
-#if NET8_0
-		Expression<Func<SetPropertyCalls<TEntity>, SetPropertyCalls<TEntity>>> setPropertyCalls)
-#else
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls)
-#endif
 		=> Update(ByIds(ids), setPropertyCalls);
 
 	/// <inheritdoc/>
 	public async Task<int> UpdateAsync(
 		TKey id,
-#if NET8_0
-		Expression<Func<SetPropertyCalls<TEntity>, SetPropertyCalls<TEntity>>> setPropertyCalls,
-#else
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls,
-#endif
 		CancellationToken token = default)
 		=> await UpdateAsync(ById(id), setPropertyCalls, token).ConfigureAwait(false);
 
 	/// <inheritdoc/>
 	public async Task<int> UpdateAsync(
 		IEnumerable<TKey> ids,
-#if NET8_0
-		Expression<Func<SetPropertyCalls<TEntity>, SetPropertyCalls<TEntity>>> setPropertyCalls,
-#else
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls,
-#endif
 		CancellationToken token = default)
 		=> await UpdateAsync(ByIds(ids), setPropertyCalls, token).ConfigureAwait(false);
 

--- a/src/BB84.EntityFrameworkCore.Repositories/README.md
+++ b/src/BB84.EntityFrameworkCore.Repositories/README.md
@@ -1,4 +1,3 @@
-[![net80](https://img.shields.io/badge/net8.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
 [![net100](https://img.shields.io/badge/net10.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
 [![NuGet](https://img.shields.io/nuget/v/BB84.EntityFrameworkCore.Repositories.svg?logo=nuget&logoColor=white)](https://www.nuget.org/packages/BB84.EntityFrameworkCore.Repositories)
 

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/UnitTestBase.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/UnitTestBase.cs
@@ -63,12 +63,8 @@ public abstract class UnitTestBase
 
 	private static DbContextOptions<TestDbContext> GetContextOptions()
 	{
-		string dbName = "TestDb";
-#if NET8_0
-		dbName += "80";
-#else
-		dbName += "100";
-#endif
+		const string dbName = "TestDb";
+
 		return new DbContextOptionsBuilder<TestDbContext>()
 			.UseSqlServer($"Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog={dbName};Integrated Security=True")
 			.Options;


### PR DESCRIPTION
**Changes:**

EF Core changed the `ExecuteUpdate` setter API between 9 and 10, which forced sixteen `#if NET8_0` blocks across four files.
The fork reached into the XML docs as well, so the generated API reference and the package surface differed per target framework and every signature edit had to be made twice.

- `Directory.Build.props`: `TargetFrameworks` -> `TargetFramework`.
- `Directory.Packages.props`: drop the per-TFM conditions, pin EF Core 10.0.10 unconditionally.
- Keep the `Action<UpdateSettersBuilder<TEntity>>` branch everywhere, delete the `Expression<Func<SetPropertyCalls<T>, ...>>` one.
- Test database name collapses to `TestDb`.
- README badges and target framework wording.

**BREAKING CHANGE:** net8.0 is no longer a target. Consumers on net8.0 stay on the 4.x line, which is supported until .NET 8 goes out of support in November 2026.

closes #233 