### PR TITLE
fix(mssql): apply the soft delete query filter

### DIFF
--- a/src/BB84.EntityFrameworkCore.Repositories.Abstractions/IGenericRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.Abstractions/IGenericRepository.cs
@@ -84,10 +84,18 @@ public interface IGenericRepository<TEntity>
 	/// the <paramref name="expression"/> from the database.
 	/// </summary>
 	/// <remarks>
+	/// <para>
 	/// This operation executes immediately against the database, rather than being deferred
 	/// until save changes is called. It also does not interact with the EF change tracker in
 	/// any way: entity instances which happen to be tracked when this operation is invoked
 	/// aren't taken into account, and aren't updated to reflect the changes.
+	/// </para>
+	/// <para>
+	/// <b>This deletes permanently, even for soft deletable entity types.</b> Because no save
+	/// operation takes place, save changes interceptors never run, and the soft deletable
+	/// interceptor therefore cannot turn the deletion into a flag update. The rows are gone.
+	/// Use <see cref="Delete(TEntity)"/> together with a save operation to soft delete.
+	/// </para>
 	/// </remarks>
 	/// <param name="expression">The condition to fulfill to be deleted.</param>
 	/// <returns>The total number of rows deleted in the database.</returns>
@@ -630,11 +638,19 @@ public interface IGenericRepository<TEntity>
 	/// the <paramref name="expression"/> from the database.
 	/// </summary>
 	/// <remarks>
+	/// <para>
 	/// This operation executes immediately against the database, rather than being deferred
 	/// until save changes is called. It also does not interact with the EF change tracker in
 	/// any way: entity instances which happen to be tracked when this operation is invoked
 	/// aren't taken into account, and aren't updated to reflect the changes.
-	/// </remarks>	
+	/// </para>
+	/// <para>
+	/// <b>Auditing does not happen for this operation.</b> Because no save operation takes
+	/// place, save changes interceptors never run, so the audit columns are left untouched
+	/// unless <paramref name="setPropertyCalls"/> sets them explicitly. Use
+	/// <see cref="Update(TEntity)"/> together with a save operation to have them maintained.
+	/// </para>
+	/// </remarks>
 	/// <param name="expression">The condition to fulfill to be updated.</param>
 	/// <param name="setPropertyCalls">A collection of set property statements specifying properties to update.</param>
 	/// <returns>The total number of rows updated in the database.</returns>

--- a/src/BB84.EntityFrameworkCore.Repositories.Abstractions/IIdentityRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.Abstractions/IIdentityRepository.cs
@@ -31,11 +31,18 @@ public interface IIdentityRepository<TEntity, TKey> : IGenericRepository<TEntity
 	/// the <paramref name="id"/> from the database.
 	/// </summary>
 	/// <remarks>
+	/// <para>
 	/// This operation executes immediately against the database, rather than being deferred
 	/// until save changes is called. It also does not interact with the EF change tracker in
 	/// any way: entity instances which happen to be tracked when this operation is invoked
 	/// aren't taken into account, and aren't updated to reflect the changes.
-	/// </remarks>	
+	/// </para>
+	/// <para>
+	/// <b>This deletes permanently, even for soft deletable entity types.</b> Because no save
+	/// operation takes place, save changes interceptors never run, and the soft deletable
+	/// interceptor therefore cannot turn the deletion into a flag update. The rows are gone.
+	/// </para>
+	/// </remarks>
 	/// <param name="id">The primary key of the <typeparamref name="TEntity"/>.</param>
 	/// <returns>The total number of rows deleted in the database.</returns>
 	int Delete(TKey id);
@@ -45,11 +52,18 @@ public interface IIdentityRepository<TEntity, TKey> : IGenericRepository<TEntity
 	/// the <paramref name="ids"/> from the database.
 	/// </summary>
 	/// <remarks>
+	/// <para>
 	/// This operation executes immediately against the database, rather than being deferred
 	/// until save changes is called. It also does not interact with the EF change tracker in
 	/// any way: entity instances which happen to be tracked when this operation is invoked
 	/// aren't taken into account, and aren't updated to reflect the changes.
-	/// </remarks>	
+	/// </para>
+	/// <para>
+	/// <b>This deletes permanently, even for soft deletable entity types.</b> Because no save
+	/// operation takes place, save changes interceptors never run, and the soft deletable
+	/// interceptor therefore cannot turn the deletion into a flag update. The rows are gone.
+	/// </para>
+	/// </remarks>
 	/// <param name="ids">The primary keys of the <typeparamref name="TEntity"/>.</param>
 	/// <returns>The total number of rows deleted in the database.</returns>
 	int Delete(IEnumerable<TKey> ids);

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/EnumeratorConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/EnumeratorConfiguration.cs
@@ -17,8 +17,23 @@ namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations;
 /// <see cref="IEnumeratorEntity{Tkey}"/> interface.
 /// </summary>
 /// <remarks>
+/// <para>
 /// This class defines a standard configuration for entities, including primary key setup,
-/// concurrency tokens, property constraints and indexing.</remarks>
+/// concurrency tokens, property constraints and indexing.
+/// </para>
+/// <para>
+/// A global query filter excluding soft deleted rows is applied, so that entities marked as
+/// deleted by the soft deletable interceptor are no longer returned by queries. Pass
+/// <see langword="true"/> for the <c>ignoreQueryFilters</c> parameter of the repository read
+/// methods to include them again.
+/// </para>
+/// <para>
+/// Be aware that a <b>required</b> navigation pointing at a soft deletable entity type
+/// interacts badly with this filter: filtering out the principal row also removes the
+/// dependents that require it. Model such navigations as optional, or apply a matching filter
+/// to both ends of the relationship.
+/// </para>
+/// </remarks>
 /// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
 /// <typeparam name="TKey">The type of the key for the entity.</typeparam>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
@@ -53,6 +68,8 @@ public abstract class EnumeratorConfiguration<TEntity, TKey> : IEntityTypeConfig
 		builder.Property(e => e.IsDeleted)
 			.HasColumnOrder(5)
 			.HasDefaultValue(false);
+
+		builder.HasQueryFilter(e => !e.IsDeleted);
 
 		builder.HasIndex(e => e.Name)
 			.IsUnique();

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonTypeTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonTypeTests.cs
@@ -7,6 +7,8 @@ using BB84.EntityFrameworkCore.Repositories.Tests.Persistence;
 using BB84.EntityFrameworkCore.Repositories.Tests.Persistence.Entities;
 using BB84.EntityFrameworkCore.Repositories.Tests.Persistence.Repositories;
 
+using Microsoft.EntityFrameworkCore;
+
 namespace BB84.EntityFrameworkCore.Repositories.Tests;
 
 [TestClass]
@@ -86,25 +88,53 @@ public sealed class PersonTypeTests : UnitTestBase
 	public void SoftDeleteTest()
 	{
 		PersonTypeRepository repository = new(DbContext);
+		PersonTypeEntity entity = new() { Name = "SoftDeleteTest", Description = "To be soft deleted." };
 
-		PersonTypeEntity? result = repository.GetById(1, false, true);
-		Assert.IsNotNull(result);
-
-		repository.Delete(result);
+		repository.Create(entity);
 		_ = DbContext.SaveChanges();
-		Assert.IsTrue(result.IsDeleted);
+
+		repository.Delete(entity);
+		_ = DbContext.SaveChanges();
+
+		Assert.IsTrue(entity.IsDeleted);
+		Assert.IsNull(repository.GetById(entity.Id));
+		Assert.IsNotNull(repository.GetById(entity.Id, ignoreQueryFilters: true));
+
+		Purge(entity);
 	}
 
 	[TestMethod]
 	public async Task SoftDeleteAsyncTest()
 	{
 		PersonTypeRepository repository = new(DbContext);
+		PersonTypeEntity entity = new() { Name = "SoftDeleteAsyncTest", Description = "To be soft deleted." };
 
-		PersonTypeEntity? result = await repository.GetByIdAsync(2, false, true);
-		Assert.IsNotNull(result);
-
-		await repository.DeleteAsync(result);
+		await repository.CreateAsync(entity);
 		_ = await DbContext.SaveChangesAsync();
-		Assert.IsTrue(result.IsDeleted);
+
+		await repository.DeleteAsync(entity);
+		_ = await DbContext.SaveChangesAsync();
+
+		Assert.IsTrue(entity.IsDeleted);
+		Assert.IsNull(await repository.GetByIdAsync(entity.Id));
+		Assert.IsNotNull(await repository.GetByIdAsync(entity.Id, ignoreQueryFilters: true));
+
+		Purge(entity);
 	}
+
+	/// <summary>
+	/// Removes a soft deleted row for good, so that the shared test database is left as the
+	/// seed data defines it.
+	/// </summary>
+	/// <remarks>
+	/// This deliberately bypasses the repository. The expression based delete applies the
+	/// global query filter, so it cannot reach a row that is already soft deleted.
+	/// </remarks>
+	/// <param name="entity">The soft deleted entity to remove.</param>
+	private void Purge(PersonTypeEntity entity)
+		=> _ = DbContext.Set<PersonTypeEntity>()
+			.AsQueryable()
+			.IgnoreQueryFilters()
+			.Where(x => x.Id == entity.Id)
+			.ExecuteDelete();
 }


### PR DESCRIPTION
**Changes:**

- `SoftDeletableInterceptor` flipped `IsDeleted` and left the row in the table, but no configuration ever called `HasQueryFilter`, so soft deleted rows kept showing up in every read.
- Soft delete was a flag nobody read, and the `ignoreQueryFilters` parameter threaded through some thirty public methods had nothing to ignore.
- `EnumeratorConfiguration<TEntity, TKey>` now applies `HasQueryFilter(e => !e.IsDeleted)`. `ISoftDeletable` is only reachable through `IEnumeratorEntity<TKey>`, so this one rung covers it.

**Behavioral break:** consumers who relied, knowingly or not, on soft deleted rows being visible will see them disappear. Pass `ignoreQueryFilters: true` to get them back.

- A required navigation pointing at a soft deletable type now drops its dependents along with the principal. And `Delete(expression)` builds its query through `PrepareQuery` with filters active, so it can no longer reach a row that is already soft deleted.
- Also documents that the expression based `Delete` and `Update` overloads bypass the change tracker: no save takes place, no interceptor runs, and the deletion is therefore permanent even for soft deletable types.
- The rename that makes this visible at the call site is tracked separately.

closes #217 & closes #218 