### PR TITLE
test(mssql): replace `LocalDB` with `Testcontainers`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   build-and-test:
     name: Build & Test
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,5 +6,6 @@
     <PackageVersion Include="MSTest" Version="4.3.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.10" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.14.0" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -45,10 +45,12 @@ dotnet build
 
 # Run all tests
 dotnet test
-
-# Run tests
-dotnet test
 ```
+
+The repository tests start a SQL Server container through
+[Testcontainers](https://testcontainers.com/), so a running Docker daemon is required for
+`dotnet test`. The entity tests have no such dependency. On Apple silicon the SQL Server image
+runs under emulation, which works but is noticeably slower.
 
 ## 🏗️ Project structure
 
@@ -62,7 +64,7 @@ BB84.EntityFrameworkCore/
 │   └── BB84.EntityFrameworkCore.Repositories.SqlServer/  # SQL Server configurations and extensions
 ├── tests/
 │   ├── BB84.EntityFrameworkCore.Entities.Tests/          # Entity unit tests
-│   └── BB84.EntityFrameworkCore.Repositories.Tests/      # Repository integration tests (requires LocalDB)
+│   └── BB84.EntityFrameworkCore.Repositories.Tests/      # Repository integration tests (requires Docker)
 └── docs/                                                 # DocFX documentation source
 ```
 

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/BB84.EntityFrameworkCore.Repositories.Tests.csproj
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/BB84.EntityFrameworkCore.Repositories.Tests.csproj
@@ -6,6 +6,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
 		<PackageReference Include="MSTest" />
+		<PackageReference Include="Testcontainers.MsSql" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\BB84.EntityFrameworkCore.Repositories.SqlServer\BB84.EntityFrameworkCore.Repositories.SqlServer.csproj" />

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/CreateScriptTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/CreateScriptTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright: 2024 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using BB84.EntityFrameworkCore.Repositories.Tests.Persistence;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace BB84.EntityFrameworkCore.Repositories.Tests;
+
+/// <summary>
+/// Generates the create script for the test model.
+/// </summary>
+/// <remarks>
+/// This deliberately does not derive from <see cref="UnitTestBase"/>. MSTest discovers
+/// inherited test methods, so a test declared there would run once per derived class and
+/// every run would write the same file.
+/// </remarks>
+[TestClass]
+[SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, unit testing.")]
+public sealed class CreateScriptTests
+{
+	public TestContext TestContext { get; set; } = default!;
+
+	[TestMethod]
+	public void GenerateCreateScriptTest()
+	{
+		using TestDbContext dbContext = UnitTestBase.GetTestContext();
+
+		string sqlScript = dbContext.Database.GenerateCreateScript();
+
+		Assert.IsFalse(string.IsNullOrWhiteSpace(sqlScript));
+		foreach (string tableName in new[] { "Jobs", "JobTypes", "Persons", "PersonJobs", "PersonTypes", "Skills" })
+			StringAssert.Contains(sqlScript, tableName);
+
+		string filePath = Path.Combine(TestContext.TestRunResultsDirectory ?? AppContext.BaseDirectory, "CreateScript.sql");
+		File.WriteAllText(filePath, sqlScript);
+	}
+}

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/UnitTestBase.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/UnitTestBase.cs
@@ -7,7 +7,10 @@ using BB84.EntityFrameworkCore.Repositories.SqlServer.Interceptors;
 using BB84.EntityFrameworkCore.Repositories.Tests.Persistence;
 using BB84.EntityFrameworkCore.Repositories.Tests.Persistence.Interceptors;
 
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
+
+using Testcontainers.MsSql;
 
 namespace BB84.EntityFrameworkCore.Repositories.Tests;
 
@@ -15,22 +18,41 @@ namespace BB84.EntityFrameworkCore.Repositories.Tests;
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, unit testing.")]
 public abstract class UnitTestBase
 {
+	private const string DatabaseName = "TestDb";
+	private const string ContainerImage = "mcr.microsoft.com/mssql/server:2022-latest";
+
 	private static readonly SoftDeletableInterceptor SoftDeletableInterceptor = new();
 	private static readonly TimeAuditedInterceptor TimeAuditedInterceptor = new();
 	private static readonly UserAuditedInterceptor UserAuditedInterceptor = new();
+	private static readonly MsSqlContainer Container = new MsSqlBuilder(ContainerImage).Build();
+
+	private static string? connectionString;
 
 	[AssemblyInitialize]
-	public static void AssemblyInitialize(TestContext context)
+	public static async Task AssemblyInitialize(TestContext context)
 	{
+		await Container.StartAsync()
+			.ConfigureAwait(false);
+
+		// The container hands out a connection string pointing at "master";
+		// the test database itself is created by "EnsureCreated" below.
+		connectionString = new SqlConnectionStringBuilder(Container.GetConnectionString())
+		{
+			InitialCatalog = DatabaseName
+		}.ConnectionString;
+
 		using TestDbContext dbContext = GetTestContext();
 		dbContext.Database.EnsureCreated();
 	}
 
 	[AssemblyCleanup]
-	public static void AssemblyCleanup()
+	public static async Task AssemblyCleanup()
 	{
-		using TestDbContext dbContext = GetTestContext();
-		dbContext.Database.EnsureDeleted();
+		using (TestDbContext dbContext = GetTestContext())
+			dbContext.Database.EnsureDeleted();
+
+		await Container.DisposeAsync()
+			.ConfigureAwait(false);
 	}
 
 	/// <summary>
@@ -51,22 +73,16 @@ public abstract class UnitTestBase
 	public void TestCleanup()
 		=> DbContext.Dispose();
 
-	[TestMethod]
-	public void GenerateCreateScriptTest()
-	{
-		string sqlScript = DbContext.Database.GenerateCreateScript();
-		File.WriteAllText("CreateScript.sql", sqlScript);
-	}
-
 	public static TestDbContext GetTestContext()
 		=> new(GetContextOptions(), SoftDeletableInterceptor, TimeAuditedInterceptor, UserAuditedInterceptor);
 
 	private static DbContextOptions<TestDbContext> GetContextOptions()
 	{
-		const string dbName = "TestDb";
+		if (connectionString is null)
+			throw new InvalidOperationException($"The database container has not been started, '{nameof(AssemblyInitialize)}' must run first.");
 
 		return new DbContextOptionsBuilder<TestDbContext>()
-			.UseSqlServer($"Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog={dbName};Integrated Security=True")
+			.UseSqlServer(connectionString)
 			.Options;
 	}
 }


### PR DESCRIPTION
**Changes:**

- `LocalDB` is Windows-only, which pinned CI to `windows-latest` and made the repository test suite unrunnable on macOS and Linux.
- `UnitTestBase` now starts a SQL Server container and derives the connection string from it, so the suite runs anywhere Docker does. CI moves to `ubuntu-latest`.
- The test model stays as it is: it uses temporal history tables and xml/money/datetime2 columns throughout, so it cannot be built by SQLite.
- Swapping the connection string keeps the model, the schema and the interceptors untouched.
- Also folds in the inherited `GenerateCreateScriptTest`. Being declared on the base class, it ran once per derived class -- seven executions, all writing the same relative path and asserting nothing.
- It is now a single test on its own class, with assertions and a unique output path.

closes #241 & closes #221 