### PR TITLE
refactor(packages): correct the package boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@
 | [BB84.EntityFrameworkCore.Entities.Abstractions](src/BB84.EntityFrameworkCore.Entities.Abstractions/README.md)         | Core entity interface definitions — no dependencies               |
 | [BB84.EntityFrameworkCore.Entities](src/BB84.EntityFrameworkCore.Entities/README.md)                                   | Default implementations of the entity abstractions                |
 | [BB84.EntityFrameworkCore.Repositories.Abstractions](src/BB84.EntityFrameworkCore.Repositories.Abstractions/README.md) | Repository interface definitions                                  |
-| [BB84.EntityFrameworkCore.Repositories](src/BB84.EntityFrameworkCore.Repositories/README.md)                           | Default repository implementations and `DatabaseFacadeExtensions` |
-| [BB84.EntityFrameworkCore.Repositories.SqlServer](src/BB84.EntityFrameworkCore.Repositories.SqlServer/README.md)       | SQL Server entity configurations, interceptors, and extensions    |
+| [BB84.EntityFrameworkCore.Repositories](src/BB84.EntityFrameworkCore.Repositories/README.md)                           | Repository implementations, provider-agnostic configurations and interceptors |
+| [BB84.EntityFrameworkCore.Repositories.SqlServer](src/BB84.EntityFrameworkCore.Repositories.SqlServer/README.md)       | SQL Server configuration tuning, column type extensions and `DatabaseFacadeExtensions` |
 
 ## 💾 Installation
 

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/BB84.EntityFrameworkCore.Repositories.SqlServer.csproj
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/BB84.EntityFrameworkCore.Repositories.SqlServer.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<Description>This package contains configurations and extensions for the use of EntityFrameworkCore with SqlServer.</Description>
+		<Description>This package contains the SqlServer specific tuning of the entity type configurations, column type extensions and DatabaseFacade extensions for the use of EntityFrameworkCore with SqlServer.</Description>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
 	</ItemGroup>
 	<ItemGroup>
-		<ProjectReference Include="..\BB84.EntityFrameworkCore.Entities.Abstractions\BB84.EntityFrameworkCore.Entities.Abstractions.csproj" />
+		<ProjectReference Include="..\BB84.EntityFrameworkCore.Repositories\BB84.EntityFrameworkCore.Repositories.csproj" />
 	</ItemGroup>
 </Project>

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/AuditedCompositeConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/AuditedCompositeConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright: 2024 Robert Peter Meyer
+// Copyright: 2024 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -6,41 +6,29 @@
 using System.Diagnostics.CodeAnalysis;
 
 using BB84.EntityFrameworkCore.Entities.Abstractions;
-using BB84.EntityFrameworkCore.Repositories.SqlServer.Extensions;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
+using Base = BB84.EntityFrameworkCore.Repositories.Configurations;
+
 namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations;
 
-/// <summary>
-/// Provides a base configuration for entities that implement the
-/// <see cref="IAuditedCompositeEntity{TCreator, TEdited}"/> interface.
-/// </summary>
+/// <inheritdoc cref="Base.AuditedCompositeConfiguration{TEntity, TCreator, TEdited}"/>
 /// <remarks>
-/// This abstract class provides a reusable configuration for audited composite entities,
-/// ensuring that the <c>Timestamp</c>, <c>Creator</c>, and <c>Editor</c> properties are consistently
-/// configured across all derived entity types. The <c>Timestamp</c> property is marked as a concurrency
-/// token and is automatically updated on add or update operations. The <c>Creator</c> property is required,
-/// while the <c>Editor</c> property is optional.
+/// Nothing in this rung is SQL Server specific. The type exists so that the ladder is complete
+/// in both namespaces and a consumer can pick the namespace rather than the type.
 /// </remarks>
-/// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
-/// <typeparam name="TCreator">The type representing the creator of the entity.</typeparam>
-/// <typeparam name="TEdited">The type representing the editor of the entity.</typeparam>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
-public abstract class AuditedCompositeConfiguration<TEntity, TCreator, TEdited> : IEntityTypeConfiguration<TEntity>
+public abstract class AuditedCompositeConfiguration<TEntity, TCreator, TEdited> : Base.AuditedCompositeConfiguration<TEntity, TCreator, TEdited>, IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IAuditedCompositeEntity<TCreator, TEdited>
 	where TCreator : notnull
-{
-	/// <inheritdoc/>
-	public virtual void Configure(EntityTypeBuilder<TEntity> builder)
-	{
-		EntityTypeBuilderDefaults.ApplyConcurrencyToken(builder, columnOrder: 3);
-		EntityTypeBuilderDefaults.ApplyUserAuditColumns<TEntity, TCreator, TEdited>(builder, createdByOrder: 4, editedByOrder: 5);
-	}
-}
+{ }
 
 /// <inheritdoc cref="AuditedCompositeConfiguration{TEntity, TCreator, TEdited}"/>
+/// <remarks>
+/// The creator and editor columns are mapped as <b>sysname</b>.
+/// </remarks>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
 public abstract class AuditedCompositeConfiguration<TEntity> : AuditedCompositeConfiguration<TEntity, string, string?>, IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IAuditedCompositeEntity

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/CompositeConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/CompositeConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright: 2024 Robert Peter Meyer
+// Copyright: 2024 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -8,25 +8,17 @@ using System.Diagnostics.CodeAnalysis;
 using BB84.EntityFrameworkCore.Entities.Abstractions;
 
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Base = BB84.EntityFrameworkCore.Repositories.Configurations;
 
 namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations;
 
-/// <summary>
-/// Represents an abstract base class for configuring entity types that implement the
-/// <see cref="ICompositeEntity"/> interface.
-/// </summary>
+/// <inheritdoc cref="Base.CompositeConfiguration{TEntity}"/>
 /// <remarks>
-/// This class is intended to be used as a base for defining entity type configurations in
-/// Entity Framework Core. It provides a default implementation for configuring common properties,
-/// such as the <c>Timestamp</c> property.
+/// Nothing in this configuration is SQL Server specific. The type exists so that the ladder is
+/// complete in both namespaces and a consumer can pick the namespace rather than the type.
 /// </remarks>
-/// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
-public abstract class CompositeConfiguration<TEntity> : IEntityTypeConfiguration<TEntity>
+public abstract class CompositeConfiguration<TEntity> : Base.CompositeConfiguration<TEntity>, IEntityTypeConfiguration<TEntity>
 	where TEntity : class, ICompositeEntity
-{
-	/// <inheritdoc/>
-	public virtual void Configure(EntityTypeBuilder<TEntity> builder)
-		=> EntityTypeBuilderDefaults.ApplyConcurrencyToken(builder, columnOrder: 3);
-}
+{ }

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/EntityTypeBuilderDefaults.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/EntityTypeBuilderDefaults.cs
@@ -14,69 +14,29 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations;
 
 /// <summary>
-/// Provides the shared property configuration used by the entity type configuration base classes.
+/// Provides the SQL Server specific property configuration used by the entity type configuration
+/// base classes of this package.
 /// </summary>
 /// <remarks>
-/// The configuration base classes form ladders of progressively narrower generic aliases. The rungs
-/// share no common base that pins the creator and key types to their defaults, so the defaults that
-/// depend on those types live here instead of being repeated on every rung.
+/// The provider-agnostic counterpart lives in the <c>BB84.EntityFrameworkCore.Repositories</c>
+/// package. Only defaults that cannot be expressed without SQL Server belong here.
 /// </remarks>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
 internal static class EntityTypeBuilderDefaults
 {
 	/// <summary>
-	/// Configures the non clustered primary key and the identifier column of the entity.
+	/// Configures whether the primary key of the entity is clustered.
 	/// </summary>
 	/// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
 	/// <typeparam name="TKey">The type of the primary key for the entity.</typeparam>
 	/// <param name="builder">The builder for the entity type being configured.</param>
-	internal static void ApplyIdentityKey<TEntity, TKey>(EntityTypeBuilder<TEntity> builder)
+	/// <param name="clustered">Whether the primary key is clustered.</param>
+	internal static void ApplyKeyClustering<TEntity, TKey>(EntityTypeBuilder<TEntity> builder, bool clustered)
 		where TEntity : class, IIdentity<TKey>
 		where TKey : IEquatable<TKey>
 	{
 		builder.HasKey(e => e.Id)
-			.IsClustered(false);
-
-		builder.Property(e => e.Id)
-			.HasColumnOrder(1)
-			.ValueGeneratedOnAdd();
-	}
-
-	/// <summary>
-	/// Configures the concurrency token of the entity.
-	/// </summary>
-	/// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
-	/// <param name="builder">The builder for the entity type being configured.</param>
-	/// <param name="columnOrder">The zero based ordering of the column within the table.</param>
-	internal static void ApplyConcurrencyToken<TEntity>(EntityTypeBuilder<TEntity> builder, int columnOrder)
-		where TEntity : class, IConcurrency
-	{
-		builder.Property(e => e.Timestamp)
-			.HasColumnOrder(columnOrder)
-			.IsConcurrencyToken()
-			.ValueGeneratedOnAddOrUpdate();
-	}
-
-	/// <summary>
-	/// Configures the creator and editor columns of the entity.
-	/// </summary>
-	/// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
-	/// <typeparam name="TCreator">The type representing the creator of the entity.</typeparam>
-	/// <typeparam name="TEdited">The type representing the editor of the entity.</typeparam>
-	/// <param name="builder">The builder for the entity type being configured.</param>
-	/// <param name="createdByOrder">The ordering of the creator column within the table.</param>
-	/// <param name="editedByOrder">The ordering of the editor column within the table.</param>
-	internal static void ApplyUserAuditColumns<TEntity, TCreator, TEdited>(EntityTypeBuilder<TEntity> builder, int createdByOrder, int editedByOrder)
-		where TEntity : class, IUserAudited<TCreator, TEdited>
-		where TCreator : notnull
-	{
-		builder.Property(e => e.CreatedBy)
-			.HasColumnOrder(createdByOrder)
-			.IsRequired();
-
-		builder.Property(e => e.EditedBy)
-			.HasColumnOrder(editedByOrder)
-			.IsRequired(false);
+			.IsClustered(clustered);
 	}
 
 	/// <summary>

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/EnumeratorConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/EnumeratorConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright: 2024 Robert Peter Meyer
+// Copyright: 2024 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -10,75 +10,34 @@ using BB84.EntityFrameworkCore.Entities.Abstractions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
+using Base = BB84.EntityFrameworkCore.Repositories.Configurations;
+
 namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations;
 
-/// <summary>
-/// Represents an abstract base class for configuring entity types that implement the
-/// <see cref="IEnumeratorEntity{Tkey}"/> interface.
-/// </summary>
+/// <inheritdoc cref="Base.EnumeratorConfiguration{TEntity, TKey}"/>
 /// <remarks>
-/// <para>
-/// This class defines a standard configuration for entities, including primary key setup,
-/// concurrency tokens, property constraints and indexing.
-/// </para>
-/// <para>
-/// A global query filter excluding soft deleted rows is applied, so that entities marked as
-/// deleted by the soft deletable interceptor are no longer returned by queries. Pass
-/// <see langword="true"/> for the <c>ignoreQueryFilters</c> parameter of the repository read
-/// methods to include them again.
-/// </para>
-/// <para>
-/// Be aware that a <b>required</b> navigation pointing at a soft deletable entity type
-/// interacts badly with this filter: filtering out the principal row also removes the
-/// dependents that require it. Model such navigations as optional, or apply a matching filter
-/// to both ends of the relationship.
-/// </para>
+/// Applies the provider-agnostic configuration of
+/// <see cref="Base.EnumeratorConfiguration{TEntity, TKey}"/> and tunes it for SQL Server by
+/// declaring the primary key as non clustered.
 /// </remarks>
-/// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
-/// <typeparam name="TKey">The type of the key for the entity.</typeparam>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
-public abstract class EnumeratorConfiguration<TEntity, TKey> : IEntityTypeConfiguration<TEntity>
+public abstract class EnumeratorConfiguration<TEntity, TKey> : Base.EnumeratorConfiguration<TEntity, TKey>, IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IEnumeratorEntity<TKey>
 	where TKey : IEquatable<TKey>
 {
 	/// <inheritdoc/>
-	public virtual void Configure(EntityTypeBuilder<TEntity> builder)
+	public override void Configure(EntityTypeBuilder<TEntity> builder)
 	{
-		builder.HasKey(x => x.Id)
-			.IsClustered(false);
+		base.Configure(builder);
 
-		builder.Property(e => e.Id)
-			.HasColumnOrder(1)
-			.IsRequired();
-
-		EntityTypeBuilderDefaults.ApplyConcurrencyToken(builder, columnOrder: 2);
-
-		builder.Property(e => e.Name)
-			.HasColumnOrder(3)
-			.HasMaxLength(64)
-			.IsRequired()
-			.IsUnicode(false);
-
-		builder.Property(e => e.Description)
-			.HasColumnOrder(4)
-			.HasMaxLength(256)
-			.IsRequired(false)
-			.IsUnicode();
-
-		builder.Property(e => e.IsDeleted)
-			.HasColumnOrder(5)
-			.HasDefaultValue(false);
-
-		builder.HasQueryFilter(e => !e.IsDeleted);
-
-		builder.HasIndex(e => e.Name)
-			.IsUnique();
+		EntityTypeBuilderDefaults.ApplyKeyClustering<TEntity, TKey>(builder, clustered: false);
 	}
 }
 
 /// <inheritdoc cref="EnumeratorConfiguration{TEntity, TKey}"/>
 /// <remarks>
-/// The identity column is of type <see cref="int"/>.
+/// The identity column is of type <see cref="int"/> and the primary key is clustered, which
+/// suits the narrow, densely packed lookup tables this rung is meant for.
 /// </remarks>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
 public abstract class EnumeratorConfiguration<TEntity> : EnumeratorConfiguration<TEntity, int>
@@ -89,7 +48,6 @@ public abstract class EnumeratorConfiguration<TEntity> : EnumeratorConfiguration
 	{
 		base.Configure(builder);
 
-		builder.HasKey(x => x.Id)
-			.IsClustered();
+		EntityTypeBuilderDefaults.ApplyKeyClustering<TEntity, int>(builder, clustered: true);
 	}
 }

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/IdentityConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/IdentityConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright: 2024 Robert Peter Meyer
+// Copyright: 2024 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -10,29 +10,27 @@ using BB84.EntityFrameworkCore.Entities.Abstractions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
+using Base = BB84.EntityFrameworkCore.Repositories.Configurations;
+
 namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations;
 
-/// <summary>
-/// Represents an abstract base class for configuring entity types that implement the
-/// <see cref="IIdentityEntity{Tkey}"/> interface.
-/// </summary>
+/// <inheritdoc cref="Base.IdentityConfiguration{TEntity, TKey}"/>
 /// <remarks>
-/// This class defines a default configuration for identity-related entities, including the primary key and
-/// concurrency token. Derived classes can override the <see cref="Configure"/> method to provide additional
-/// or customized configuration.
+/// Applies the provider-agnostic configuration of
+/// <see cref="Base.IdentityConfiguration{TEntity, TKey}"/> and tunes it for SQL Server by
+/// declaring the primary key as non clustered.
 /// </remarks>
-/// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
-/// <typeparam name="TKey">The type of the primary key for the entity.</typeparam>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
-public abstract class IdentityConfiguration<TEntity, TKey> : IEntityTypeConfiguration<TEntity>
+public abstract class IdentityConfiguration<TEntity, TKey> : Base.IdentityConfiguration<TEntity, TKey>, IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IIdentityEntity<TKey>
 	where TKey : IEquatable<TKey>
 {
 	/// <inheritdoc/>
-	public virtual void Configure(EntityTypeBuilder<TEntity> builder)
+	public override void Configure(EntityTypeBuilder<TEntity> builder)
 	{
-		EntityTypeBuilderDefaults.ApplyIdentityKey<TEntity, TKey>(builder);
-		EntityTypeBuilderDefaults.ApplyConcurrencyToken(builder, columnOrder: 2);
+		base.Configure(builder);
+
+		EntityTypeBuilderDefaults.ApplyKeyClustering<TEntity, TKey>(builder, clustered: false);
 	}
 }
 

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Extensions/DatabaseFacadeExtensions.Functions.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Extensions/DatabaseFacadeExtensions.Functions.cs
@@ -8,7 +8,7 @@ using System.Data.Common;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
-namespace BB84.EntityFrameworkCore.Repositories.Extensions;
+namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Extensions;
 
 public static partial class DatabaseFacadeExtensions
 {
@@ -28,10 +28,12 @@ public static partial class DatabaseFacadeExtensions
 		IEnumerable<DbParameter> parameters)
 	{
 		ArgumentNullException.ThrowIfNull(databaseFacade);
+		ArgumentNullException.ThrowIfNull(parameters);
 
-		string sql = CreateTableFunctionCommand(schema, name, parameters);
+		DbParameter[] materialized = [.. parameters];
+		string sql = CreateTableFunctionCommand(schema, name, materialized);
 
-		return [.. databaseFacade.SqlQueryRaw<T>(sql, [.. parameters])];
+		return [.. databaseFacade.SqlQueryRaw<T>(sql, materialized)];
 	}
 
 	/// <summary>
@@ -52,11 +54,13 @@ public static partial class DatabaseFacadeExtensions
 		CancellationToken cancellationToken = default)
 	{
 		ArgumentNullException.ThrowIfNull(databaseFacade);
+		ArgumentNullException.ThrowIfNull(parameters);
 
-		string sql = CreateTableFunctionCommand(schema, name, parameters);
+		DbParameter[] materialized = [.. parameters];
+		string sql = CreateTableFunctionCommand(schema, name, materialized);
 
 		return await databaseFacade
-			.SqlQueryRaw<T>(sql, [.. parameters])
+			.SqlQueryRaw<T>(sql, materialized)
 			.ToListAsync(cancellationToken)
 			.ConfigureAwait(false);
 	}
@@ -77,11 +81,13 @@ public static partial class DatabaseFacadeExtensions
 		IEnumerable<DbParameter> parameters)
 	{
 		ArgumentNullException.ThrowIfNull(databaseFacade);
+		ArgumentNullException.ThrowIfNull(parameters);
 
-		string sql = CreateScalarFunctionCommand(schema, name, parameters);
+		DbParameter[] materialized = [.. parameters];
+		string sql = CreateScalarFunctionCommand(schema, name, materialized);
 
 		return databaseFacade
-			.SqlQueryRaw<T>(sql, [.. parameters])
+			.SqlQueryRaw<T>(sql, materialized)
 			.SingleOrDefault();
 	}
 
@@ -103,28 +109,26 @@ public static partial class DatabaseFacadeExtensions
 		CancellationToken cancellationToken = default)
 	{
 		ArgumentNullException.ThrowIfNull(databaseFacade);
+		ArgumentNullException.ThrowIfNull(parameters);
 
-		string sql = CreateScalarFunctionCommand(schema, name, parameters);
+		DbParameter[] materialized = [.. parameters];
+		string sql = CreateScalarFunctionCommand(schema, name, materialized);
 
 		return await databaseFacade
-			.SqlQueryRaw<T>(sql, [.. parameters])
+			.SqlQueryRaw<T>(sql, materialized)
 			.SingleOrDefaultAsync(cancellationToken)
 			.ConfigureAwait(false);
 	}
 
-	private static string CreateScalarFunctionCommand(string schema, string name, IEnumerable<DbParameter> parameters)
+	private static string CreateScalarFunctionCommand(string schema, string name, IReadOnlyCollection<DbParameter> parameters)
 	{
-		ArgumentNullException.ThrowIfNull(parameters);
-
 		string parameterPlaceholders = string.Join(", ", parameters.Select(GetParameterToken));
 
 		return $"SELECT [Value] = {GetObjectToken(schema, name)}({parameterPlaceholders})";
 	}
 
-	private static string CreateTableFunctionCommand(string schema, string name, IEnumerable<DbParameter> parameters)
+	private static string CreateTableFunctionCommand(string schema, string name, IReadOnlyCollection<DbParameter> parameters)
 	{
-		ArgumentNullException.ThrowIfNull(parameters);
-
 		string parameterPlaceholders = string.Join(", ", parameters.Select(GetParameterToken));
 
 		return $"SELECT * FROM {GetObjectToken(schema, name)}({parameterPlaceholders})";

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Extensions/DatabaseFacadeExtensions.Procedures.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Extensions/DatabaseFacadeExtensions.Procedures.cs
@@ -9,7 +9,7 @@ using System.Data.Common;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
-namespace BB84.EntityFrameworkCore.Repositories.Extensions;
+namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Extensions;
 
 public static partial class DatabaseFacadeExtensions
 {
@@ -115,9 +115,13 @@ public static partial class DatabaseFacadeExtensions
 	{
 		ArgumentNullException.ThrowIfNull(parameters);
 
+		// Materialize once: the sequence is enumerated to build the assignments and again to
+		// hand the parameters to the command, and a lazy sequence would not survive that.
+		DbParameter[] materialized = [.. parameters];
+
 		List<string> assignments = [];
 
-		foreach (DbParameter parameter in parameters)
+		foreach (DbParameter parameter in materialized)
 		{
 			string token = GetParameterToken(parameter);
 			bool isOutput = parameter.Direction is ParameterDirection.Output or ParameterDirection.InputOutput;
@@ -132,6 +136,6 @@ public static partial class DatabaseFacadeExtensions
 		if (assignments.Count > 0)
 			sql = $"{sql} {string.Join(", ", assignments)}";
 
-		return (sql, [.. parameters]);
+		return (sql, materialized);
 	}
 }

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Extensions/DatabaseFacadeExtensions.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Extensions/DatabaseFacadeExtensions.cs
@@ -7,7 +7,7 @@ using System.Data.Common;
 
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
-namespace BB84.EntityFrameworkCore.Repositories.Extensions;
+namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Extensions;
 
 /// <summary>
 /// Represents extension methods for the <see cref="DatabaseFacade"/> class to execute stored

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/README.md
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/README.md
@@ -3,12 +3,33 @@
 
 # BB84.EntityFrameworkCore.Repositories.SqlServer
 
-This package provides SQL Server–specific entity type configuration base classes, `SaveChangesInterceptor` implementations for auditing and soft delete, and `EntityTypeBuilderExtensions` for temporal table support.
+This package provides the SQL Server tuning of the entity type configuration base classes, `PropertyBuilderExtensions` for column types, `EntityTypeBuilderExtensions` for temporal table support, and `DatabaseFacadeExtensions` for calling stored procedures and SQL functions.
+
+> **Moved in 5.0.** The configuration base classes now derive from provider-agnostic bases in
+> `BB84.EntityFrameworkCore.Repositories`, and the interceptors moved there outright. `DatabaseFacadeExtensions` moved
+> the other way, into this package, because it emits T-SQL. See [Package boundaries](#package-boundaries).
 
 ## Installation
 
 ```powershell
 dotnet add package BB84.EntityFrameworkCore.Repositories.SqlServer
+```
+
+## Package boundaries
+
+Each configuration ladder exists twice, under the **same type names**:
+
+| Namespace                                                | Applies                                                                     |
+| -------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `BB84.EntityFrameworkCore.Repositories.Configurations`   | Key declaration, column order, concurrency token, audit columns, soft delete filter |
+| `BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations` | The above, plus clustering, `NEWID()` defaults and `sysname` audit columns |
+
+Pick the namespace, not the type. On SQL Server, keep importing this package's namespace and nothing changes. On any other provider, import the agnostic one and you get everything except the three SQL Server calls.
+
+A file that imports **both** namespaces — a project mapping a SQL Server context and a second provider's context side by side — hits `CS0104` on the ambiguous name. Alias one of them:
+
+```csharp
+using SqlServerConfigurations = BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations;
 ```
 
 ## Configuration base classes
@@ -132,31 +153,54 @@ builder.ToHistoryTable(
 
 ## Interceptors
 
-Register interceptors on the `DbContextOptionsBuilder`:
+`SoftDeletableInterceptor` and `TimeAuditedInterceptor` moved to `BB84.EntityFrameworkCore.Repositories` in 5.0 — nothing in them was SQL Server specific. Update the `using` to `BB84.EntityFrameworkCore.Repositories.Interceptors`; the types and their behavior are unchanged.
+
+## `DatabaseFacadeExtensions`
+
+Extension methods on `DatabaseFacade` (`context.Database`) for calling SQL Server stored procedures and functions safely with parameterized SQL. These moved here from `BB84.EntityFrameworkCore.Repositories` in 5.0, because the SQL they emit — `EXECUTE [schema].[name] @p = @p OUTPUT`, `SELECT [Value] = [schema].[fn](@p)` — is T-SQL by construction.
+
+### Stored procedures
 
 ```csharp
-services.AddSingleton<SoftDeletableInterceptor>();
-services.AddSingleton<TimeAuditedInterceptor>();
+// Returns rows as IReadOnlyList<T>
+IReadOnlyList<ReportRow> rows = context.Database.ExecuteProcedure<ReportRow>(
+    schema: "dbo",
+    name: "usp_GetReport",
+    parameters: [new SqlParameter("@FromDate", fromDate)]);
 
-services.AddDbContext<AppDbContext>((sp, options) =>
-{
-    options
-        .UseSqlServer(connectionString)
-        .AddInterceptors(
-            sp.GetRequiredService<SoftDeletableInterceptor>(),
-            sp.GetRequiredService<TimeAuditedInterceptor>());
-});
+// Non-generic overload returns rows-affected count
+int affected = context.Database.ExecuteProcedure(
+    schema: "dbo",
+    name: "usp_ArchiveOrders",
+    parameters: [new SqlParameter("@CutoffDate", cutoff)]);
+
+// Async variants
+await context.Database.ExecuteProcedureAsync<ReportRow>(..., cancellationToken);
+await context.Database.ExecuteProcedureAsync(..., cancellationToken);
 ```
 
-### `SoftDeletableInterceptor`
+Output parameters are supported — parameters with `Direction = ParameterDirection.Output` are emitted as `@param = @param OUTPUT` in the generated SQL.
 
-Fires on `SavingChanges`/`SavingChangesAsync`. For every entity tracked as `Deleted` that implements `ISoftDeletable`, it sets `IsDeleted = true` and changes the state to `Modified` — preventing a physical `DELETE` from being issued.
+### Table-valued functions
 
-### `TimeAuditedInterceptor`
+```csharp
+IReadOnlyList<ProductDto> results = context.Database.ExecuteTableFunction<ProductDto>(
+    schema: "dbo",
+    name: "fn_GetActiveProducts",
+    parameters: [new SqlParameter("@CategoryId", categoryId)]);
 
-Fires on `SavingChanges`/`SavingChangesAsync`. For every entity implementing `ITimeAudited`:
+await context.Database.ExecuteTableFunctionAsync<ProductDto>(..., cancellationToken);
+```
 
-- `EntityState.Added` → sets `CreatedAt = DateTimeOffset.UtcNow`
-- `EntityState.Modified` → sets `EditedAt = DateTimeOffset.UtcNow`
+### Scalar-valued functions
 
-`CreatedBy` / `EditedBy` are **not** set automatically by this interceptor — implement a custom `SaveChangesInterceptor` for user auditing and register it alongside the built-in ones.
+```csharp
+decimal? total = context.Database.ExecuteScalarFunction<decimal>(
+    schema: "dbo",
+    name: "fn_GetOrderTotal",
+    parameters: [new SqlParameter("@OrderId", orderId)]);
+
+await context.Database.ExecuteScalarFunctionAsync<decimal>(..., cancellationToken);
+```
+
+All methods sanitize schema/name inputs and use parameterized SQL to prevent injection. The parameter sequence is materialized once on entry, so a lazily generated `IEnumerable<DbParameter>` is safe to pass.

--- a/src/BB84.EntityFrameworkCore.Repositories/BB84.EntityFrameworkCore.Repositories.csproj
+++ b/src/BB84.EntityFrameworkCore.Repositories/BB84.EntityFrameworkCore.Repositories.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<Description>This package contains frequently used repository implementations of their respective abstractions.</Description>
+		<Description>This package contains frequently used repository implementations of their respective abstractions, along with provider agnostic entity type configurations and save changes interceptors.</Description>
 		<!-- CS1573: the asynchronous query cores inherit their parameter documentation from the
 		     synchronous ones and only document the additional cancellation token themselves. -->
 		<NoWarn>$(NoWarn);CS1573</NoWarn>

--- a/src/BB84.EntityFrameworkCore.Repositories/Configurations/AuditedCompositeConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Configurations/AuditedCompositeConfiguration.cs
@@ -1,0 +1,46 @@
+// Copyright: 2024 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using System.Diagnostics.CodeAnalysis;
+
+using BB84.EntityFrameworkCore.Entities.Abstractions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace BB84.EntityFrameworkCore.Repositories.Configurations;
+
+/// <summary>
+/// Provides a base configuration for entities that implement the
+/// <see cref="IAuditedCompositeEntity{TCreator, TEdited}"/> interface.
+/// </summary>
+/// <remarks>
+/// This abstract class provides a reusable configuration for audited composite entities,
+/// ensuring that the <c>Timestamp</c>, <c>Creator</c>, and <c>Editor</c> properties are consistently
+/// configured across all derived entity types. The <c>Timestamp</c> property is marked as a concurrency
+/// token and is automatically updated on add or update operations. The <c>Creator</c> property is required,
+/// while the <c>Editor</c> property is optional.
+/// </remarks>
+/// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
+/// <typeparam name="TCreator">The type representing the creator of the entity.</typeparam>
+/// <typeparam name="TEdited">The type representing the editor of the entity.</typeparam>
+[SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
+public abstract class AuditedCompositeConfiguration<TEntity, TCreator, TEdited> : IEntityTypeConfiguration<TEntity>
+	where TEntity : class, IAuditedCompositeEntity<TCreator, TEdited>
+	where TCreator : notnull
+{
+	/// <inheritdoc/>
+	public virtual void Configure(EntityTypeBuilder<TEntity> builder)
+	{
+		EntityTypeBuilderDefaults.ApplyConcurrencyToken(builder, columnOrder: 3);
+		EntityTypeBuilderDefaults.ApplyUserAuditColumns<TEntity, TCreator, TEdited>(builder, createdByOrder: 4, editedByOrder: 5);
+	}
+}
+
+/// <inheritdoc cref="AuditedCompositeConfiguration{TEntity, TCreator, TEdited}"/>
+[SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
+public abstract class AuditedCompositeConfiguration<TEntity> : AuditedCompositeConfiguration<TEntity, string, string?>, IEntityTypeConfiguration<TEntity>
+	where TEntity : class, IAuditedCompositeEntity
+{ }

--- a/src/BB84.EntityFrameworkCore.Repositories/Configurations/AuditedConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Configurations/AuditedConfiguration.cs
@@ -10,82 +10,53 @@ using BB84.EntityFrameworkCore.Entities.Abstractions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-using Base = BB84.EntityFrameworkCore.Repositories.Configurations;
+namespace BB84.EntityFrameworkCore.Repositories.Configurations;
 
-namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations;
-
-/// <inheritdoc cref="Base.AuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/>
+/// <summary>
+/// Represents an abstract base class for configuring the entities of type
+/// <see cref="IAuditedEntity{TKey, TCreator, TEdited}"/> for identity-related and time audited
+/// entities in the Entity Framework Core model.
+/// </summary>
 /// <remarks>
-/// Applies the provider-agnostic configuration of
-/// <see cref="Base.AuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/> and tunes it for
-/// SQL Server by declaring the primary key as non clustered.
+/// This class provides a default configuration for audited entities, including primary key setup,
+/// concurrency token configuration, and required properties for creator and editor fields.
+/// Derived classes can override the <see cref="Configure"/> method to customize the configuration.
 /// </remarks>
+/// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
+/// <typeparam name="TKey">The type of the primary key for the entity.</typeparam>
+/// <typeparam name="TCreator">The type representing the creator of the entity.</typeparam>
+/// <typeparam name="TEdited">The type representing the editor of the entity.</typeparam>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
-public abstract class AuditedConfiguration<TEntity, TKey, TCreator, TEdited> : Base.AuditedConfiguration<TEntity, TKey, TCreator, TEdited>, IEntityTypeConfiguration<TEntity>
+public abstract class AuditedConfiguration<TEntity, TKey, TCreator, TEdited> : IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IAuditedEntity<TKey, TCreator, TEdited>
 	where TKey : IEquatable<TKey>
 	where TCreator : notnull
 {
 	/// <inheritdoc/>
-	public override void Configure(EntityTypeBuilder<TEntity> builder)
+	public virtual void Configure(EntityTypeBuilder<TEntity> builder)
 	{
-		base.Configure(builder);
-
-		EntityTypeBuilderDefaults.ApplyKeyClustering<TEntity, TKey>(builder, clustered: false);
+		EntityTypeBuilderDefaults.ApplyIdentityKey<TEntity, TKey>(builder);
+		EntityTypeBuilderDefaults.ApplyConcurrencyToken(builder, columnOrder: 2);
+		EntityTypeBuilderDefaults.ApplyUserAuditColumns<TEntity, TCreator, TEdited>(builder, createdByOrder: 3, editedByOrder: 4);
 	}
 }
 
 /// <inheritdoc cref="AuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/>
-/// <remarks>
-/// The creator and editor columns are mapped as <b>sysname</b>.
-/// </remarks>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
 public abstract class AuditedConfiguration<TEntity, TKey> : AuditedConfiguration<TEntity, TKey, string, string?>, IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IAuditedEntity<TKey>
 	where TKey : IEquatable<TKey>
-{
-	/// <inheritdoc/>
-	public override void Configure(EntityTypeBuilder<TEntity> builder)
-	{
-		base.Configure(builder);
-
-		EntityTypeBuilderDefaults.ApplySysNameAuditColumns(builder);
-	}
-}
+{ }
 
 /// <inheritdoc cref="AuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/>
-/// <remarks>
-/// The identifier column defaults to <c>NEWID()</c>.
-/// </remarks>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
 public abstract class AuditedConfiguration<TEntity, TCreator, TEdited> : AuditedConfiguration<TEntity, Guid, TCreator, TEdited>, IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IAuditedEntity<TCreator, TEdited>
 	where TCreator : notnull
-{
-	/// <inheritdoc/>
-	public override void Configure(EntityTypeBuilder<TEntity> builder)
-	{
-		base.Configure(builder);
-
-		EntityTypeBuilderDefaults.ApplyGuidIdDefault(builder);
-	}
-}
+{ }
 
 /// <inheritdoc cref="AuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/>
-/// <remarks>
-/// The identifier column defaults to <c>NEWID()</c> and the creator and editor columns are
-/// mapped as <b>sysname</b>.
-/// </remarks>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
 public abstract class AuditedConfiguration<TEntity> : AuditedConfiguration<TEntity, Guid, string, string?>,
 	IEntityTypeConfiguration<TEntity> where TEntity : class, IAuditedEntity
-{
-	/// <inheritdoc/>
-	public override void Configure(EntityTypeBuilder<TEntity> builder)
-	{
-		base.Configure(builder);
-
-		EntityTypeBuilderDefaults.ApplyGuidIdDefault(builder);
-		EntityTypeBuilderDefaults.ApplySysNameAuditColumns(builder);
-	}
-}
+{ }

--- a/src/BB84.EntityFrameworkCore.Repositories/Configurations/CompositeConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Configurations/CompositeConfiguration.cs
@@ -1,0 +1,32 @@
+// Copyright: 2024 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using System.Diagnostics.CodeAnalysis;
+
+using BB84.EntityFrameworkCore.Entities.Abstractions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace BB84.EntityFrameworkCore.Repositories.Configurations;
+
+/// <summary>
+/// Represents an abstract base class for configuring entity types that implement the
+/// <see cref="ICompositeEntity"/> interface.
+/// </summary>
+/// <remarks>
+/// This class is intended to be used as a base for defining entity type configurations in
+/// Entity Framework Core. It provides a default implementation for configuring common properties,
+/// such as the <c>Timestamp</c> property.
+/// </remarks>
+/// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
+[SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
+public abstract class CompositeConfiguration<TEntity> : IEntityTypeConfiguration<TEntity>
+	where TEntity : class, ICompositeEntity
+{
+	/// <inheritdoc/>
+	public virtual void Configure(EntityTypeBuilder<TEntity> builder)
+		=> EntityTypeBuilderDefaults.ApplyConcurrencyToken(builder, columnOrder: 3);
+}

--- a/src/BB84.EntityFrameworkCore.Repositories/Configurations/EntityTypeBuilderDefaults.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Configurations/EntityTypeBuilderDefaults.cs
@@ -1,0 +1,79 @@
+// Copyright: 2024 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using System.Diagnostics.CodeAnalysis;
+
+using BB84.EntityFrameworkCore.Entities.Abstractions.Components;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace BB84.EntityFrameworkCore.Repositories.Configurations;
+
+/// <summary>
+/// Provides the shared property configuration used by the entity type configuration base classes.
+/// </summary>
+/// <remarks>
+/// The configuration base classes form ladders of progressively narrower generic aliases. The rungs
+/// share no common base that pins the creator and key types to their defaults, so the defaults that
+/// depend on those types live here instead of being repeated on every rung.
+/// </remarks>
+[SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
+internal static class EntityTypeBuilderDefaults
+{
+	/// <summary>
+	/// Configures the primary key and the identifier column of the entity.
+	/// </summary>
+	/// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
+	/// <typeparam name="TKey">The type of the primary key for the entity.</typeparam>
+	/// <param name="builder">The builder for the entity type being configured.</param>
+	internal static void ApplyIdentityKey<TEntity, TKey>(EntityTypeBuilder<TEntity> builder)
+		where TEntity : class, IIdentity<TKey>
+		where TKey : IEquatable<TKey>
+	{
+		builder.HasKey(e => e.Id);
+
+		builder.Property(e => e.Id)
+			.HasColumnOrder(1)
+			.ValueGeneratedOnAdd();
+	}
+
+	/// <summary>
+	/// Configures the concurrency token of the entity.
+	/// </summary>
+	/// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
+	/// <param name="builder">The builder for the entity type being configured.</param>
+	/// <param name="columnOrder">The zero based ordering of the column within the table.</param>
+	internal static void ApplyConcurrencyToken<TEntity>(EntityTypeBuilder<TEntity> builder, int columnOrder)
+		where TEntity : class, IConcurrency
+	{
+		builder.Property(e => e.Timestamp)
+			.HasColumnOrder(columnOrder)
+			.IsConcurrencyToken()
+			.ValueGeneratedOnAddOrUpdate();
+	}
+
+	/// <summary>
+	/// Configures the creator and editor columns of the entity.
+	/// </summary>
+	/// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
+	/// <typeparam name="TCreator">The type representing the creator of the entity.</typeparam>
+	/// <typeparam name="TEdited">The type representing the editor of the entity.</typeparam>
+	/// <param name="builder">The builder for the entity type being configured.</param>
+	/// <param name="createdByOrder">The ordering of the creator column within the table.</param>
+	/// <param name="editedByOrder">The ordering of the editor column within the table.</param>
+	internal static void ApplyUserAuditColumns<TEntity, TCreator, TEdited>(EntityTypeBuilder<TEntity> builder, int createdByOrder, int editedByOrder)
+		where TEntity : class, IUserAudited<TCreator, TEdited>
+		where TCreator : notnull
+	{
+		builder.Property(e => e.CreatedBy)
+			.HasColumnOrder(createdByOrder)
+			.IsRequired();
+
+		builder.Property(e => e.EditedBy)
+			.HasColumnOrder(editedByOrder)
+			.IsRequired(false);
+	}
+}

--- a/src/BB84.EntityFrameworkCore.Repositories/Configurations/EnumeratorConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Configurations/EnumeratorConfiguration.cs
@@ -1,0 +1,85 @@
+// Copyright: 2024 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using System.Diagnostics.CodeAnalysis;
+
+using BB84.EntityFrameworkCore.Entities.Abstractions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace BB84.EntityFrameworkCore.Repositories.Configurations;
+
+/// <summary>
+/// Represents an abstract base class for configuring entity types that implement the
+/// <see cref="IEnumeratorEntity{Tkey}"/> interface.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This class defines a standard configuration for entities, including primary key setup,
+/// concurrency tokens, property constraints and indexing.
+/// </para>
+/// <para>
+/// A global query filter excluding soft deleted rows is applied, so that entities marked as
+/// deleted by the soft deletable interceptor are no longer returned by queries. Pass
+/// <see langword="true"/> for the <c>ignoreQueryFilters</c> parameter of the repository read
+/// methods to include them again.
+/// </para>
+/// <para>
+/// Be aware that a <b>required</b> navigation pointing at a soft deletable entity type
+/// interacts badly with this filter: filtering out the principal row also removes the
+/// dependents that require it. Model such navigations as optional, or apply a matching filter
+/// to both ends of the relationship.
+/// </para>
+/// </remarks>
+/// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
+/// <typeparam name="TKey">The type of the key for the entity.</typeparam>
+[SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
+public abstract class EnumeratorConfiguration<TEntity, TKey> : IEntityTypeConfiguration<TEntity>
+	where TEntity : class, IEnumeratorEntity<TKey>
+	where TKey : IEquatable<TKey>
+{
+	/// <inheritdoc/>
+	public virtual void Configure(EntityTypeBuilder<TEntity> builder)
+	{
+		builder.HasKey(x => x.Id);
+
+		builder.Property(e => e.Id)
+			.HasColumnOrder(1)
+			.IsRequired();
+
+		EntityTypeBuilderDefaults.ApplyConcurrencyToken(builder, columnOrder: 2);
+
+		builder.Property(e => e.Name)
+			.HasColumnOrder(3)
+			.HasMaxLength(64)
+			.IsRequired()
+			.IsUnicode(false);
+
+		builder.Property(e => e.Description)
+			.HasColumnOrder(4)
+			.HasMaxLength(256)
+			.IsRequired(false)
+			.IsUnicode();
+
+		builder.Property(e => e.IsDeleted)
+			.HasColumnOrder(5)
+			.HasDefaultValue(false);
+
+		builder.HasQueryFilter(e => !e.IsDeleted);
+
+		builder.HasIndex(e => e.Name)
+			.IsUnique();
+	}
+}
+
+/// <inheritdoc cref="EnumeratorConfiguration{TEntity, TKey}"/>
+/// <remarks>
+/// The identity column is of type <see cref="int"/>.
+/// </remarks>
+[SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
+public abstract class EnumeratorConfiguration<TEntity> : EnumeratorConfiguration<TEntity, int>
+	where TEntity : class, IEnumeratorEntity
+{ }

--- a/src/BB84.EntityFrameworkCore.Repositories/Configurations/FullAuditedConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Configurations/FullAuditedConfiguration.cs
@@ -10,82 +10,60 @@ using BB84.EntityFrameworkCore.Entities.Abstractions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-using Base = BB84.EntityFrameworkCore.Repositories.Configurations;
+namespace BB84.EntityFrameworkCore.Repositories.Configurations;
 
-namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations;
-
-/// <inheritdoc cref="Base.FullAuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/>
+/// <summary>
+/// Provides a base configuration for entities that implement the
+/// <see cref="IFullAuditedEntity{TKey, TCreator, TEdited}"/> interface.
+/// </summary>
 /// <remarks>
-/// Applies the provider-agnostic configuration of
-/// <see cref="Base.FullAuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/> and tunes it for
-/// SQL Server by declaring the primary key as non clustered.
+/// This configuration defines common properties for audited entities, including primary key,
+/// timestamps and audit fields such as creator and editor. It is intended to be used as a
+/// base class for configuring entities that require full auditing support.
 /// </remarks>
+/// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
+/// <typeparam name="TKey">The type of the primary key for the entity.</typeparam>
+/// <typeparam name="TCreator">The type representing the creator of the entity.</typeparam>
+/// <typeparam name="TEdited">The type representing the editor of the entity.</typeparam>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
-public abstract class FullAuditedConfiguration<TEntity, TKey, TCreator, TEdited> : Base.FullAuditedConfiguration<TEntity, TKey, TCreator, TEdited>, IEntityTypeConfiguration<TEntity>
+public abstract class FullAuditedConfiguration<TEntity, TKey, TCreator, TEdited> : IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IFullAuditedEntity<TKey, TCreator, TEdited>
 	where TKey : IEquatable<TKey>
 	where TCreator : notnull
 {
 	/// <inheritdoc/>
-	public override void Configure(EntityTypeBuilder<TEntity> builder)
+	public virtual void Configure(EntityTypeBuilder<TEntity> builder)
 	{
-		base.Configure(builder);
+		EntityTypeBuilderDefaults.ApplyIdentityKey<TEntity, TKey>(builder);
+		EntityTypeBuilderDefaults.ApplyConcurrencyToken(builder, columnOrder: 2);
+		EntityTypeBuilderDefaults.ApplyUserAuditColumns<TEntity, TCreator, TEdited>(builder, createdByOrder: 3, editedByOrder: 5);
 
-		EntityTypeBuilderDefaults.ApplyKeyClustering<TEntity, TKey>(builder, clustered: false);
+		builder.Property(p => p.CreatedAt)
+			.HasColumnOrder(4)
+			.IsRequired();
+
+		builder.Property(p => p.EditedAt)
+			.HasColumnOrder(6)
+			.IsRequired(false);
 	}
 }
 
 /// <inheritdoc cref="FullAuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/>
-/// <remarks>
-/// The creator and editor columns are mapped as <b>sysname</b>.
-/// </remarks>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
 public abstract class FullAuditedConfiguration<TEntity, TKey> : FullAuditedConfiguration<TEntity, TKey, string, string?>, IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IFullAuditedEntity<TKey>
 	where TKey : IEquatable<TKey>
-{
-	/// <inheritdoc/>
-	public override void Configure(EntityTypeBuilder<TEntity> builder)
-	{
-		base.Configure(builder);
-
-		EntityTypeBuilderDefaults.ApplySysNameAuditColumns(builder);
-	}
-}
+{ }
 
 /// <inheritdoc cref="FullAuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/>
-/// <remarks>
-/// The identifier column defaults to <c>NEWID()</c>.
-/// </remarks>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
 public abstract class FullAuditedConfiguration<TEntity, TCreator, TEdited> : FullAuditedConfiguration<TEntity, Guid, TCreator, TEdited>, IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IFullAuditedEntity<TCreator, TEdited>
 	where TCreator : notnull
-{
-	/// <inheritdoc/>
-	public override void Configure(EntityTypeBuilder<TEntity> builder)
-	{
-		base.Configure(builder);
-
-		EntityTypeBuilderDefaults.ApplyGuidIdDefault(builder);
-	}
-}
+{ }
 
 /// <inheritdoc cref="FullAuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/>
-/// <remarks>
-/// The identifier column defaults to <c>NEWID()</c> and the creator and editor columns are
-/// mapped as <b>sysname</b>.
-/// </remarks>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
 public abstract class FullAuditedConfiguration<TEntity> : FullAuditedConfiguration<TEntity, Guid, string, string?>, IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IFullAuditedEntity
-{
-	/// <inheritdoc/>
-	public override void Configure(EntityTypeBuilder<TEntity> builder)
-	{
-		base.Configure(builder);
-
-		EntityTypeBuilderDefaults.ApplyGuidIdDefault(builder);
-		EntityTypeBuilderDefaults.ApplySysNameAuditColumns(builder);
-	}
-}
+{ }

--- a/src/BB84.EntityFrameworkCore.Repositories/Configurations/IdentityConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Configurations/IdentityConfiguration.cs
@@ -1,0 +1,43 @@
+// Copyright: 2024 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using System.Diagnostics.CodeAnalysis;
+
+using BB84.EntityFrameworkCore.Entities.Abstractions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace BB84.EntityFrameworkCore.Repositories.Configurations;
+
+/// <summary>
+/// Represents an abstract base class for configuring entity types that implement the
+/// <see cref="IIdentityEntity{Tkey}"/> interface.
+/// </summary>
+/// <remarks>
+/// This class defines a default configuration for identity-related entities, including the primary key and
+/// concurrency token. Derived classes can override the <see cref="Configure"/> method to provide additional
+/// or customized configuration.
+/// </remarks>
+/// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
+/// <typeparam name="TKey">The type of the primary key for the entity.</typeparam>
+[SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
+public abstract class IdentityConfiguration<TEntity, TKey> : IEntityTypeConfiguration<TEntity>
+	where TEntity : class, IIdentityEntity<TKey>
+	where TKey : IEquatable<TKey>
+{
+	/// <inheritdoc/>
+	public virtual void Configure(EntityTypeBuilder<TEntity> builder)
+	{
+		EntityTypeBuilderDefaults.ApplyIdentityKey<TEntity, TKey>(builder);
+		EntityTypeBuilderDefaults.ApplyConcurrencyToken(builder, columnOrder: 2);
+	}
+}
+
+/// <inheritdoc cref="IdentityConfiguration{TEntity, TKey}"/>
+[SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
+public abstract class IdentityConfiguration<TEntity> : IdentityConfiguration<TEntity, Guid>, IEntityTypeConfiguration<TEntity>
+	where TEntity : class, IIdentityEntity
+{ }

--- a/src/BB84.EntityFrameworkCore.Repositories/Interceptors/SoftDeletableInterceptor.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Interceptors/SoftDeletableInterceptor.cs
@@ -9,19 +9,20 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Interceptors;
+namespace BB84.EntityFrameworkCore.Repositories.Interceptors;
 
 /// <summary>
-/// A save changes interceptor that automatically updates audit timestamps for entities
-/// implementing the <see cref="ITimeAudited"/> interface.
+/// Intercepts save operations in a <see cref="DbContext"/> to enforce soft delete behavior for
+/// entities implementing the <see cref="ISoftDeletable"/> interface.
 /// </summary>
 /// <remarks>
-/// This interceptor updates the <see cref="ITimeAudited.CreatedAt"/> property to the current
-/// UTC time when an entity is added and the <see cref="ITimeAudited.EditedAt"/> property to
-/// the current UTC time when an entity is modified.
+/// This interceptor modifies the behavior of entities marked for deletion by setting their
+/// <see cref="ISoftDeletable.IsDeleted"/> property to <see langword="true"/> and changing their
+/// state to <see cref="EntityState.Modified"/>. This ensures that soft-deleted entities are not
+/// physically removed from the database.
 /// </remarks>
 /// <inheritdoc cref="SaveChangesInterceptor"/>
-public sealed class TimeAuditedInterceptor : SaveChangesInterceptor
+public sealed class SoftDeletableInterceptor : SaveChangesInterceptor
 {
 	/// <inheritdoc/>
 	public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
@@ -38,7 +39,7 @@ public sealed class TimeAuditedInterceptor : SaveChangesInterceptor
 	}
 
 	/// <summary>
-	/// Intercepts and processes entities implementing <see cref="ITimeAudited"/> in the
+	/// Intercepts and processes entities implementing <see cref="ISoftDeletable"/> in the
 	/// specified <see cref="DbContext"/>.
 	/// </summary>
 	/// <param name="dbContext">
@@ -48,21 +49,20 @@ public sealed class TimeAuditedInterceptor : SaveChangesInterceptor
 	{
 		if (dbContext is not null)
 		{
-			IEnumerable<EntityEntry<ITimeAudited>> entityEntries = dbContext.ChangeTracker.Entries<ITimeAudited>();
+			IEnumerable<EntityEntry<ISoftDeletable>> entityEntries = dbContext.ChangeTracker.Entries<ISoftDeletable>();
 
-			foreach (EntityEntry<ITimeAudited> entityEntry in entityEntries)
+			foreach (EntityEntry<ISoftDeletable> entityEntry in entityEntries)
 			{
 				switch (entityEntry.State)
 				{
-					case EntityState.Added:
-						entityEntry.Entity.CreatedAt = DateTimeOffset.UtcNow;
-						continue;
-					case EntityState.Modified:
-						entityEntry.Entity.EditedAt = DateTimeOffset.UtcNow;
-						continue;
+					case EntityState.Deleted:
+						entityEntry.Entity.IsDeleted = true;
+						entityEntry.State = EntityState.Modified;
+						break;
 					case EntityState.Detached:
 					case EntityState.Unchanged:
-					case EntityState.Deleted:
+					case EntityState.Modified:
+					case EntityState.Added:
 					default:
 						break;
 				}

--- a/src/BB84.EntityFrameworkCore.Repositories/Interceptors/TimeAuditedInterceptor.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Interceptors/TimeAuditedInterceptor.cs
@@ -9,20 +9,19 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Interceptors;
+namespace BB84.EntityFrameworkCore.Repositories.Interceptors;
 
 /// <summary>
-/// Intercepts save operations in a <see cref="DbContext"/> to enforce soft delete behavior for
-/// entities implementing the <see cref="ISoftDeletable"/> interface.
+/// A save changes interceptor that automatically updates audit timestamps for entities
+/// implementing the <see cref="ITimeAudited"/> interface.
 /// </summary>
 /// <remarks>
-/// This interceptor modifies the behavior of entities marked for deletion by setting their
-/// <see cref="ISoftDeletable.IsDeleted"/> property to <see langword="true"/> and changing their
-/// state to <see cref="EntityState.Modified"/>. This ensures that soft-deleted entities are not
-/// physically removed from the database.
+/// This interceptor updates the <see cref="ITimeAudited.CreatedAt"/> property to the current
+/// UTC time when an entity is added and the <see cref="ITimeAudited.EditedAt"/> property to
+/// the current UTC time when an entity is modified.
 /// </remarks>
 /// <inheritdoc cref="SaveChangesInterceptor"/>
-public sealed class SoftDeletableInterceptor : SaveChangesInterceptor
+public sealed class TimeAuditedInterceptor : SaveChangesInterceptor
 {
 	/// <inheritdoc/>
 	public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
@@ -39,7 +38,7 @@ public sealed class SoftDeletableInterceptor : SaveChangesInterceptor
 	}
 
 	/// <summary>
-	/// Intercepts and processes entities implementing <see cref="ISoftDeletable"/> in the
+	/// Intercepts and processes entities implementing <see cref="ITimeAudited"/> in the
 	/// specified <see cref="DbContext"/>.
 	/// </summary>
 	/// <param name="dbContext">
@@ -49,20 +48,21 @@ public sealed class SoftDeletableInterceptor : SaveChangesInterceptor
 	{
 		if (dbContext is not null)
 		{
-			IEnumerable<EntityEntry<ISoftDeletable>> entityEntries = dbContext.ChangeTracker.Entries<ISoftDeletable>();
+			IEnumerable<EntityEntry<ITimeAudited>> entityEntries = dbContext.ChangeTracker.Entries<ITimeAudited>();
 
-			foreach (EntityEntry<ISoftDeletable> entityEntry in entityEntries)
+			foreach (EntityEntry<ITimeAudited> entityEntry in entityEntries)
 			{
 				switch (entityEntry.State)
 				{
-					case EntityState.Deleted:
-						entityEntry.Entity.IsDeleted = true;
-						entityEntry.State = EntityState.Modified;
-						break;
+					case EntityState.Added:
+						entityEntry.Entity.CreatedAt = DateTimeOffset.UtcNow;
+						continue;
+					case EntityState.Modified:
+						entityEntry.Entity.EditedAt = DateTimeOffset.UtcNow;
+						continue;
 					case EntityState.Detached:
 					case EntityState.Unchanged:
-					case EntityState.Modified:
-					case EntityState.Added:
+					case EntityState.Deleted:
 					default:
 						break;
 				}

--- a/src/BB84.EntityFrameworkCore.Repositories/README.md
+++ b/src/BB84.EntityFrameworkCore.Repositories/README.md
@@ -3,7 +3,11 @@
 
 # BB84.EntityFrameworkCore.Repositories
 
-This package provides the default repository implementations and `DatabaseFacadeExtensions` for calling stored procedures and SQL functions.
+This package provides the default repository implementations, the provider-agnostic entity type configuration base classes, and the save changes interceptors for auditing and soft delete.
+
+> **Moved in 5.0.** The configuration base classes and the interceptors came here from
+> `BB84.EntityFrameworkCore.Repositories.SqlServer`, where almost nothing about them was SQL Server specific.
+> `DatabaseFacadeExtensions` went the other way, into that package, because it emits T-SQL.
 
 ## Installation
 
@@ -84,52 +88,54 @@ repository.Create(entity);
 await dbContext.SaveChangesAsync(token);
 ```
 
-## `DatabaseFacadeExtensions`
+## Configuration base classes
 
-Extension methods on `DatabaseFacade` (`context.Database`) for calling SQL Server stored procedures and functions safely with parameterized SQL.
+Provider-agnostic `IEntityTypeConfiguration<TEntity>` base classes in `BB84.EntityFrameworkCore.Repositories.Configurations`. They apply key declaration, column ordering, the concurrency token, audit columns and — for enumerator entities — the name/description constraints, unique index and soft delete query filter. Everything they do is EF Core or EF Core Relational, so they work on PostgreSQL, SQLite, MySQL and Oracle.
 
-### Stored procedures
+| Configuration class                                          | For entity type                               |
+| ------------------------------------------------------------ | --------------------------------------------- |
+| `IdentityConfiguration<TEntity, TKey>`                       | `IIdentityEntity<TKey>`                       |
+| `AuditedConfiguration<TEntity, TKey, TCreator, TEdited>`     | `IAuditedEntity<TKey, TCreator, TEdited>`     |
+| `FullAuditedConfiguration<TEntity, TKey, TCreator, TEdited>` | `IFullAuditedEntity<TKey, TCreator, TEdited>` |
+| `CompositeConfiguration<TEntity>`                            | `ICompositeEntity`                            |
+| `AuditedCompositeConfiguration<TEntity, TCreator, TEdited>`  | `IAuditedCompositeEntity<TCreator, TEdited>`  |
+| `EnumeratorConfiguration<TEntity, TKey>`                     | `IEnumeratorEntity<TKey>`                     |
 
-```csharp
-// Returns rows as IReadOnlyList<T>
-IReadOnlyList<ReportRow> rows = context.Database.ExecuteProcedure<ReportRow>(
-    schema: "dbo",
-    name: "usp_GetReport",
-    parameters: [new SqlParameter("@FromDate", fromDate)]);
+Each ladder has narrower generic aliases that default the key to `Guid` (`int` for the enumerator) and the creator/editor to `string`.
 
-// Non-generic overload returns rows-affected count
-int affected = context.Database.ExecuteProcedure(
-    schema: "dbo",
-    name: "usp_ArchiveOrders",
-    parameters: [new SqlParameter("@CutoffDate", cutoff)]);
+On SQL Server, use the same type names from `BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations` instead — those derive from these and add clustering, `NEWID()` defaults and `sysname` audit columns.
 
-// Async variants
-await context.Database.ExecuteProcedureAsync<ReportRow>(..., cancellationToken);
-await context.Database.ExecuteProcedureAsync(..., cancellationToken);
-```
+## Interceptors
 
-Output parameters are supported — parameters with `Direction = ParameterDirection.Output` are emitted as `@param = @param OUTPUT` in the generated SQL.
-
-### Table-valued functions
+Register on the `DbContextOptionsBuilder`:
 
 ```csharp
-IReadOnlyList<ProductDto> results = context.Database.ExecuteTableFunction<ProductDto>(
-    schema: "dbo",
-    name: "fn_GetActiveProducts",
-    parameters: [new SqlParameter("@CategoryId", categoryId)]);
+services.AddSingleton<SoftDeletableInterceptor>();
+services.AddSingleton<TimeAuditedInterceptor>();
 
-await context.Database.ExecuteTableFunctionAsync<ProductDto>(..., cancellationToken);
+services.AddDbContext<AppDbContext>((sp, options) =>
+{
+    options
+        .UseSqlServer(connectionString) // any provider
+        .AddInterceptors(
+            sp.GetRequiredService<SoftDeletableInterceptor>(),
+            sp.GetRequiredService<TimeAuditedInterceptor>());
+});
 ```
 
-### Scalar-valued functions
+### `SoftDeletableInterceptor`
 
-```csharp
-decimal? total = context.Database.ExecuteScalarFunction<decimal>(
-    schema: "dbo",
-    name: "fn_GetOrderTotal",
-    parameters: [new SqlParameter("@OrderId", orderId)]);
+Fires on `SavingChanges`/`SavingChangesAsync`. For every entity tracked as `Deleted` that implements `ISoftDeletable`, it sets `IsDeleted = true` and changes the state to `Modified` — preventing a physical `DELETE` from being issued.
 
-await context.Database.ExecuteScalarFunctionAsync<decimal>(..., cancellationToken);
-```
+Pair it with a configuration deriving from `EnumeratorConfiguration<TEntity, TKey>`, which applies the matching `HasQueryFilter(e => !e.IsDeleted)`. Without that filter the flag is set but never read.
 
-All methods sanitize schema/name inputs and use parameterized SQL to prevent injection.
+### `TimeAuditedInterceptor`
+
+Fires on `SavingChanges`/`SavingChangesAsync`. For every entity implementing `ITimeAudited`:
+
+- `EntityState.Added` → sets `CreatedAt = DateTimeOffset.UtcNow`
+- `EntityState.Modified` → sets `EditedAt = DateTimeOffset.UtcNow`
+
+`CreatedBy` / `EditedBy` are **not** set automatically by this interceptor — implement a custom `SaveChangesInterceptor` for user auditing and register it alongside the built-in ones.
+
+Both interceptors run on save. The expression-based `Delete` / `Update` repository overloads execute immediately and bypass the change tracker, so neither interceptor fires for them.

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/DatabaseFacadeExtensionsTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/DatabaseFacadeExtensionsTests.cs
@@ -5,7 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 using System.Data;
 
-using BB84.EntityFrameworkCore.Repositories.Extensions;
+using BB84.EntityFrameworkCore.Repositories.SqlServer.Extensions;
 using BB84.EntityFrameworkCore.Repositories.Tests.Persistence;
 
 using Microsoft.Data.SqlClient;

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/Persistence/TestDbContext.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/Persistence/TestDbContext.cs
@@ -3,7 +3,7 @@
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
-using BB84.EntityFrameworkCore.Repositories.SqlServer.Interceptors;
+using BB84.EntityFrameworkCore.Repositories.Interceptors;
 using BB84.EntityFrameworkCore.Repositories.Tests.Abstractions;
 using BB84.EntityFrameworkCore.Repositories.Tests.Persistence.Interceptors;
 

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/UnitTestBase.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/UnitTestBase.cs
@@ -3,7 +3,7 @@
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
-using BB84.EntityFrameworkCore.Repositories.SqlServer.Interceptors;
+using BB84.EntityFrameworkCore.Repositories.Interceptors;
 using BB84.EntityFrameworkCore.Repositories.Tests.Persistence;
 using BB84.EntityFrameworkCore.Repositories.Tests.Persistence.Interceptors;
 


### PR DESCRIPTION
**Changes:**

Three moves that all fix the same mistake in both directions: agnostic code sitting in the `SqlServer` package, and provider specific code sitting in the agnostic one. Doing them together means consumers change their `using` directives once.

- Entity type configurations split across both packages. Auditing the individual steps, exactly three are SQL Server specific: `IsClustered`, the `NEWID()` default and the `sysname` audit columns.
- Everything else is EF Core or EF Core Relational and works unchanged on other providers.
- The agnostic bases now live in `BB84.EntityFrameworkCore.Repositories.Configurations`; the SqlServer ladder derives from them and adds only those three.
- Type names are identical in both namespaces, so the namespace carries the distinction and existing SQL Server consumers change one `using`.
- Both ladders are complete: every rung exists in both namespaces even where the SqlServer counterpart adds nothing, so that picking a namespace is never a trap.
- The interceptors move to `BB84.EntityFrameworkCore.Repositories` outright. Neither had any SQL Server dependency.
- `DatabaseFacadeExtensions` moves the other way, into the SqlServer package. It emits `EXECUTE [schema].[name] @p = @p OUTPUT` and `SELECT [Value] = [schema].[fn](@p)`, which is T-SQL by construction.
- While moving it, the parameter sequence is now materialized once.
- Previously it was enumerated to build the SQL and enumerated again to bind the command, so a lazily generated sequence produced placeholders that did not match the parameters it was given.
- The duplicate key declaration in the enumerator configuration goes away with the split.
- Clustering is the only job of the SqlServer rungs now, so re-declaring the key is what those rungs are for rather than a redundant second call inside one class.

**Verified behavior preserving:** the create script generated from the test model is byte identical before and after.

closes #219 & closes #222 & closes #234 & closes #235 & closes #243 