### PR TITLE
feat(repositories): collapse the read API onto a query object

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@
 
 ## 📦 Packages
 
-| Package                                                                                                                | Description                                                       |
-| ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| [BB84.EntityFrameworkCore.Entities.Abstractions](src/BB84.EntityFrameworkCore.Entities.Abstractions/README.md)         | Core entity interface definitions — no dependencies               |
-| [BB84.EntityFrameworkCore.Entities](src/BB84.EntityFrameworkCore.Entities/README.md)                                   | Default implementations of the entity abstractions                |
-| [BB84.EntityFrameworkCore.Repositories.Abstractions](src/BB84.EntityFrameworkCore.Repositories.Abstractions/README.md) | Repository interface definitions                                  |
-| [BB84.EntityFrameworkCore.Repositories](src/BB84.EntityFrameworkCore.Repositories/README.md)                           | Repository implementations, provider-agnostic configurations and interceptors |
+| Package                                                                                                                | Description                                                                            |
+| ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| [BB84.EntityFrameworkCore.Entities.Abstractions](src/BB84.EntityFrameworkCore.Entities.Abstractions/README.md)         | Core entity interface definitions — no dependencies                                    |
+| [BB84.EntityFrameworkCore.Entities](src/BB84.EntityFrameworkCore.Entities/README.md)                                   | Default implementations of the entity abstractions                                     |
+| [BB84.EntityFrameworkCore.Repositories.Abstractions](src/BB84.EntityFrameworkCore.Repositories.Abstractions/README.md) | Repository interface definitions                                                       |
+| [BB84.EntityFrameworkCore.Repositories](src/BB84.EntityFrameworkCore.Repositories/README.md)                           | Repository implementations, provider-agnostic configurations and interceptors          |
 | [BB84.EntityFrameworkCore.Repositories.SqlServer](src/BB84.EntityFrameworkCore.Repositories.SqlServer/README.md)       | SQL Server configuration tuning, column type extensions and `DatabaseFacadeExtensions` |
 
 ## 💾 Installation

--- a/src/BB84.EntityFrameworkCore.Repositories.Abstractions/IEnumeratorRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.Abstractions/IEnumeratorRepository.cs
@@ -23,46 +23,42 @@ public interface IEnumeratorRepository<TEntity, TKey> : IIdentityRepository<TEnt
 	where TKey : IEquatable<TKey>
 {
 	/// <summary>
-	/// Retrieves an entity by its name.
+	/// Returns the entity with the specified <paramref name="name"/>, or <see langword="null"/>
+	/// when no such entity exists.
 	/// </summary>
-	/// <param name="name">The name of the entity to retrieve.</param>
-	/// <param name="ignoreQueryFilters">A value indicating whether to ignore any query filters applied to the entity.</param>
-	/// <param name="trackChanges">A value indicating whether the retrieved entity should be tracked by the context.</param>
-	/// <returns>The entity that matches the specified name, or <see langword="null"/> if no such entity is found.</returns>
-	TEntity? GetByName(
-		string name,
-		bool ignoreQueryFilters = false,
-		bool trackChanges = false);
+	/// <remarks>
+	/// The name acts as an additional condition. Anything the <paramref name="query"/> already
+	/// filters by still applies.
+	/// </remarks>
+	/// <param name="name">The name of the <typeparamref name="TEntity"/>.</param>
+	/// <param name="query">The query describing how to read.</param>
+	/// <returns>The matching entity, or <see langword="null"/>.</returns>
+	TEntity? GetByName(string name, Query<TEntity>? query = null);
 
-	/// <inheritdoc cref="GetByName(string, bool, bool)"/>
+	/// <inheritdoc cref="GetByName(string, Query{TEntity})"/>
 	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
 	Task<TEntity?> GetByNameAsync(
 		string name,
-		bool ignoreQueryFilters = false,
-		bool trackChanges = false,
+		Query<TEntity>? query = null,
 		CancellationToken cancellationToken = default);
 
 	/// <summary>
-	/// Retrieves a collection of entities that match the specified names.
+	/// Returns the entities matching the specified <paramref name="names"/>.
 	/// </summary>
-	/// <param name="names">A collection of names to filter the entities by.</param>
-	/// <param name="ignoreQueryFilters">A value indicating whether to ignore any query filters applied to the entity type.</param>
-	/// <param name="trackChanges">A value indicating whether the returned entities should be tracked by the context.</param>
-	/// <returns>
-	/// An <see cref="IReadOnlyList{TEntity}"/> containing the entities that match the specified names.
-	/// If no entities match, an empty collection is returned.
-	/// </returns>
-	IReadOnlyList<TEntity> GetByNames(
-		IEnumerable<string> names,
-		bool ignoreQueryFilters = false,
-		bool trackChanges = false);
+	/// <remarks>
+	/// The names act as an additional condition. Anything the <paramref name="query"/> already
+	/// filters by still applies.
+	/// </remarks>
+	/// <param name="names">The names of the <typeparamref name="TEntity"/>.</param>
+	/// <param name="query">The query describing how to read.</param>
+	/// <returns>The matching entities.</returns>
+	IReadOnlyList<TEntity> GetByNames(IEnumerable<string> names, Query<TEntity>? query = null);
 
-	/// <inheritdoc cref="GetByNames(IEnumerable{string}, bool, bool)"/>
+	/// <inheritdoc cref="GetByNames(IEnumerable{string}, Query{TEntity})"/>
 	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
 	Task<IReadOnlyList<TEntity>> GetByNamesAsync(
 		IEnumerable<string> names,
-		bool ignoreQueryFilters = false,
-		bool trackChanges = false,
+		Query<TEntity>? query = null,
 		CancellationToken cancellationToken = default);
 }
 

--- a/src/BB84.EntityFrameworkCore.Repositories.Abstractions/IGenericRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.Abstractions/IGenericRepository.cs
@@ -14,10 +14,16 @@ namespace BB84.EntityFrameworkCore.Repositories.Abstractions;
 /// entities of type <typeparamref name="TEntity"/>.
 /// </summary>
 /// <remarks>
+/// <para>
 /// This interface provides synchronous and asynchronous methods for creating, reading,
 /// updating, and deleting entities, as well as methods for querying entities based on
 /// conditions. It is designed to abstract data access logic, making it easier to work
 /// with different data sources or implement unit testing.
+/// </para>
+/// <para>
+/// The read methods take their options as a single <see cref="Query{TEntity}"/>. Passing
+/// none reads the whole set, so there is no separate "all" method.
+/// </para>
 /// </remarks>
 /// <typeparam name="TEntity">
 /// The type of the entity for which the repository provides data access functionality.
@@ -40,24 +46,24 @@ public interface IGenericRepository<TEntity>
 	/// </summary>
 	/// <remarks>
 	/// This method marks the provided entities as added in the database context. so that
-	/// changes to the entities will be persisted to the database during the next save operation.
+	/// changes to the entity will be persisted to the database during the next save operation.
 	/// </remarks>
 	/// <param name="entities">The collection of entities to add.</param>
 	void Create(IEnumerable<TEntity> entities);
 
 	/// <inheritdoc cref="Create(TEntity)"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
 	/// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
 	Task CreateAsync(
 		TEntity entity,
-		CancellationToken token = default);
+		CancellationToken cancellationToken = default);
 
 	/// <inheritdoc cref="Create(IEnumerable{TEntity})"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
 	/// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
 	Task CreateAsync(
 		IEnumerable<TEntity> entities,
-		CancellationToken token = default);
+		CancellationToken cancellationToken = default);
 
 	/// <summary>
 	/// Deletes the specified entity from the underlying data store.
@@ -102,522 +108,145 @@ public interface IGenericRepository<TEntity>
 	int Delete(Expression<Func<TEntity, bool>> expression);
 
 	/// <inheritdoc cref="Delete(TEntity)"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
 	/// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
 	Task DeleteAsync(
 		TEntity entity,
-		CancellationToken token = default);
+		CancellationToken cancellationToken = default);
 
 	/// <inheritdoc cref="Delete(IEnumerable{TEntity})"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
 	/// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
 	Task DeleteAsync(
 		IEnumerable<TEntity> entities,
-		CancellationToken token = default);
+		CancellationToken cancellationToken = default);
 
 	/// <inheritdoc cref="Delete(Expression{Func{TEntity, bool}})"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
 	Task<int> DeleteAsync(
 		Expression<Func<TEntity, bool>> expression,
-		CancellationToken token = default);
+		CancellationToken cancellationToken = default);
 
 	/// <summary>
-	/// Counts the total number of entities in the data source.
-	/// </summary>
-	/// <param name="ignoreQueryFilters">
-	/// A value indicating whether to ignore any query filters applied to the entity type.
-	/// <see langword="true"/> to ignore query filters; otherwise, <see langword="false"/>.
-	/// </param>
-	/// <returns>The total number of entities in the data source.</returns>
-	int CountAll(bool ignoreQueryFilters = false);
-
-	/// <summary>
-	/// Counts the number of entities that satisfy the specified query filter.
+	/// Counts the entities matching the specified <paramref name="query"/>.
 	/// </summary>
 	/// <remarks>
-	/// Use this method to count entities based on custom conditions. If ignoreQueryFilters is
-	/// set to true, any global query filters (such as soft-delete or multi-tenancy filters) will
-	/// be bypassed when counting.
+	/// Only the filtering options of the query take part in a count. Ordering, paging,
+	/// includes and tracking are ignored, because none of them can change how many rows match.
 	/// </remarks>
-	/// <param name="queryFilter">A function that applies additional filtering to the entity set.</param>
-	/// <param name="ignoreQueryFilters">true to ignore any global query filters applied to the entity set.</param>
-	/// <returns>The number of entities that match the specified filter.</returns>
-	int CountByCondition(
-		Func<IQueryable<TEntity>, IQueryable<TEntity>> queryFilter,
-		bool ignoreQueryFilters = false);
+	/// <param name="query">The query describing what to count. Counts everything when omitted.</param>
+	/// <returns>The number of matching entities.</returns>
+	int Count(Query<TEntity>? query = null);
+
+	/// <inheritdoc cref="Count(Query{TEntity})"/>
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
+	Task<int> CountAsync(
+		Query<TEntity>? query = null,
+		CancellationToken cancellationToken = default);
 
 	/// <summary>
-	/// Counts the number of entities in the data source that satisfy the specified conditions.
+	/// Returns the single entity matching the specified <paramref name="query"/>, or
+	/// <see langword="null"/> when nothing matches.
 	/// </summary>
 	/// <remarks>
-	/// This method allows for flexible filtering and customization of the query through the
-	/// <paramref name="expression"/> and <paramref name="queryFilter"/> parameters.
-	/// Use <paramref name="ignoreQueryFilters"/> to bypass global filters  such as soft delete
-	/// or multi-tenancy filters.
+	/// Matching more than one entity is an error and throws. Use
+	/// <see cref="GetList(Query{TEntity})"/> when several matches are expected.
 	/// </remarks>
-	/// <param name="expression">
-	/// An optional LINQ expression used to filter the entities to be counted.
-	/// </param>
-	/// <param name="queryFilter">
-	/// An optional function to apply additional transformations or filters to the query.
-	/// </param>
-	/// <param name="ignoreQueryFilters">
-	/// A value indicating whether to ignore any global query filters applied to the entity type.
-	/// </param>
-	/// <returns>The total number of entities that match the specified conditions.</returns>
-	int CountByCondition(
-		Expression<Func<TEntity, bool>> expression,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false);
+	/// <param name="query">The query describing what to read.</param>
+	/// <returns>The matching entity, or <see langword="null"/>.</returns>
+	/// <exception cref="InvalidOperationException">Thrown when more than one entity matches.</exception>
+	TEntity? GetSingle(Query<TEntity>? query = null);
 
-	/// <inheritdoc cref="CountAll(bool)"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	Task<int> CountAllAsync(
-		bool ignoreQueryFilters = false,
-		CancellationToken token = default);
-
-	/// <inheritdoc cref="CountByCondition(Func{IQueryable{TEntity}, IQueryable{TEntity}}, bool)"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	Task<int> CountByConditionAsync(
-		Func<IQueryable<TEntity>, IQueryable<TEntity>> queryFilter,
-		bool ignoreQueryFilters = false,
-		CancellationToken token = default);
-
-	/// <inheritdoc cref="CountByCondition(Expression{Func{TEntity, bool}}, Func{IQueryable{TEntity}, IQueryable{TEntity}}, bool)"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	Task<int> CountByConditionAsync(
-		Expression<Func<TEntity, bool>> expression,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false,
-		CancellationToken token = default);
-
-	/// <summary>
-	/// Retrieves all entities of type <typeparamref name="TEntity"/> from the data source.
-	/// </summary>
-	/// <remarks>
-	/// Use the <paramref name="ignoreQueryFilters"/> parameter to bypass global query filters,
-	/// such as soft delete filters, when retrieving entities. The <paramref name="trackChanges"/>
-	/// parameter determines whether the returned entities are tracked by the context, which can
-	/// impact performance and memory usage.
-	/// </remarks>
-	/// <param name="ignoreQueryFilters">
-	/// A value indicating whether to ignore any query filters applied to the entity type.
-	/// </param>
-	/// <param name="trackChanges">
-	/// A value indicating whether the retrieved entities should be tracked by the context.
-	/// </param>
-	/// <returns>
-	/// An <see cref="IReadOnlyList{T}"/> containing all entities of type <typeparamref name="TEntity"/>
-	/// that match the query criteria.
-	/// </returns>
-	IReadOnlyList<TEntity> GetAll(
-		bool ignoreQueryFilters = false,
-		bool trackChanges = false);
-
-	/// <summary>
-	/// Retrieves all entities of type <typeparamref name="TEntity"/> from the data source and projects them
-	/// into a different form using the specified <paramref name="selector"/>. The optional <paramref name="fieldSelector"/>
-	/// is used to specify which fields to include in the projection, and the <paramref name="ignoreQueryFilters"/> parameter
-	/// allows bypassing global query filters when retrieving entities.
-	/// </summary>
-	/// <typeparam name="TResult">
-	/// The type to which the entities should be projected. This can be a DTO, an anonymous type, or any other type that can
-	/// be constructed from the properties of <typeparamref name="TEntity"/>.
-	/// </typeparam>
-	/// <param name="selector">The expression used to project the entities into the desired form.</param>
-	/// <param name="fieldSelector">The optional expression used to specify which fields to include in the projection.</param>
-	/// <param name="ignoreQueryFilters">
-	/// A value indicating whether to ignore any query filters applied to the entity type when retrieving entities for projection.
-	/// </param>
-	/// <returns>
-	/// A collection of <typeparamref name="TResult"/> containing the projected entities based on the specified selector and field selector.
-	/// </returns>
-	IReadOnlyList<TResult> GetAll<TResult>(
+	/// <inheritdoc cref="GetSingle(Query{TEntity})"/>
+	/// <typeparam name="TResult">The type the entity is projected into.</typeparam>
+	/// <param name="selector">The projection applied to the matching entity.</param>
+	/// <param name="query">The query describing what to read.</param>
+	TResult? GetSingle<TResult>(
 		Expression<Func<TEntity, TResult>> selector,
-		Expression<Func<TResult, TResult>>? fieldSelector = null,
-		bool ignoreQueryFilters = false);
+		Query<TEntity>? query = null);
 
-	/// <inheritdoc cref="GetAll(bool, bool)"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	Task<IReadOnlyList<TEntity>> GetAllAsync(
-		bool ignoreQueryFilters = false,
-		bool trackChanges = false,
-		CancellationToken token = default);
+	/// <inheritdoc cref="GetSingle(Query{TEntity})"/>
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
+	Task<TEntity?> GetSingleAsync(
+		Query<TEntity>? query = null,
+		CancellationToken cancellationToken = default);
 
-	/// <inheritdoc cref="GetAll{TResult}(Expression{Func{TEntity, TResult}}, Expression{Func{TResult, TResult}}, bool)"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	Task<IReadOnlyList<TResult>> GetAllAsync<TResult>(
+	/// <inheritdoc cref="GetSingle{TResult}(Expression{Func{TEntity, TResult}}, Query{TEntity})"/>
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
+	Task<TResult?> GetSingleAsync<TResult>(
 		Expression<Func<TEntity, TResult>> selector,
-		Expression<Func<TResult, TResult>>? fieldSelector = null,
-		bool ignoreQueryFilters = false,
-		CancellationToken token = default);
+		Query<TEntity>? query = null,
+		CancellationToken cancellationToken = default);
 
 	/// <summary>
-	/// Retrieves a single entity that matches the specified query filter, with optional control over query filters,
-	/// change tracking, and related data inclusion.
+	/// Returns the entities matching the specified <paramref name="query"/>.
 	/// </summary>
 	/// <remarks>
-	/// The condition is expected to match at most one entity; matching more than one throws. This method allows
-	/// customization of the query pipeline, including the ability to bypass global query filters and control entity
-	/// tracking behavior. Use the includeProperties parameter to load related data as part of the query.
+	/// The result is buffered. Use <see cref="Stream(Query{TEntity}, CancellationToken)"/> for
+	/// reads large enough that holding every row in memory is a problem.
 	/// </remarks>
-	/// <param name="queryFilter">A function that applies additional filtering or transformation to the entity set.</param>
-	/// <param name="ignoreQueryFilters">true to ignore any global query filters applied to the entity type; otherwise, false.</param>
-	/// <param name="trackChanges">true to enable change tracking for the returned entity; otherwise, false.</param>
-	/// <param name="includeProperties">An array of related entity property names to include in the query results.</param>
-	/// <returns>The entity that matches the specified condition, or null if no such entity is found.</returns>
-	TEntity? GetByCondition(
-		Func<IQueryable<TEntity>, IQueryable<TEntity>> queryFilter,
-		bool ignoreQueryFilters = false,
-		bool trackChanges = false,
-		params string[] includeProperties);
+	/// <param name="query">The query describing what to read. Reads everything when omitted.</param>
+	/// <returns>The matching entities.</returns>
+	IReadOnlyList<TEntity> GetList(Query<TEntity>? query = null);
 
-	/// <summary>
-	/// Returns a <typeparamref name="TEntity"/> by a certain <paramref name="expression"/>.
-	/// </summary>
-	/// <param name="expression">The search condition.</param>
-	/// <param name="queryFilter">The function used to filter the entities.</param>
-	/// <param name="ignoreQueryFilters">Should model-level entity query filters be applied?</param>
-	/// <param name="trackChanges">Should the fetched entity be tracked?</param>
-	/// <param name="includeProperties">Any other navigation properties to include when returning the entity.</param>
-	/// <returns>The found <typeparamref name="TEntity"/> or <see langword="null"/>.</returns>
-	TEntity? GetByCondition(
-		Expression<Func<TEntity, bool>> expression,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false,
-		bool trackChanges = false,
-		params string[] includeProperties);
-
-	/// <summary>
-	/// Retrieves a single result of type <typeparamref name="TResult"/> from entities that satisfy the
-	/// specified condition.
-	/// </summary>
-	/// <remarks>
-	/// The condition is expected to match at most one entity; matching more than one throws. This method
-	/// can be used to efficiently retrieve a single value or projection from a filtered set of entities.
-	/// The behavior of global query filters can be controlled using the <paramref name="ignoreQueryFilters"/>
-	/// parameter.
-	/// </remarks>
-	/// <typeparam name="TResult">The type of the result to project from the entity.</typeparam>
-	/// <param name="expression">An expression that defines the condition to filter entities of type <typeparamref name="TEntity"/>.</param>
-	/// <param name="selector">An expression that specifies how to project the filtered entity to a result of type <typeparamref name="TResult"/>.</param>
-	/// <param name="fieldSelector">An optional expression to further select or transform fields from the projected result.</param>
-	/// <param name="queryFilter">An optional function to apply additional query operations, such as sorting or including related entities, to the
-	/// filtered set.</param>
-	/// <param name="ignoreQueryFilters">true to ignore any global query filters applied to the entity type; otherwise, false.</param>
-	/// <returns>
-	/// The projected result of type <typeparamref name="TResult"/> if an entity matching the condition is found; otherwise, null.
-	/// </returns>
-	TResult? GetByCondition<TResult>(
-		Expression<Func<TEntity, bool>> expression,
+	/// <inheritdoc cref="GetList(Query{TEntity})"/>
+	/// <typeparam name="TResult">The type the entities are projected into.</typeparam>
+	/// <param name="selector">The projection applied to each matching entity.</param>
+	/// <param name="query">The query describing what to read.</param>
+	IReadOnlyList<TResult> GetList<TResult>(
 		Expression<Func<TEntity, TResult>> selector,
-		Expression<Func<TResult, TResult>>? fieldSelector = null,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false);
+		Query<TEntity>? query = null);
 
-	/// <inheritdoc cref="GetByCondition(Func{IQueryable{TEntity}, IQueryable{TEntity}}, bool, bool, string[])"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	Task<TEntity?> GetByConditionAsync(
-		Func<IQueryable<TEntity>, IQueryable<TEntity>> queryFilter,
-		bool ignoreQueryFilters = false,
-		bool trackChanges = false,
-		CancellationToken token = default,
-		params string[] includeProperties);
+	/// <inheritdoc cref="GetList(Query{TEntity})"/>
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
+	Task<IReadOnlyList<TEntity>> GetListAsync(
+		Query<TEntity>? query = null,
+		CancellationToken cancellationToken = default);
 
-	/// <inheritdoc cref="GetByCondition(Expression{Func{TEntity, bool}}, Func{IQueryable{TEntity}, IQueryable{TEntity}}, bool, bool, string[])"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	Task<TEntity?> GetByConditionAsync(
-		Expression<Func<TEntity, bool>> expression,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false,
-		bool trackChanges = false,
-		CancellationToken token = default,
-		params string[] includeProperties);
-
-	/// <inheritdoc cref="GetByCondition{TResult}(Expression{Func{TEntity, bool}}, Expression{Func{TEntity, TResult}}, Expression{Func{TResult, TResult}}, Func{IQueryable{TEntity}, IQueryable{TEntity}}, bool)"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	Task<TResult?> GetByConditionAsync<TResult>(
-		Expression<Func<TEntity, bool>> expression,
+	/// <inheritdoc cref="GetList{TResult}(Expression{Func{TEntity, TResult}}, Query{TEntity})"/>
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
+	Task<IReadOnlyList<TResult>> GetListAsync<TResult>(
 		Expression<Func<TEntity, TResult>> selector,
-		Expression<Func<TResult, TResult>>? fieldSelector = null,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false,
-		CancellationToken token = default);
+		Query<TEntity>? query = null,
+		CancellationToken cancellationToken = default);
 
 	/// <summary>
-	/// Retrieves a collection of entities that satisfy the specified query conditions, with optional ordering,
-	/// paging, and related data inclusion.
+	/// Streams the entities matching the specified <paramref name="query"/>.
 	/// </summary>
 	/// <remarks>
-	/// Use this method to retrieve multiple entities with flexible filtering, sorting, paging, and eager
-	/// loading options. When trackChanges is set to false, the returned entities are not tracked by the
-	/// context, which can improve performance for read-only operations.
+	/// <para>
+	/// Rows are yielded as they arrive instead of being buffered, which suits exports, batch
+	/// jobs and other unbounded reads.
+	/// </para>
+	/// <para>
+	/// The sequence is lazy. It has to be enumerated within the lifetime of the context, and
+	/// EF Core allows only one active stream per context at a time. Leave
+	/// <see cref="Query{TEntity}.TrackChanges"/> off, or the change tracker grows with every
+	/// entity yielded and the point of streaming is lost.
+	/// </para>
 	/// </remarks>
-	/// <param name="queryFilter">A function that applies additional filtering to the entity query.</param>
-	/// <param name="ignoreQueryFilters">true to ignore any global query filters applied to the entity type; otherwise, false.</param>
-	/// <param name="orderBy">An optional function to specify the ordering of the resulting entities.</param>
-	/// <param name="skip">The number of entities to skip before starting to return results.</param>
-	/// <param name="take">The maximum number of entities to return.</param>
-	/// <param name="trackChanges">true to enable change tracking for the returned entities; otherwise, false to retrieve entities without tracking.</param>
-	/// <param name="includeProperties">An array of related entity property names to include in the query results for eager loading.</param>
-	/// <returns>
-	/// A read-only list of entities that match the specified conditions. The list is empty if no entities satisfy the query.
-	/// </returns>
-	IReadOnlyList<TEntity> GetManyByCondition(
-		Func<IQueryable<TEntity>, IQueryable<TEntity>> queryFilter,
-		bool ignoreQueryFilters = false,
-		Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
-		int? skip = null,
-		int? take = null,
-		bool trackChanges = false,
-		params string[] includeProperties);
+	/// <param name="query">The query describing what to read. Reads everything when omitted.</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
+	/// <returns>The matching entities, yielded as they arrive.</returns>
+	IAsyncEnumerable<TEntity> Stream(
+		Query<TEntity>? query = null,
+		CancellationToken cancellationToken = default);
 
-	/// <summary>
-	/// Returns a collection of <typeparamref name="TEntity"/> based on the specified <paramref name="expression"/>.
-	/// </summary>
-	/// <param name="expression">The condition to fulfill to be returned.</param>
-	/// <param name="queryFilter">The function used to filter the entities.</param>
-	/// <param name="ignoreQueryFilters">Should model-level entity query filters be applied?</param>
-	/// <param name="orderBy">The function used to order the entities.</param>
-	/// <param name="skip">The number of records to skip.</param>
-	/// <param name="take">The number of records to limit the results to.</param>
-	/// <param name="trackChanges">Should the fetched entities be tracked?</param>
-	/// <param name="includeProperties">Any other navigation properties to include when returning the collection.</param>
-	/// <returns>A collection of <typeparamref name="TEntity"/>.</returns>
-	IReadOnlyList<TEntity> GetManyByCondition(
-		Expression<Func<TEntity, bool>> expression,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false,
-		Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
-		int? skip = null,
-		int? take = null,
-		bool trackChanges = false,
-		params string[] includeProperties);
-
-	/// <summary>
-	/// Retrieves a collection of entities that satisfy the specified condition, projects them to the specified result
-	/// type, and applies optional filtering, ordering, and pagination.
-	/// </summary>
-	/// <remarks>
-	/// Use this method to retrieve and project multiple entities based on complex query scenarios, including custom
-	/// filtering, ordering, and pagination. This method is typically used in repository patterns to abstract data access logic.
-	/// </remarks>
-	/// <typeparam name="TResult">The type of the result returned by the selector expression.</typeparam>
-	/// <param name="expression">An expression that defines the condition entities must satisfy to be included in the result.</param>
-	/// <param name="selector">An expression that specifies how to project each matching entity to the result type.</param>
-	/// <param name="fieldSelector">An optional expression that selects specific fields from the projected result.</param>
-	/// <param name="queryFilter">An optional function to apply additional filtering or transformation to the query before execution.</param>
-	/// <param name="ignoreQueryFilters">true to ignore any global query filters applied to the entity type; otherwise, false.</param>
-	/// <param name="orderBy">An optional function to specify the ordering of the results.</param>
-	/// <param name="skip">The number of results to skip before returning results. If null, no results are skipped.</param>
-	/// <param name="take">The maximum number of results to return. If null, all matching results are returned.</param>
-	/// <returns>
-	/// An enumerable collection of projected results that match the specified condition and query options.
-	/// The collection may be empty if no entities satisfy the condition.
-	/// </returns>
-	IReadOnlyList<TResult> GetManyByCondition<TResult>(
-		Expression<Func<TEntity, bool>> expression,
+	/// <inheritdoc cref="Stream(Query{TEntity}, CancellationToken)"/>
+	/// <typeparam name="TResult">The type the entities are projected into.</typeparam>
+	/// <param name="selector">The projection applied to each matching entity.</param>
+	/// <param name="query">The query describing what to read.</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
+	IAsyncEnumerable<TResult> Stream<TResult>(
 		Expression<Func<TEntity, TResult>> selector,
-		Expression<Func<TResult, TResult>>? fieldSelector = null,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false,
-		Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
-		int? skip = null,
-		int? take = null);
-
-	/// <inheritdoc cref="GetManyByCondition(Func{IQueryable{TEntity}, IQueryable{TEntity}}, bool, Func{IQueryable{TEntity}, IOrderedQueryable{TEntity}}, int?, int?, bool, string[])"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	Task<IReadOnlyList<TEntity>> GetManyByConditionAsync(
-		Func<IQueryable<TEntity>, IQueryable<TEntity>> queryFilter,
-		bool ignoreQueryFilters = false,
-		Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
-		int? skip = null,
-		int? take = null,
-		bool trackChanges = false,
-		CancellationToken token = default,
-		params string[] includeProperties);
-
-	/// <inheritdoc cref="GetManyByCondition(Expression{Func{TEntity, bool}}, Func{IQueryable{TEntity}, IQueryable{TEntity}}, bool, Func{IQueryable{TEntity}, IOrderedQueryable{TEntity}}, int?, int?, bool, string[])"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	Task<IReadOnlyList<TEntity>> GetManyByConditionAsync(
-		Expression<Func<TEntity, bool>> expression,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false,
-		Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
-		int? skip = null,
-		int? take = null,
-		bool trackChanges = false,
-		CancellationToken token = default,
-		params string[] includeProperties);
-
-	/// <inheritdoc cref="GetManyByCondition{TResult}(Expression{Func{TEntity, bool}}, Expression{Func{TEntity, TResult}}, Expression{Func{TResult, TResult}}, Func{IQueryable{TEntity}, IQueryable{TEntity}}, bool, Func{IQueryable{TEntity}, IOrderedQueryable{TEntity}}, int?, int?)"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	Task<IReadOnlyList<TResult>> GetManyByConditionAsync<TResult>(
-		Expression<Func<TEntity, bool>> expression,
-		Expression<Func<TEntity, TResult>> selector,
-		Expression<Func<TResult, TResult>>? fieldSelector = null,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false,
-		Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
-		int? skip = null,
-		int? take = null,
-		CancellationToken token = default);
-
-	/// <summary>
-	/// Streams all entities of type <typeparamref name="TEntity"/> from the data source.
-	/// </summary>
-	/// <remarks>
-	/// In contrast to <see cref="GetAllAsync(bool, bool, CancellationToken)"/> the result set is not
-	/// buffered, the entities are yielded as they are read from the database. The returned sequence is
-	/// lazy and must be enumerated within the lifetime of the underlying database context. Enumerating
-	/// with change tracking enabled makes the change tracker grow with every yielded entity.
-	/// </remarks>
-	/// <param name="ignoreQueryFilters">
-	/// A value indicating whether to ignore any query filters applied to the entity type.
-	/// </param>
-	/// <param name="trackChanges">
-	/// A value indicating whether the streamed entities should be tracked by the context.
-	/// </param>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	/// <returns>
-	/// An <see cref="IAsyncEnumerable{T}"/> that yields all entities of type <typeparamref name="TEntity"/>.
-	/// </returns>
-	IAsyncEnumerable<TEntity> StreamAll(
-		bool ignoreQueryFilters = false,
-		bool trackChanges = false,
-		CancellationToken token = default);
-
-	/// <summary>
-	/// Streams all entities of type <typeparamref name="TEntity"/> from the data source and projects
-	/// them into a different form using the specified <paramref name="selector"/>.
-	/// </summary>
-	/// <remarks>
-	/// In contrast to <see cref="GetAllAsync{TResult}(Expression{Func{TEntity, TResult}}, Expression{Func{TResult, TResult}}, bool, CancellationToken)"/>
-	/// the result set is not buffered, the projections are yielded as they are read from the database.
-	/// The returned sequence is lazy and must be enumerated within the lifetime of the underlying
-	/// database context.
-	/// </remarks>
-	/// <typeparam name="TResult">The type of the result elements after projection.</typeparam>
-	/// <param name="selector">The expression used to project the entities into the desired form.</param>
-	/// <param name="fieldSelector">The optional expression used to specify which fields to include in the projection.</param>
-	/// <param name="ignoreQueryFilters">
-	/// A value indicating whether to ignore any query filters applied to the entity type.
-	/// </param>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	/// <returns>
-	/// An <see cref="IAsyncEnumerable{T}"/> that yields the projected <typeparamref name="TResult"/> instances.
-	/// </returns>
-	IAsyncEnumerable<TResult> StreamAll<TResult>(
-		Expression<Func<TEntity, TResult>> selector,
-		Expression<Func<TResult, TResult>>? fieldSelector = null,
-		bool ignoreQueryFilters = false,
-		CancellationToken token = default);
-
-	/// <summary>
-	/// Streams the entities that satisfy the specified query filter, with optional ordering, paging and
-	/// related data inclusion.
-	/// </summary>
-	/// <remarks>
-	/// In contrast to <see cref="GetManyByConditionAsync(Func{IQueryable{TEntity}, IQueryable{TEntity}}, bool, Func{IQueryable{TEntity}, IOrderedQueryable{TEntity}}, int?, int?, bool, CancellationToken, string[])"/>
-	/// the result set is not buffered, the entities are yielded as they are read from the database. The
-	/// returned sequence is lazy and must be enumerated within the lifetime of the underlying database
-	/// context. Enumerating with change tracking enabled makes the change tracker grow with every yielded
-	/// entity.
-	/// </remarks>
-	/// <param name="queryFilter">A function that applies additional filtering to the entity query.</param>
-	/// <param name="ignoreQueryFilters">true to ignore any global query filters applied to the entity type; otherwise, false.</param>
-	/// <param name="orderBy">An optional function to specify the ordering of the streamed entities.</param>
-	/// <param name="skip">The number of entities to skip before starting to yield results.</param>
-	/// <param name="take">The maximum number of entities to yield.</param>
-	/// <param name="trackChanges">true to enable change tracking for the streamed entities; otherwise, false.</param>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	/// <param name="includeProperties">An array of related entity property names to include in the query results for eager loading.</param>
-	/// <returns>
-	/// An <see cref="IAsyncEnumerable{T}"/> that yields the entities matching the specified conditions.
-	/// </returns>
-	IAsyncEnumerable<TEntity> StreamByCondition(
-		Func<IQueryable<TEntity>, IQueryable<TEntity>> queryFilter,
-		bool ignoreQueryFilters = false,
-		Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
-		int? skip = null,
-		int? take = null,
-		bool trackChanges = false,
-		CancellationToken token = default,
-		params string[] includeProperties);
-
-	/// <summary>
-	/// Streams the entities that satisfy the specified <paramref name="expression"/>, with optional
-	/// ordering, paging and related data inclusion.
-	/// </summary>
-	/// <remarks>
-	/// In contrast to <see cref="GetManyByConditionAsync(Expression{Func{TEntity, bool}}, Func{IQueryable{TEntity}, IQueryable{TEntity}}, bool, Func{IQueryable{TEntity}, IOrderedQueryable{TEntity}}, int?, int?, bool, CancellationToken, string[])"/>
-	/// the result set is not buffered, the entities are yielded as they are read from the database. The
-	/// returned sequence is lazy and must be enumerated within the lifetime of the underlying database
-	/// context. Enumerating with change tracking enabled makes the change tracker grow with every yielded
-	/// entity.
-	/// </remarks>
-	/// <param name="expression">The condition to fulfill to be streamed.</param>
-	/// <param name="queryFilter">The function used to filter the entities.</param>
-	/// <param name="ignoreQueryFilters">Should model-level entity query filters be applied?</param>
-	/// <param name="orderBy">The function used to order the entities.</param>
-	/// <param name="skip">The number of records to skip.</param>
-	/// <param name="take">The number of records to limit the results to.</param>
-	/// <param name="trackChanges">Should the streamed entities be tracked?</param>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	/// <param name="includeProperties">Any other navigation properties to include when streaming the entities.</param>
-	/// <returns>
-	/// An <see cref="IAsyncEnumerable{T}"/> that yields the entities matching the specified conditions.
-	/// </returns>
-	IAsyncEnumerable<TEntity> StreamByCondition(
-		Expression<Func<TEntity, bool>> expression,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false,
-		Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
-		int? skip = null,
-		int? take = null,
-		bool trackChanges = false,
-		CancellationToken token = default,
-		params string[] includeProperties);
-
-	/// <summary>
-	/// Streams the entities that satisfy the specified <paramref name="expression"/> and projects them
-	/// into the specified result type, with optional ordering and paging.
-	/// </summary>
-	/// <remarks>
-	/// In contrast to <see cref="GetManyByConditionAsync{TResult}(Expression{Func{TEntity, bool}}, Expression{Func{TEntity, TResult}}, Expression{Func{TResult, TResult}}, Func{IQueryable{TEntity}, IQueryable{TEntity}}, bool, Func{IQueryable{TEntity}, IOrderedQueryable{TEntity}}, int?, int?, CancellationToken)"/>
-	/// the result set is not buffered, the projections are yielded as they are read from the database.
-	/// The returned sequence is lazy and must be enumerated within the lifetime of the underlying
-	/// database context.
-	/// </remarks>
-	/// <typeparam name="TResult">The type of the result returned by the selector expression.</typeparam>
-	/// <param name="expression">An expression that defines the condition entities must satisfy to be streamed.</param>
-	/// <param name="selector">An expression that specifies how to project each matching entity to the result type.</param>
-	/// <param name="fieldSelector">An optional expression that selects specific fields from the projected result.</param>
-	/// <param name="queryFilter">An optional function to apply additional filtering or transformation to the query before execution.</param>
-	/// <param name="ignoreQueryFilters">true to ignore any global query filters applied to the entity type; otherwise, false.</param>
-	/// <param name="orderBy">An optional function to specify the ordering of the results.</param>
-	/// <param name="skip">The number of results to skip before yielding results. If null, no results are skipped.</param>
-	/// <param name="take">The maximum number of results to yield. If null, all matching results are yielded.</param>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	/// <returns>
-	/// An <see cref="IAsyncEnumerable{T}"/> that yields the projected <typeparamref name="TResult"/> instances.
-	/// </returns>
-	IAsyncEnumerable<TResult> StreamByCondition<TResult>(
-		Expression<Func<TEntity, bool>> expression,
-		Expression<Func<TEntity, TResult>> selector,
-		Expression<Func<TResult, TResult>>? fieldSelector = null,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false,
-		Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
-		int? skip = null,
-		int? take = null,
-		CancellationToken token = default);
+		Query<TEntity>? query = null,
+		CancellationToken cancellationToken = default);
 
 	/// <summary>
 	/// Updates the specified entity in the underlying data store.
 	/// </summary>
 	/// <remarks>
-	/// This method marks the provided entity as modified in the database context, so that
+	/// This method marks the provided entity as modified in the database context. so that
 	/// changes to the entity will be persisted to the database during the next save operation.
 	/// </remarks>
 	/// <param name="entity">The entity to update.</param>
@@ -659,23 +288,23 @@ public interface IGenericRepository<TEntity>
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls);
 
 	/// <inheritdoc cref="Update(TEntity)"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
 	/// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
 	Task UpdateAsync(
 		TEntity entity,
-		CancellationToken token = default);
+		CancellationToken cancellationToken = default);
 
 	/// <inheritdoc cref="Update(IEnumerable{TEntity})"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
 	/// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
 	Task UpdateAsync(
 		IEnumerable<TEntity> entities,
-		CancellationToken token = default);
+		CancellationToken cancellationToken = default);
 
 	/// <inheritdoc cref="Update(Expression{Func{TEntity, bool}}, Action{UpdateSettersBuilder{TEntity}})"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
 	Task<int> UpdateAsync(
 		Expression<Func<TEntity, bool>> expression,
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls,
-		CancellationToken token = default);
+		CancellationToken cancellationToken = default);
 }

--- a/src/BB84.EntityFrameworkCore.Repositories.Abstractions/IIdentityRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.Abstractions/IIdentityRepository.cs
@@ -69,145 +69,90 @@ public interface IIdentityRepository<TEntity, TKey> : IGenericRepository<TEntity
 	int Delete(IEnumerable<TKey> ids);
 
 	/// <inheritdoc cref="Delete(TKey)"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	Task<int> DeleteAsync(TKey id, CancellationToken token = default);
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
+	Task<int> DeleteAsync(TKey id, CancellationToken cancellationToken = default);
 
 	/// <inheritdoc cref="Delete(IEnumerable{TKey})"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	Task<int> DeleteAsync(IEnumerable<TKey> ids, CancellationToken token = default);
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
+	Task<int> DeleteAsync(IEnumerable<TKey> ids, CancellationToken cancellationToken = default);
 
 	/// <summary>
-	/// Retrieves an entity by its unique identifier.
-	/// </summary>
-	/// <param name="id">The unique identifier of the entity to retrieve.</param>
-	/// <param name="ignoreQueryFilters">
-	/// A value indicating whether to ignore query filters, such as global filters or soft delete filters.
-	/// </param>
-	/// <param name="trackChanges">
-	/// A value indicating whether the retrieved entity should be tracked by the context.
-	/// </param>
-	/// <param name="includeProperties">
-	/// An array of related entity property names to include in the query.
-	/// </param>
-	/// <returns>
-	/// The entity that matches the specified identifier, or <see langword="null"/> if no such entity exists.
-	/// </returns>
-	TEntity? GetById(
-		TKey id,
-		bool ignoreQueryFilters = false,
-		bool trackChanges = false,
-		params string[] includeProperties);
-
-	/// <summary>
-	/// Retrieves a projection of an entity identified by the specified key.
+	/// Returns the entity with the specified <paramref name="id"/>, or <see langword="null"/>
+	/// when no such entity exists.
 	/// </summary>
 	/// <remarks>
-	/// Use <paramref name="ignoreQueryFilters"/> with caution, as ignoring query filters may expose entities that
-	/// are normally excluded (such as soft-deleted records or tenant-specific data). The <paramref name="fieldSelector"/>
-	/// parameter allows for additional shaping of the result after the initial projection.
+	/// The identifier acts as an additional condition. Anything the <paramref name="query"/>
+	/// already filters by still applies.
 	/// </remarks>
-	/// <typeparam name="TResult">The type of the result returned by the selector expression.</typeparam>
-	/// <param name="id">The unique identifier of the entity to retrieve.</param>
-	/// <param name="selector">
-	/// An expression that defines the projection to apply to the entity. This determines which fields are included in the result.
-	/// </param>
-	/// <param name="fieldSelector">
-	/// An optional expression to further select or transform the projected result. If null, the entire projection defined by
-	/// <paramref name="selector"/> is returned.
-	/// </param>
-	/// <param name="ignoreQueryFilters">true to ignore any global query filters applied to the entity type; otherwise, false.</param>
-	/// <returns>
-	/// The projected result of type <typeparamref name="TResult"/> if an entity with the specified identifier exists; otherwise, null.
-	/// </returns>
+	/// <param name="id">The primary key of the <typeparamref name="TEntity"/>.</param>
+	/// <param name="query">The query describing how to read.</param>
+	/// <returns>The matching entity, or <see langword="null"/>.</returns>
+	TEntity? GetById(TKey id, Query<TEntity>? query = null);
+
+	/// <inheritdoc cref="GetById(TKey, Query{TEntity})"/>
+	/// <typeparam name="TResult">The type the entity is projected into.</typeparam>
+	/// <param name="id">The primary key of the <typeparamref name="TEntity"/>.</param>
+	/// <param name="selector">The projection applied to the matching entity.</param>
+	/// <param name="query">The query describing how to read.</param>
 	TResult? GetById<TResult>(
 		TKey id,
 		Expression<Func<TEntity, TResult>> selector,
-		Expression<Func<TResult, TResult>>? fieldSelector = null,
-		bool ignoreQueryFilters = false);
+		Query<TEntity>? query = null);
 
-	/// <inheritdoc cref="GetById(TKey, bool, bool, string[])"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
+	/// <inheritdoc cref="GetById(TKey, Query{TEntity})"/>
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
 	Task<TEntity?> GetByIdAsync(
 		TKey id,
-		bool ignoreQueryFilters = false,
-		bool trackChanges = false,
-		CancellationToken token = default,
-		params string[] includeProperties);
+		Query<TEntity>? query = null,
+		CancellationToken cancellationToken = default);
 
-	/// <inheritdoc cref="GetById{TResult}(TKey, Expression{Func{TEntity, TResult}}, Expression{Func{TResult, TResult}}, bool)"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
+	/// <inheritdoc cref="GetById{TResult}(TKey, Expression{Func{TEntity, TResult}}, Query{TEntity})"/>
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
 	Task<TResult?> GetByIdAsync<TResult>(
 		TKey id,
 		Expression<Func<TEntity, TResult>> selector,
-		Expression<Func<TResult, TResult>>? fieldSelector = null,
-		bool ignoreQueryFilters = false,
-		CancellationToken token = default);
+		Query<TEntity>? query = null,
+		CancellationToken cancellationToken = default);
 
 	/// <summary>
-	/// Retrieves a collection of entities that match the specified identifiers.
-	/// </summary>
-	/// <param name="ids">A collection of identifiers used to filter the entities.</param>
-	/// <param name="ignoreQueryFilters">
-	/// A value indicating whether to ignore any query filters applied to the entity type.
-	/// </param>
-	/// <param name="trackChanges">
-	/// A value indicating whether the returned entities should be tracked by the context.
-	/// </param>
-	/// <param name="includeProperties">
-	/// An array of related entity property names to include in the query results.
-	/// </param>
-	/// <returns>
-	/// A read only collection of entities of type <typeparamref name="TEntity"/> that match the
-	/// specified identifiers. If no entities match, an empty collection is returned.
-	/// </returns>
-	IReadOnlyList<TEntity> GetByIds(
-		IEnumerable<TKey> ids,
-		bool ignoreQueryFilters = false,
-		bool trackChanges = false,
-		params string[] includeProperties);
-
-	/// <summary>
-	/// Retrieves entities by their identifiers and projects them into the specified result type.
+	/// Returns the entities matching the specified <paramref name="ids"/>.
 	/// </summary>
 	/// <remarks>
-	/// The order of the returned results is not guaranteed to match the order of the provided identifiers.
-	/// If an identifier does not correspond to an existing entity, it is omitted from the results. This
-	/// method is typically used to efficiently fetch and project multiple entities in a single query.
+	/// The order of the results is not guaranteed to match the order of the identifiers, and an
+	/// identifier without a matching row is simply absent from the result. The identifiers act
+	/// as an additional condition, so anything the <paramref name="query"/> already filters by
+	/// still applies.
 	/// </remarks>
-	/// <typeparam name="TResult">The type of the result returned for each entity.</typeparam>
-	/// <param name="ids">A collection of entity identifiers to retrieve.</param>
-	/// <param name="selector">An expression that defines the projection from the entity to the result type.</param>
-	/// <param name="fieldSelector">
-	/// An optional expression to further select or shape the projected result. If null, the full result from the selector is returned.
-	/// </param>
-	/// <param name="ignoreQueryFilters">true to ignore any global query filters applied to the entity type; otherwise, false.</param>
-	/// <returns>
-	/// An read only collection of projected results of <typeparamref name="TResult"/> corresponding to the specified identifiers.
-	/// The collection may be empty if no entities are found.
-	/// </returns>
+	/// <param name="ids">The primary keys of the <typeparamref name="TEntity"/>.</param>
+	/// <param name="query">The query describing how to read.</param>
+	/// <returns>The matching entities.</returns>
+	IReadOnlyList<TEntity> GetByIds(IEnumerable<TKey> ids, Query<TEntity>? query = null);
+
+	/// <inheritdoc cref="GetByIds(IEnumerable{TKey}, Query{TEntity})"/>
+	/// <typeparam name="TResult">The type the entities are projected into.</typeparam>
+	/// <param name="ids">The primary keys of the <typeparamref name="TEntity"/>.</param>
+	/// <param name="selector">The projection applied to each matching entity.</param>
+	/// <param name="query">The query describing how to read.</param>
 	IReadOnlyList<TResult> GetByIds<TResult>(
 		IEnumerable<TKey> ids,
 		Expression<Func<TEntity, TResult>> selector,
-		Expression<Func<TResult, TResult>>? fieldSelector = null,
-		bool ignoreQueryFilters = false);
+		Query<TEntity>? query = null);
 
-	/// <inheritdoc cref="GetByIds(IEnumerable{TKey}, bool, bool, string[])"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
+	/// <inheritdoc cref="GetByIds(IEnumerable{TKey}, Query{TEntity})"/>
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
 	Task<IReadOnlyList<TEntity>> GetByIdsAsync(
 		IEnumerable<TKey> ids,
-		bool ignoreQueryFilters = false,
-		bool trackChanges = false,
-		CancellationToken token = default,
-		params string[] includeProperties);
+		Query<TEntity>? query = null,
+		CancellationToken cancellationToken = default);
 
-	/// <inheritdoc cref="GetByIds{TResult}(IEnumerable{TKey}, Expression{Func{TEntity, TResult}}, Expression{Func{TResult, TResult}}, bool)"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
+	/// <inheritdoc cref="GetByIds{TResult}(IEnumerable{TKey}, Expression{Func{TEntity, TResult}}, Query{TEntity})"/>
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
 	Task<IReadOnlyList<TResult>> GetByIdsAsync<TResult>(
 		IEnumerable<TKey> ids,
 		Expression<Func<TEntity, TResult>> selector,
-		Expression<Func<TResult, TResult>>? fieldSelector = null,
-		bool ignoreQueryFilters = false,
-		CancellationToken token = default);
+		Query<TEntity>? query = null,
+		CancellationToken cancellationToken = default);
+
 
 	/// <summary>
 	/// Updates the entity identified by the specified identifier with the provided property changes.
@@ -248,18 +193,18 @@ public interface IIdentityRepository<TEntity, TKey> : IGenericRepository<TEntity
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls);
 
 	/// <inheritdoc cref="Update(TKey, Action{UpdateSettersBuilder{TEntity}})"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
 	Task<int> UpdateAsync(
 		TKey id,
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls,
-		CancellationToken token = default);
+		CancellationToken cancellationToken = default);
 
 	/// <inheritdoc cref="Update(IEnumerable{TKey}, Action{UpdateSettersBuilder{TEntity}})"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
 	Task<int> UpdateAsync(
 		IEnumerable<TKey> ids,
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls,
-		CancellationToken token = default);
+		CancellationToken cancellationToken = default);
 }
 
 /// <inheritdoc cref="IIdentityRepository{TEntity, TKey}"/>

--- a/src/BB84.EntityFrameworkCore.Repositories.Abstractions/Query.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.Abstractions/Query.cs
@@ -1,0 +1,99 @@
+﻿// Copyright: 2024 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using System.Linq.Expressions;
+
+namespace BB84.EntityFrameworkCore.Repositories.Abstractions;
+
+/// <summary>
+/// Describes how a read operation composes its query: what to filter by, what to include,
+/// how to order, how much to skip and take, and how to treat tracking and query filters.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every option is <b>optional</b>. An instance with nothing set means "everything, untracked,
+/// with the global query filters applied", so passing no query at all reads the whole set.
+/// </para>
+/// <para>
+/// The options are applied in a fixed order: <see cref="Where"/>, <see cref="QueryFilter"/>,
+/// <see cref="IgnoreQueryFilters"/>, <see cref="Include"/>, <see cref="OrderBy"/>,
+/// <see cref="Skip"/>, <see cref="Take"/>. Ordering therefore happens before paging, which is
+/// the only combination of the two that is meaningful.
+/// </para>
+/// <example>
+/// <code>
+/// IReadOnlyList&lt;PersonEntity&gt; people = await repository.GetListAsync(
+///     new()
+///     {
+///         Where = x =&gt; x.IsActive,
+///         OrderBy = q =&gt; q.OrderBy(x =&gt; x.LastName),
+///         Include = [x =&gt; x.Jobs],
+///         Take = 50,
+///     },
+///     cancellationToken);
+/// </code>
+/// </example>
+/// </remarks>
+/// <typeparam name="TEntity">The type of the entity being queried.</typeparam>
+public sealed record Query<TEntity>
+	where TEntity : class
+{
+	/// <summary>
+	/// The condition an entity has to fulfill to be selected.
+	/// </summary>
+	public Expression<Func<TEntity, bool>>? Where { get; init; }
+
+	/// <summary>
+	/// An additional composition step applied to the query.
+	/// </summary>
+	/// <remarks>
+	/// The escape hatch for anything the other options cannot express, such as
+	/// <c>ThenInclude</c>, grouping or a join. Applied after <see cref="Where"/>.
+	/// </remarks>
+	public Func<IQueryable<TEntity>, IQueryable<TEntity>>? QueryFilter { get; init; }
+
+	/// <summary>
+	/// The related data to load along with the entity.
+	/// </summary>
+	/// <remarks>
+	/// Each expression names a navigation property, for example <c>x =&gt; x.Jobs</c>. Use
+	/// <see cref="QueryFilter"/> instead when a nested <c>ThenInclude</c> is needed.
+	/// </remarks>
+	public IReadOnlyList<Expression<Func<TEntity, object?>>>? Include { get; init; }
+
+	/// <summary>
+	/// The ordering applied to the query.
+	/// </summary>
+	public Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? OrderBy { get; init; }
+
+	/// <summary>
+	/// The number of entities to bypass.
+	/// </summary>
+	public int? Skip { get; init; }
+
+	/// <summary>
+	/// The number of entities to return.
+	/// </summary>
+	public int? Take { get; init; }
+
+	/// <summary>
+	/// Whether the returned entities are tracked by the change tracker.
+	/// </summary>
+	/// <remarks>
+	/// Defaults to <see langword="false"/>. Leave it off for reads that are not going to be
+	/// written back, and especially for streaming reads, where tracking makes the change
+	/// tracker grow with every entity yielded.
+	/// </remarks>
+	public bool TrackChanges { get; init; }
+
+	/// <summary>
+	/// Whether the global query filters are ignored.
+	/// </summary>
+	/// <remarks>
+	/// Defaults to <see langword="false"/>. Set it to <see langword="true"/> to read rows that
+	/// a global filter would otherwise hide, such as soft deleted ones.
+	/// </remarks>
+	public bool IgnoreQueryFilters { get; init; }
+}

--- a/src/BB84.EntityFrameworkCore.Repositories.Abstractions/README.md
+++ b/src/BB84.EntityFrameworkCore.Repositories.Abstractions/README.md
@@ -1,4 +1,4 @@
-[![net100](https://img.shields.io/badge/net10.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
+﻿[![net100](https://img.shields.io/badge/net10.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
 [![NuGet](https://img.shields.io/nuget/v/BB84.EntityFrameworkCore.Repositories.Abstractions.svg?logo=nuget&logoColor=white)](https://www.nuget.org/packages/BB84.EntityFrameworkCore.Repositories.Abstractions)
 
 # BB84.EntityFrameworkCore.Repositories.Abstractions
@@ -27,9 +27,48 @@ services.AddDbContext<AppDbContext>(...);
 services.AddScoped<IDbContext>(sp => sp.GetRequiredService<AppDbContext>());
 ```
 
+## `Query<TEntity>`
+
+Every read method takes its options as one immutable record instead of a positional parameter list. All options are optional, so passing nothing reads everything.
+
+| Property             | Type                                                     | Default |
+| -------------------- | -------------------------------------------------------- | ------- |
+| `Where`              | `Expression<Func<TEntity, bool>>?`                       | `null`  |
+| `QueryFilter`        | `Func<IQueryable<TEntity>, IQueryable<TEntity>>?`        | `null`  |
+| `Include`            | `IReadOnlyList<Expression<Func<TEntity, object?>>>?`     | `null`  |
+| `OrderBy`            | `Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>?` | `null`  |
+| `Skip` / `Take`      | `int?`                                                   | `null`  |
+| `TrackChanges`       | `bool`                                                   | `false` |
+| `IgnoreQueryFilters` | `bool`                                                   | `false` |
+
+Options apply in a fixed order: `Where`, `QueryFilter`, `IgnoreQueryFilters`, `Include`, `OrderBy`, `Skip`, `Take` — so ordering always precedes paging.
+
+```csharp
+IReadOnlyList<Person> people = await repository.GetListAsync(
+    new()
+    {
+        Where = x => x.IsActive,
+        OrderBy = q => q.OrderBy(x => x.LastName),
+        Include = [x => x.Jobs],
+        Take = 50,
+    },
+    cancellationToken);
+```
+
+Being a record, a base query can be varied with `with` instead of rebuilt:
+
+```csharp
+Query<Person> active = new() { Where = x => x.IsActive };
+
+int total = repository.Count(active);
+IReadOnlyList<Person> firstPage = repository.GetList(active with { Take = 25 });
+```
+
+`Include` names navigations as expressions, so a rename is a compile error rather than a runtime one. Use `QueryFilter` for anything the properties cannot express — a nested `ThenInclude`, a join, a grouping.
+
 ## `IGenericRepository<TEntity>`
 
-The base repository interface. All methods have synchronous and asynchronous variants.
+The base repository interface. All methods have synchronous and asynchronous variants, and every `Async` variant takes `CancellationToken cancellationToken` last.
 
 **Create**
 
@@ -38,22 +77,19 @@ The base repository interface. All methods have synchronous and asynchronous var
 
 **Read**
 
-- `GetAll(ignoreQueryFilters, trackChanges)` — returns all entities
-- `GetAll<TResult>(selector, fieldSelector, ignoreQueryFilters)` — returns projected DTO list
-- `GetByCondition(expression, queryFilter, ignoreQueryFilters, trackChanges, includeProperties)` — returns single or null
-- `GetByCondition<TResult>(expression, selector, fieldSelector, ...)` — projected single
-- `GetManyByCondition(expression, queryFilter, ignoreQueryFilters, orderBy, skip, take, trackChanges, includeProperties)` — paged/filtered list
-- `GetManyByCondition<TResult>(...)` — projected paged/filtered list
-- `CountAll(ignoreQueryFilters)` / `CountByCondition(expression, ...)` — count queries
+- `Count(query)` — number of matching rows
+- `GetSingle(query)` — one entity or `null`; throws when more than one matches
+- `GetSingle<TResult>(selector, query)` — projected single
+- `GetList(query)` — matching entities, buffered
+- `GetList<TResult>(selector, query)` — projected list
+- `Stream(query, cancellationToken)` — matching entities as `IAsyncEnumerable<TEntity>`, not buffered
+- `Stream<TResult>(selector, query, cancellationToken)` — projected stream
 
-**Stream** (asynchronous only, returns `IAsyncEnumerable<T>`)
+There is no separate "all" method: an absent `Where` already means everything, so `GetList()` reads the whole set.
 
-- `StreamAll(ignoreQueryFilters, trackChanges, token)` — streams all entities
-- `StreamAll<TResult>(selector, fieldSelector, ignoreQueryFilters, token)` — streams projected DTOs
-- `StreamByCondition(expression, queryFilter, ignoreQueryFilters, orderBy, skip, take, trackChanges, token, includeProperties)`
-- `StreamByCondition<TResult>(...)` — streams projected results
+`Count` deliberately ignores `OrderBy`, `Skip`, `Take` and `Include`, because none of them changes how many rows match.
 
-The parameters mirror the corresponding `GetAllAsync` / `GetManyByConditionAsync` methods; only the return type differs. Unlike those, the result set is **not buffered** — entities are yielded as they are read from the database. The returned sequence is lazy, so it must be enumerated within the lifetime of the `IDbContext` and only one stream may be live per context at a time.
+Streaming yields rows as they arrive. The sequence is lazy, so it has to be enumerated within the lifetime of the `IDbContext`, only one stream may be live per context at a time, and `TrackChanges` should stay off or the change tracker grows with every entity yielded.
 
 **Update**
 
@@ -65,17 +101,17 @@ The parameters mirror the corresponding `GetAllAsync` / `GetManyByConditionAsync
 - `Delete(entity)` / `Delete(entities)` — marks entity/entities as `Deleted`
 - `Delete(expression)` — bulk `ExecuteDelete` (bypasses change tracker)
 
-All `Async` variants accept an optional `CancellationToken`.
-
 ## `IIdentityRepository<TEntity, TKey>` / `IIdentityRepository<TEntity>`
 
 Extends `IGenericRepository<TEntity>` with ID-based operations. The non-generic overload defaults `TKey` to `Guid`.
 
 **Additional read methods**
 
-- `GetById(id, ignoreQueryFilters, trackChanges, includeProperties)`
-- `GetById<TResult>(id, selector, fieldSelector, ignoreQueryFilters)` — projected
-- `GetByIds(ids, ...)` / `GetByIdsAsync(ids, ...)`
+- `GetById(id, query)` / `GetById<TResult>(id, selector, query)`
+- `GetByIds(ids, query)` / `GetByIds<TResult>(ids, selector, query)`
+- Async variants of all four
+
+The key condition is **added** to the query rather than replacing it, so a `Where` in the query keeps applying alongside it.
 
 **Additional delete methods**
 
@@ -89,9 +125,32 @@ Extends `IGenericRepository<TEntity>` with ID-based operations. The non-generic 
 
 Extends `IIdentityRepository` with name-based lookups. The non-generic overload defaults `TKey` to `int`.
 
-- `GetByName(name, ignoreQueryFilters, trackChanges)`
-- `GetByNames(names, ignoreQueryFilters, trackChanges)`
+- `GetByName(name, query)` / `GetByNames(names, query)`
 - Async variants of both
+
+## Migrating from 4.x
+
+| 4.x                                                         | 5.0                                                             |
+| ----------------------------------------------------------- | --------------------------------------------------------------- |
+| `GetAll(ignoreQueryFilters, trackChanges)`                  | `GetList(new() { IgnoreQueryFilters = …, TrackChanges = … })`   |
+| `GetAll<TResult>(selector, fieldSelector, …)`               | `GetList(selector, query)`                                      |
+| `GetByCondition(expression, …)`                             | `GetSingle(new() { Where = … })`                                |
+| `GetByCondition(queryFilter, …)`                            | `GetSingle(new() { QueryFilter = … })`                          |
+| `GetByCondition<TResult>(expression, selector, …)`          | `GetSingle(selector, new() { Where = … })`                      |
+| `GetManyByCondition(expression, …, orderBy, skip, take, …)` | `GetList(new() { Where = …, OrderBy = …, Skip = …, Take = … })` |
+| `GetManyByCondition<TResult>(…)`                            | `GetList(selector, query)`                                      |
+| `CountAll(ignoreQueryFilters)`                              | `Count(new() { IgnoreQueryFilters = … })`                       |
+| `CountByCondition(expression, …)`                           | `Count(new() { Where = … })`                                    |
+| `StreamAll(…)`                                              | `Stream(query, cancellationToken)`                              |
+| `StreamByCondition(expression, …)`                          | `Stream(new() { Where = … }, cancellationToken)`                |
+| `StreamByCondition<TResult>(…)`                             | `Stream(selector, query, cancellationToken)`                    |
+| `GetById(id, ignoreQueryFilters, trackChanges, includes)`   | `GetById(id, query)`                                            |
+| `GetByName(name, ignoreQueryFilters, trackChanges)`         | `GetByName(name, query)`                                        |
+| `includeProperties: [nameof(X.Nav)]`                        | `Include = [x => x.Nav]`                                        |
+| `fieldSelector: …`                                          | removed — compose it into `selector`                            |
+| `token:`                                                    | `cancellationToken:`                                            |
+
+Every `Async` method now takes its cancellation token **last**. Call sites that passed arguments positionally around the old token position need checking, not just recompiling.
 
 ## `ICurrentUserProvider<TUser>` / `ICurrentUserProvider`
 

--- a/src/BB84.EntityFrameworkCore.Repositories/EnumeratorRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/EnumeratorRepository.cs
@@ -1,4 +1,4 @@
-// Copyright: 2024 Robert Peter Meyer
+﻿// Copyright: 2024 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -26,20 +26,20 @@ public abstract class EnumeratorRepository<TEntity, TKey>(IDbContext dbContext) 
 	where TKey : IEquatable<TKey>
 {
 	/// <inheritdoc/>
-	public TEntity? GetByName(string name, bool ignoreQueryFilters = false, bool trackChanges = false)
-		=> QuerySingle(expression: ByName(name), ignoreQueryFilters: ignoreQueryFilters, trackChanges: trackChanges);
+	public TEntity? GetByName(string name, Query<TEntity>? query = null)
+		=> GetSingle(WithCondition(query, ByName(name)));
 
 	/// <inheritdoc/>
-	public async Task<TEntity?> GetByNameAsync(string name, bool ignoreQueryFilters = false, bool trackChanges = false, CancellationToken cancellationToken = default)
-		=> await QuerySingleAsync(expression: ByName(name), ignoreQueryFilters: ignoreQueryFilters, trackChanges: trackChanges, token: cancellationToken).ConfigureAwait(false);
+	public async Task<TEntity?> GetByNameAsync(string name, Query<TEntity>? query = null, CancellationToken cancellationToken = default)
+		=> await GetSingleAsync(WithCondition(query, ByName(name)), cancellationToken).ConfigureAwait(false);
 
 	/// <inheritdoc/>
-	public IReadOnlyList<TEntity> GetByNames(IEnumerable<string> names, bool ignoreQueryFilters = false, bool trackChanges = false)
-		=> QueryMany(expression: ByNames(names), ignoreQueryFilters: ignoreQueryFilters, trackChanges: trackChanges);
+	public IReadOnlyList<TEntity> GetByNames(IEnumerable<string> names, Query<TEntity>? query = null)
+		=> GetList(WithCondition(query, ByNames(names)));
 
 	/// <inheritdoc/>
-	public async Task<IReadOnlyList<TEntity>> GetByNamesAsync(IEnumerable<string> names, bool ignoreQueryFilters = false, bool trackChanges = false, CancellationToken cancellationToken = default)
-		=> await QueryManyAsync(expression: ByNames(names), ignoreQueryFilters: ignoreQueryFilters, trackChanges: trackChanges, token: cancellationToken).ConfigureAwait(false);
+	public async Task<IReadOnlyList<TEntity>> GetByNamesAsync(IEnumerable<string> names, Query<TEntity>? query = null, CancellationToken cancellationToken = default)
+		=> await GetListAsync(WithCondition(query, ByNames(names)), cancellationToken).ConfigureAwait(false);
 
 	/// <summary>
 	/// Returns the condition that matches the <typeparamref name="TEntity"/> with the provided <paramref name="name"/>.

--- a/src/BB84.EntityFrameworkCore.Repositories/GenericRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/GenericRepository.cs
@@ -1,4 +1,4 @@
-// Copyright: 2024 Robert Peter Meyer
+﻿// Copyright: 2024 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -21,206 +21,148 @@ namespace BB84.EntityFrameworkCore.Repositories;
 public abstract class GenericRepository<TEntity>(IDbContext dbContext) : IGenericRepository<TEntity>
 	where TEntity : class
 {
-	/// <summary>
-	/// The collection of all <typeparamref name="TEntity"/> within the database context.
-	/// </summary>
-	protected DbSet<TEntity> DbSet
-		=> dbContext.Set<TEntity>();
+	private readonly DbSet<TEntity> _dbSet = dbContext.Set<TEntity>();
 
 	/// <inheritdoc/>
 	public void Create(TEntity entity)
-		=> DbSet.Add(entity);
+		=> _dbSet.Add(entity);
 
 	/// <inheritdoc/>
 	public void Create(IEnumerable<TEntity> entities)
-		=> DbSet.AddRange(entities);
+		=> _dbSet.AddRange(entities);
 
 	/// <inheritdoc/>
-	public async Task CreateAsync(TEntity entity, CancellationToken token = default)
-		=> await DbSet.AddAsync(entity, token).ConfigureAwait(false);
+	public async Task CreateAsync(TEntity entity, CancellationToken cancellationToken = default)
+		=> await _dbSet.AddAsync(entity, cancellationToken).ConfigureAwait(false);
 
 	/// <inheritdoc/>
-	public async Task CreateAsync(IEnumerable<TEntity> entities, CancellationToken token = default)
-		=> await DbSet.AddRangeAsync(entities, token).ConfigureAwait(false);
-
-	/// <inheritdoc/>
-	public int CountAll(bool ignoreQueryFilters = false)
-		=> QueryCount(ignoreQueryFilters: ignoreQueryFilters);
-
-	/// <inheritdoc/>
-	public async Task<int> CountAllAsync(bool ignoreQueryFilters = false, CancellationToken token = default)
-		=> await QueryCountAsync(ignoreQueryFilters: ignoreQueryFilters, token: token).ConfigureAwait(false);
-
-	/// <inheritdoc/>
-	public int CountByCondition(Func<IQueryable<TEntity>, IQueryable<TEntity>> queryFilter, bool ignoreQueryFilters = false)
-		=> QueryCount(queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters);
-
-	/// <inheritdoc/>
-	public int CountByCondition(Expression<Func<TEntity, bool>> expression, Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null, bool ignoreQueryFilters = false)
-		=> QueryCount(expression: expression, queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters);
-
-	/// <inheritdoc/>
-	public async Task<int> CountByConditionAsync(Func<IQueryable<TEntity>, IQueryable<TEntity>> queryFilter, bool ignoreQueryFilters = false, CancellationToken token = default)
-		=> await QueryCountAsync(queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters, token: token).ConfigureAwait(false);
-
-	/// <inheritdoc/>
-	public async Task<int> CountByConditionAsync(Expression<Func<TEntity, bool>> expression, Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null, bool ignoreQueryFilters = false, CancellationToken token = default)
-		=> await QueryCountAsync(expression: expression, queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters, token: token).ConfigureAwait(false);
+	public async Task CreateAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
+		=> await _dbSet.AddRangeAsync(entities, cancellationToken).ConfigureAwait(false);
 
 	/// <inheritdoc/>
 	public void Delete(TEntity entity)
-		=> DbSet.Remove(entity);
+		=> _dbSet.Remove(entity);
 
 	/// <inheritdoc/>
 	public void Delete(IEnumerable<TEntity> entities)
-		=> DbSet.RemoveRange(entities);
+		=> _dbSet.RemoveRange(entities);
 
 	/// <inheritdoc/>
 	public int Delete(Expression<Func<TEntity, bool>> expression)
-		=> PrepareQuery(expression).ExecuteDelete();
+		=> _dbSet.Where(expression).ExecuteDelete();
 
 	/// <inheritdoc/>
-	public Task DeleteAsync(TEntity entity, CancellationToken token = default)
+	public Task DeleteAsync(TEntity entity, CancellationToken cancellationToken = default)
 	{
-		if (token.IsCancellationRequested)
-			return Task.FromCanceled(token);
+		if (cancellationToken.IsCancellationRequested)
+			return Task.FromCanceled(cancellationToken);
 
-		DbSet.Remove(entity);
+		_ = _dbSet.Remove(entity);
 
 		return Task.CompletedTask;
 	}
 
 	/// <inheritdoc/>
-	public Task DeleteAsync(IEnumerable<TEntity> entities, CancellationToken token = default)
+	public Task DeleteAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
 	{
-		if (token.IsCancellationRequested)
-			return Task.FromCanceled(token);
+		if (cancellationToken.IsCancellationRequested)
+			return Task.FromCanceled(cancellationToken);
 
-		DbSet.RemoveRange(entities);
+		_dbSet.RemoveRange(entities);
 
 		return Task.CompletedTask;
 	}
 
 	/// <inheritdoc/>
-	public async Task<int> DeleteAsync(Expression<Func<TEntity, bool>> expression, CancellationToken token = default)
-		=> await PrepareQuery(expression).ExecuteDeleteAsync(token).ConfigureAwait(false);
+	public async Task<int> DeleteAsync(Expression<Func<TEntity, bool>> expression, CancellationToken cancellationToken = default)
+		=> await _dbSet.Where(expression).ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
 
 	/// <inheritdoc/>
-	public IReadOnlyList<TEntity> GetAll(bool ignoreQueryFilters = false, bool trackChanges = false)
-		=> QueryMany(ignoreQueryFilters: ignoreQueryFilters, trackChanges: trackChanges);
+	public int Count(Query<TEntity>? query = null)
+		=> PrepareQuery(query, forCount: true).Count();
 
 	/// <inheritdoc/>
-	public IReadOnlyList<TResult> GetAll<TResult>(Expression<Func<TEntity, TResult>> selector, Expression<Func<TResult, TResult>>? fieldSelector = null, bool ignoreQueryFilters = false)
-		=> QueryMany(selector: selector, fieldSelector: fieldSelector, ignoreQueryFilters: ignoreQueryFilters);
+	public async Task<int> CountAsync(Query<TEntity>? query = null, CancellationToken cancellationToken = default)
+		=> await PrepareQuery(query, forCount: true).CountAsync(cancellationToken).ConfigureAwait(false);
 
 	/// <inheritdoc/>
-	public async Task<IReadOnlyList<TEntity>> GetAllAsync(bool ignoreQueryFilters = false, bool trackChanges = false, CancellationToken token = default)
-		=> await QueryManyAsync(ignoreQueryFilters: ignoreQueryFilters, trackChanges: trackChanges, token: token).ConfigureAwait(false);
+	public TEntity? GetSingle(Query<TEntity>? query = null)
+		=> PrepareQuery(query).SingleOrDefault();
 
 	/// <inheritdoc/>
-	public async Task<IReadOnlyList<TResult>> GetAllAsync<TResult>(Expression<Func<TEntity, TResult>> selector, Expression<Func<TResult, TResult>>? fieldSelector = null, bool ignoreQueryFilters = false, CancellationToken token = default)
-		=> await QueryManyAsync(selector: selector, fieldSelector: fieldSelector, ignoreQueryFilters: ignoreQueryFilters, token: token).ConfigureAwait(false);
+	public TResult? GetSingle<TResult>(Expression<Func<TEntity, TResult>> selector, Query<TEntity>? query = null)
+		=> ApplyProjection(PrepareQuery(query), selector).SingleOrDefault();
 
 	/// <inheritdoc/>
-	public TEntity? GetByCondition(Func<IQueryable<TEntity>, IQueryable<TEntity>> queryFilter, bool ignoreQueryFilters = false, bool trackChanges = false, params string[] includeProperties)
-		=> QuerySingle(queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters, trackChanges: trackChanges, includeProperties: includeProperties);
+	public async Task<TEntity?> GetSingleAsync(Query<TEntity>? query = null, CancellationToken cancellationToken = default)
+		=> await PrepareQuery(query).SingleOrDefaultAsync(cancellationToken).ConfigureAwait(false);
 
 	/// <inheritdoc/>
-	public TEntity? GetByCondition(Expression<Func<TEntity, bool>> expression, Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null, bool ignoreQueryFilters = false, bool trackChanges = false, params string[] includeProperties)
-		=> QuerySingle(expression: expression, queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters, trackChanges: trackChanges, includeProperties: includeProperties);
+	public async Task<TResult?> GetSingleAsync<TResult>(Expression<Func<TEntity, TResult>> selector, Query<TEntity>? query = null, CancellationToken cancellationToken = default)
+		=> await ApplyProjection(PrepareQuery(query), selector).SingleOrDefaultAsync(cancellationToken).ConfigureAwait(false);
 
 	/// <inheritdoc/>
-	public TResult? GetByCondition<TResult>(Expression<Func<TEntity, bool>> expression, Expression<Func<TEntity, TResult>> selector, Expression<Func<TResult, TResult>>? fieldSelector = null, Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null, bool ignoreQueryFilters = false)
-		=> QuerySingle(selector: selector, fieldSelector: fieldSelector, expression: expression, queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters);
+	public IReadOnlyList<TEntity> GetList(Query<TEntity>? query = null)
+		=> [.. PrepareQuery(query)];
 
 	/// <inheritdoc/>
-	public async Task<TEntity?> GetByConditionAsync(Func<IQueryable<TEntity>, IQueryable<TEntity>> queryFilter, bool ignoreQueryFilters = false, bool trackChanges = false, CancellationToken token = default, params string[] includeProperties)
-		=> await QuerySingleAsync(queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters, trackChanges: trackChanges, token: token, includeProperties: includeProperties).ConfigureAwait(false);
+	public IReadOnlyList<TResult> GetList<TResult>(Expression<Func<TEntity, TResult>> selector, Query<TEntity>? query = null)
+		=> [.. ApplyProjection(PrepareQuery(query), selector)];
 
 	/// <inheritdoc/>
-	public async Task<TEntity?> GetByConditionAsync(Expression<Func<TEntity, bool>> expression, Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null, bool ignoreQueryFilters = false, bool trackChanges = false, CancellationToken token = default, params string[] includeProperties)
-		=> await QuerySingleAsync(expression: expression, queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters, trackChanges: trackChanges, token: token, includeProperties: includeProperties).ConfigureAwait(false);
+	public async Task<IReadOnlyList<TEntity>> GetListAsync(Query<TEntity>? query = null, CancellationToken cancellationToken = default)
+		=> await PrepareQuery(query).ToListAsync(cancellationToken).ConfigureAwait(false);
 
 	/// <inheritdoc/>
-	public async Task<TResult?> GetByConditionAsync<TResult>(Expression<Func<TEntity, bool>> expression, Expression<Func<TEntity, TResult>> selector, Expression<Func<TResult, TResult>>? fieldSelector = null, Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null, bool ignoreQueryFilters = false, CancellationToken token = default)
-		=> await QuerySingleAsync(selector: selector, fieldSelector: fieldSelector, expression: expression, queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters, token: token).ConfigureAwait(false);
+	public async Task<IReadOnlyList<TResult>> GetListAsync<TResult>(Expression<Func<TEntity, TResult>> selector, Query<TEntity>? query = null, CancellationToken cancellationToken = default)
+		=> await ApplyProjection(PrepareQuery(query), selector).ToListAsync(cancellationToken).ConfigureAwait(false);
 
 	/// <inheritdoc/>
-	public IReadOnlyList<TEntity> GetManyByCondition(Func<IQueryable<TEntity>, IQueryable<TEntity>> queryFilter, bool ignoreQueryFilters = false, Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null, int? skip = null, int? take = null, bool trackChanges = false, params string[] includeProperties)
-		=> QueryMany(queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters, orderBy: orderBy, skip: skip, take: take, trackChanges: trackChanges, includeProperties: includeProperties);
+	public async IAsyncEnumerable<TEntity> Stream(Query<TEntity>? query = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+	{
+		await foreach (TEntity entity in PrepareQuery(query).AsAsyncEnumerable().WithCancellation(cancellationToken).ConfigureAwait(false))
+			yield return entity;
+	}
 
 	/// <inheritdoc/>
-	public IReadOnlyList<TEntity> GetManyByCondition(Expression<Func<TEntity, bool>> expression, Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null, bool ignoreQueryFilters = false, Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null, int? skip = null, int? take = null, bool trackChanges = false, params string[] includeProperties)
-		=> QueryMany(expression: expression, queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters, orderBy: orderBy, skip: skip, take: take, trackChanges: trackChanges, includeProperties: includeProperties);
-
-	/// <inheritdoc/>
-	public IReadOnlyList<TResult> GetManyByCondition<TResult>(Expression<Func<TEntity, bool>> expression, Expression<Func<TEntity, TResult>> selector, Expression<Func<TResult, TResult>>? fieldSelector = null, Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null, bool ignoreQueryFilters = false, Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null, int? skip = null, int? take = null)
-		=> QueryMany(selector: selector, fieldSelector: fieldSelector, expression: expression, queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters, orderBy: orderBy, skip: skip, take: take);
-
-	/// <inheritdoc/>
-	public async Task<IReadOnlyList<TEntity>> GetManyByConditionAsync(Func<IQueryable<TEntity>, IQueryable<TEntity>> queryFilter, bool ignoreQueryFilters = false, Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null, int? skip = null, int? take = null, bool trackChanges = false, CancellationToken token = default, params string[] includeProperties)
-		=> await QueryManyAsync(queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters, orderBy: orderBy, skip: skip, take: take, trackChanges: trackChanges, token: token, includeProperties: includeProperties).ConfigureAwait(false);
-
-	/// <inheritdoc/>
-	public async Task<IReadOnlyList<TEntity>> GetManyByConditionAsync(Expression<Func<TEntity, bool>> expression, Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null, bool ignoreQueryFilters = false, Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null, int? skip = null, int? take = null, bool trackChanges = false, CancellationToken token = default, params string[] includeProperties)
-		=> await QueryManyAsync(expression: expression, queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters, orderBy: orderBy, skip: skip, take: take, trackChanges: trackChanges, token: token, includeProperties: includeProperties).ConfigureAwait(false);
-
-	/// <inheritdoc/>
-	public async Task<IReadOnlyList<TResult>> GetManyByConditionAsync<TResult>(Expression<Func<TEntity, bool>> expression, Expression<Func<TEntity, TResult>> selector, Expression<Func<TResult, TResult>>? fieldSelector = null, Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null, bool ignoreQueryFilters = false, Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null, int? skip = null, int? take = null, CancellationToken token = default)
-		=> await QueryManyAsync(selector: selector, fieldSelector: fieldSelector, expression: expression, queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters, orderBy: orderBy, skip: skip, take: take, token: token).ConfigureAwait(false);
-
-	/// <inheritdoc/>
-	public IAsyncEnumerable<TEntity> StreamAll(bool ignoreQueryFilters = false, bool trackChanges = false, CancellationToken token = default)
-		=> QueryManyStream(ignoreQueryFilters: ignoreQueryFilters, trackChanges: trackChanges, token: token);
-
-	/// <inheritdoc/>
-	public IAsyncEnumerable<TResult> StreamAll<TResult>(Expression<Func<TEntity, TResult>> selector, Expression<Func<TResult, TResult>>? fieldSelector = null, bool ignoreQueryFilters = false, CancellationToken token = default)
-		=> QueryManyStream(selector: selector, fieldSelector: fieldSelector, ignoreQueryFilters: ignoreQueryFilters, token: token);
-
-	/// <inheritdoc/>
-	public IAsyncEnumerable<TEntity> StreamByCondition(Func<IQueryable<TEntity>, IQueryable<TEntity>> queryFilter, bool ignoreQueryFilters = false, Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null, int? skip = null, int? take = null, bool trackChanges = false, CancellationToken token = default, params string[] includeProperties)
-		=> QueryManyStream(queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters, orderBy: orderBy, skip: skip, take: take, trackChanges: trackChanges, token: token, includeProperties: includeProperties);
-
-	/// <inheritdoc/>
-	public IAsyncEnumerable<TEntity> StreamByCondition(Expression<Func<TEntity, bool>> expression, Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null, bool ignoreQueryFilters = false, Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null, int? skip = null, int? take = null, bool trackChanges = false, CancellationToken token = default, params string[] includeProperties)
-		=> QueryManyStream(expression: expression, queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters, orderBy: orderBy, skip: skip, take: take, trackChanges: trackChanges, token: token, includeProperties: includeProperties);
-
-	/// <inheritdoc/>
-	public IAsyncEnumerable<TResult> StreamByCondition<TResult>(Expression<Func<TEntity, bool>> expression, Expression<Func<TEntity, TResult>> selector, Expression<Func<TResult, TResult>>? fieldSelector = null, Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null, bool ignoreQueryFilters = false, Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null, int? skip = null, int? take = null, CancellationToken token = default)
-		=> QueryManyStream(selector: selector, fieldSelector: fieldSelector, expression: expression, queryFilter: queryFilter, ignoreQueryFilters: ignoreQueryFilters, orderBy: orderBy, skip: skip, take: take, token: token);
+	public async IAsyncEnumerable<TResult> Stream<TResult>(Expression<Func<TEntity, TResult>> selector, Query<TEntity>? query = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+	{
+		await foreach (TResult result in ApplyProjection(PrepareQuery(query), selector).AsAsyncEnumerable().WithCancellation(cancellationToken).ConfigureAwait(false))
+			yield return result;
+	}
 
 	/// <inheritdoc/>
 	public void Update(TEntity entity)
-		=> DbSet.Update(entity);
+		=> _dbSet.Update(entity);
 
 	/// <inheritdoc/>
 	public void Update(IEnumerable<TEntity> entities)
-		=> DbSet.UpdateRange(entities);
+		=> _dbSet.UpdateRange(entities);
 
 	/// <inheritdoc/>
 	public int Update(
 		Expression<Func<TEntity, bool>> expression,
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls)
-		=> PrepareQuery(expression).ExecuteUpdate(setPropertyCalls);
+		=> _dbSet.Where(expression).ExecuteUpdate(setPropertyCalls);
 
 	/// <inheritdoc/>
-	public Task UpdateAsync(TEntity entity, CancellationToken token = default)
+	public Task UpdateAsync(TEntity entity, CancellationToken cancellationToken = default)
 	{
-		if (token.IsCancellationRequested)
-			return Task.FromCanceled(token);
+		if (cancellationToken.IsCancellationRequested)
+			return Task.FromCanceled(cancellationToken);
 
-		DbSet.Update(entity);
+		_ = _dbSet.Update(entity);
 
 		return Task.CompletedTask;
 	}
 
 	/// <inheritdoc/>
-	public Task UpdateAsync(IEnumerable<TEntity> entities, CancellationToken token = default)
+	public Task UpdateAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
 	{
-		if (token.IsCancellationRequested)
-			return Task.FromCanceled(token);
+		if (cancellationToken.IsCancellationRequested)
+			return Task.FromCanceled(cancellationToken);
 
-		DbSet.UpdateRange(entities);
+		_dbSet.UpdateRange(entities);
 
 		return Task.CompletedTask;
 	}
@@ -229,429 +171,93 @@ public abstract class GenericRepository<TEntity>(IDbContext dbContext) : IGeneri
 	public async Task<int> UpdateAsync(
 		Expression<Func<TEntity, bool>> expression,
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls,
-		CancellationToken token = default)
-		=> await PrepareQuery(expression).ExecuteUpdateAsync(setPropertyCalls, token).ConfigureAwait(false);
+		CancellationToken cancellationToken = default)
+		=> await _dbSet.Where(expression).ExecuteUpdateAsync(setPropertyCalls, cancellationToken).ConfigureAwait(false);
 
 	/// <summary>
-	/// Counts the <typeparamref name="TEntity"/> instances that match the provided criteria.
-	/// </summary>
-	/// <param name="expression">The condition to fulfill to be counted.</param>
-	/// <param name="queryFilter">The function used to filter the entities.</param>
-	/// <param name="ignoreQueryFilters">Should model-level entity query filters be applied?</param>
-	/// <returns>The total number of matching <typeparamref name="TEntity"/> instances.</returns>
-	protected int QueryCount(
-		Expression<Func<TEntity, bool>>? expression = null,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false)
-	{
-		IQueryable<TEntity> query = PrepareQuery(
-			expression: expression,
-			queryFilter: queryFilter,
-			ignoreQueryFilters: ignoreQueryFilters
-			);
-
-		return query.Count();
-	}
-
-	/// <inheritdoc cref="QueryCount"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	protected async Task<int> QueryCountAsync(
-		Expression<Func<TEntity, bool>>? expression = null,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false,
-		CancellationToken token = default)
-	{
-		IQueryable<TEntity> query = PrepareQuery(
-			expression: expression,
-			queryFilter: queryFilter,
-			ignoreQueryFilters: ignoreQueryFilters
-			);
-
-		return await query.CountAsync(token)
-			.ConfigureAwait(false);
-	}
-
-	/// <summary>
-	/// Returns the single <typeparamref name="TEntity"/> that matches the provided criteria.
-	/// </summary>
-	/// <param name="expression">The condition to fulfill to be returned.</param>
-	/// <param name="queryFilter">The function used to filter the entities.</param>
-	/// <param name="ignoreQueryFilters">Should model-level entity query filters be applied?</param>
-	/// <param name="trackChanges">Should the fetched entity be tracked?</param>
-	/// <param name="includeProperties">Any other navigation properties to include when returning the entity.</param>
-	/// <returns>The found <typeparamref name="TEntity"/> or <see langword="null"/>.</returns>
-	protected TEntity? QuerySingle(
-		Expression<Func<TEntity, bool>>? expression = null,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false,
-		bool trackChanges = false,
-		params string[] includeProperties)
-	{
-		IQueryable<TEntity> query = PrepareQuery(
-			expression: expression,
-			queryFilter: queryFilter,
-			ignoreQueryFilters: ignoreQueryFilters,
-			trackChanges: trackChanges,
-			includeProperties: includeProperties
-			);
-
-		return query.SingleOrDefault();
-	}
-
-	/// <inheritdoc cref="QuerySingle(Expression{Func{TEntity, bool}}, Func{IQueryable{TEntity}, IQueryable{TEntity}}, bool, bool, string[])"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	protected async Task<TEntity?> QuerySingleAsync(
-		Expression<Func<TEntity, bool>>? expression = null,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false,
-		bool trackChanges = false,
-		CancellationToken token = default,
-		params string[] includeProperties)
-	{
-		IQueryable<TEntity> query = PrepareQuery(
-			expression: expression,
-			queryFilter: queryFilter,
-			ignoreQueryFilters: ignoreQueryFilters,
-			trackChanges: trackChanges,
-			includeProperties: includeProperties
-			);
-
-		return await query.SingleOrDefaultAsync(token)
-			.ConfigureAwait(false);
-	}
-
-	/// <summary>
-	/// Returns the single projection of type <typeparamref name="TResult"/> that matches the provided criteria.
-	/// </summary>
-	/// <typeparam name="TResult">The type of the result elements after projection.</typeparam>
-	/// <param name="selector">The expression that defines the projection from the entity to the result type.</param>
-	/// <param name="fieldSelector">The optional expression that further projects the result type.</param>
-	/// <param name="expression">The condition to fulfill to be returned.</param>
-	/// <param name="queryFilter">The function used to filter the entities.</param>
-	/// <param name="ignoreQueryFilters">Should model-level entity query filters be applied?</param>
-	/// <returns>The projected <typeparamref name="TResult"/> or <see langword="null"/>.</returns>
-	protected TResult? QuerySingle<TResult>(
-		Expression<Func<TEntity, TResult>> selector,
-		Expression<Func<TResult, TResult>>? fieldSelector = null,
-		Expression<Func<TEntity, bool>>? expression = null,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false)
-	{
-		IQueryable<TEntity> query = PrepareQuery(
-			expression: expression,
-			queryFilter: queryFilter,
-			ignoreQueryFilters: ignoreQueryFilters
-			);
-
-		return ApplyProjection(query, selector, fieldSelector)
-			.SingleOrDefault();
-	}
-
-	/// <inheritdoc cref="QuerySingle{TResult}(Expression{Func{TEntity, TResult}}, Expression{Func{TResult, TResult}}, Expression{Func{TEntity, bool}}, Func{IQueryable{TEntity}, IQueryable{TEntity}}, bool)"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	protected async Task<TResult?> QuerySingleAsync<TResult>(
-		Expression<Func<TEntity, TResult>> selector,
-		Expression<Func<TResult, TResult>>? fieldSelector = null,
-		Expression<Func<TEntity, bool>>? expression = null,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false,
-		CancellationToken token = default)
-	{
-		IQueryable<TEntity> query = PrepareQuery(
-			expression: expression,
-			queryFilter: queryFilter,
-			ignoreQueryFilters: ignoreQueryFilters
-			);
-
-		return await ApplyProjection(query, selector, fieldSelector)
-			.SingleOrDefaultAsync(token)
-			.ConfigureAwait(false);
-	}
-
-	/// <summary>
-	/// Returns the collection of <typeparamref name="TEntity"/> that matches the provided criteria.
-	/// </summary>
-	/// <param name="expression">The condition to fulfill to be returned.</param>
-	/// <param name="queryFilter">The function used to filter the entities.</param>
-	/// <param name="ignoreQueryFilters">Should model-level entity query filters be applied?</param>
-	/// <param name="orderBy">The function used to order the entities.</param>
-	/// <param name="skip">The number of records to skip.</param>
-	/// <param name="take">The number of records to limit the results to.</param>
-	/// <param name="trackChanges">Should the fetched entities be tracked?</param>
-	/// <param name="includeProperties">Any other navigation properties to include when returning the collection.</param>
-	/// <returns>A collection of <typeparamref name="TEntity"/>.</returns>
-	protected IReadOnlyList<TEntity> QueryMany(
-		Expression<Func<TEntity, bool>>? expression = null,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false,
-		Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
-		int? skip = null,
-		int? take = null,
-		bool trackChanges = false,
-		params string[] includeProperties)
-	{
-		IQueryable<TEntity> query = PrepareQuery(
-			expression: expression,
-			queryFilter: queryFilter,
-			ignoreQueryFilters: ignoreQueryFilters,
-			orderBy: orderBy,
-			skip: skip,
-			take: take,
-			trackChanges: trackChanges,
-			includeProperties: includeProperties
-			);
-
-		return [.. query];
-	}
-
-	/// <inheritdoc cref="QueryMany(Expression{Func{TEntity, bool}}, Func{IQueryable{TEntity}, IQueryable{TEntity}}, bool, Func{IQueryable{TEntity}, IOrderedQueryable{TEntity}}, int?, int?, bool, string[])"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	protected async Task<IReadOnlyList<TEntity>> QueryManyAsync(
-		Expression<Func<TEntity, bool>>? expression = null,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false,
-		Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
-		int? skip = null,
-		int? take = null,
-		bool trackChanges = false,
-		CancellationToken token = default,
-		params string[] includeProperties)
-	{
-		IQueryable<TEntity> query = PrepareQuery(
-			expression: expression,
-			queryFilter: queryFilter,
-			ignoreQueryFilters: ignoreQueryFilters,
-			orderBy: orderBy,
-			skip: skip,
-			take: take,
-			trackChanges: trackChanges,
-			includeProperties: includeProperties
-			);
-
-		return await query.ToListAsync(token)
-			.ConfigureAwait(false);
-	}
-
-	/// <summary>
-	/// Returns the collection of <typeparamref name="TResult"/> projections that match the provided criteria.
-	/// </summary>
-	/// <typeparam name="TResult">The type of the result elements after projection.</typeparam>
-	/// <param name="selector">The expression that defines the projection from the entity to the result type.</param>
-	/// <param name="fieldSelector">The optional expression that further projects the result type.</param>
-	/// <param name="expression">The condition to fulfill to be returned.</param>
-	/// <param name="queryFilter">The function used to filter the entities.</param>
-	/// <param name="ignoreQueryFilters">Should model-level entity query filters be applied?</param>
-	/// <param name="orderBy">The function used to order the entities.</param>
-	/// <param name="skip">The number of records to skip.</param>
-	/// <param name="take">The number of records to limit the results to.</param>
-	/// <returns>A collection of <typeparamref name="TResult"/>.</returns>
-	protected IReadOnlyList<TResult> QueryMany<TResult>(
-		Expression<Func<TEntity, TResult>> selector,
-		Expression<Func<TResult, TResult>>? fieldSelector = null,
-		Expression<Func<TEntity, bool>>? expression = null,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false,
-		Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
-		int? skip = null,
-		int? take = null)
-	{
-		IQueryable<TEntity> query = PrepareQuery(
-			expression: expression,
-			queryFilter: queryFilter,
-			ignoreQueryFilters: ignoreQueryFilters,
-			orderBy: orderBy,
-			skip: skip,
-			take: take
-			);
-
-		return [.. ApplyProjection(query, selector, fieldSelector)];
-	}
-
-	/// <inheritdoc cref="QueryMany{TResult}(Expression{Func{TEntity, TResult}}, Expression{Func{TResult, TResult}}, Expression{Func{TEntity, bool}}, Func{IQueryable{TEntity}, IQueryable{TEntity}}, bool, Func{IQueryable{TEntity}, IOrderedQueryable{TEntity}}, int?, int?)"/>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	protected async Task<IReadOnlyList<TResult>> QueryManyAsync<TResult>(
-		Expression<Func<TEntity, TResult>> selector,
-		Expression<Func<TResult, TResult>>? fieldSelector = null,
-		Expression<Func<TEntity, bool>>? expression = null,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false,
-		Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
-		int? skip = null,
-		int? take = null,
-		CancellationToken token = default)
-	{
-		IQueryable<TEntity> query = PrepareQuery(
-			expression: expression,
-			queryFilter: queryFilter,
-			ignoreQueryFilters: ignoreQueryFilters,
-			orderBy: orderBy,
-			skip: skip,
-			take: take
-			);
-
-		return await ApplyProjection(query, selector, fieldSelector)
-			.ToListAsync(token)
-			.ConfigureAwait(false);
-	}
-
-	/// <summary>
-	/// Streams the collection of <typeparamref name="TEntity"/> that matches the provided criteria.
+	/// Composes the <see cref="IQueryable{TEntity}"/> described by the specified
+	/// <paramref name="query"/>.
 	/// </summary>
 	/// <remarks>
-	/// The result set is not buffered, the entities are yielded as they are read from the database.
-	/// The returned sequence is lazy and must be enumerated within the lifetime of the underlying
-	/// database context.
+	/// The single place where a <see cref="Query{TEntity}"/> is turned into a query. Use it
+	/// when building a repository method the interface does not cover.
 	/// </remarks>
-	/// <param name="expression">The condition to fulfill to be returned.</param>
-	/// <param name="queryFilter">The function used to filter the entities.</param>
-	/// <param name="ignoreQueryFilters">Should model-level entity query filters be applied?</param>
-	/// <param name="orderBy">The function used to order the entities.</param>
-	/// <param name="skip">The number of records to skip.</param>
-	/// <param name="take">The number of records to limit the results to.</param>
-	/// <param name="trackChanges">Should the fetched entities be tracked?</param>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	/// <param name="includeProperties">Any other navigation properties to include when returning the collection.</param>
-	/// <returns>An asynchronous sequence of <typeparamref name="TEntity"/>.</returns>
-	protected async IAsyncEnumerable<TEntity> QueryManyStream(
-		Expression<Func<TEntity, bool>>? expression = null,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false,
-		Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
-		int? skip = null,
-		int? take = null,
-		bool trackChanges = false,
-		[EnumeratorCancellation] CancellationToken token = default,
-		params string[] includeProperties)
-	{
-		IQueryable<TEntity> query = PrepareQuery(
-			expression: expression,
-			queryFilter: queryFilter,
-			ignoreQueryFilters: ignoreQueryFilters,
-			orderBy: orderBy,
-			skip: skip,
-			take: take,
-			trackChanges: trackChanges,
-			includeProperties: includeProperties
-			);
-
-		await foreach (TEntity entity in query.AsAsyncEnumerable().WithCancellation(token).ConfigureAwait(false))
-			yield return entity;
-	}
-
-	/// <summary>
-	/// Streams the collection of <typeparamref name="TResult"/> projections that match the provided criteria.
-	/// </summary>
-	/// <remarks>
-	/// The result set is not buffered, the projections are yielded as they are read from the database.
-	/// The returned sequence is lazy and must be enumerated within the lifetime of the underlying
-	/// database context.
-	/// </remarks>
-	/// <typeparam name="TResult">The type of the result elements after projection.</typeparam>
-	/// <param name="selector">The expression that defines the projection from the entity to the result type.</param>
-	/// <param name="fieldSelector">The optional expression that further projects the result type.</param>
-	/// <param name="expression">The condition to fulfill to be returned.</param>
-	/// <param name="queryFilter">The function used to filter the entities.</param>
-	/// <param name="ignoreQueryFilters">Should model-level entity query filters be applied?</param>
-	/// <param name="orderBy">The function used to order the entities.</param>
-	/// <param name="skip">The number of records to skip.</param>
-	/// <param name="take">The number of records to limit the results to.</param>
-	/// <param name="token">The cancellation token to cancel the request.</param>
-	/// <returns>An asynchronous sequence of <typeparamref name="TResult"/>.</returns>
-	protected async IAsyncEnumerable<TResult> QueryManyStream<TResult>(
-		Expression<Func<TEntity, TResult>> selector,
-		Expression<Func<TResult, TResult>>? fieldSelector = null,
-		Expression<Func<TEntity, bool>>? expression = null,
-		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null,
-		bool ignoreQueryFilters = false,
-		Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
-		int? skip = null,
-		int? take = null,
-		[EnumeratorCancellation] CancellationToken token = default)
-	{
-		IQueryable<TEntity> query = PrepareQuery(
-			expression: expression,
-			queryFilter: queryFilter,
-			ignoreQueryFilters: ignoreQueryFilters,
-			orderBy: orderBy,
-			skip: skip,
-			take: take
-			);
-
-		await foreach (TResult result in ApplyProjection(query, selector, fieldSelector).AsAsyncEnumerable().WithCancellation(token).ConfigureAwait(false))
-			yield return result;
-	}
-
-	/// <summary>
-	/// Prepares the <see cref="IQueryable"/> of type <typeparamref name="TEntity"/> before it gets executed.
-	/// </summary>
-	/// <param name="expression">The condition to fulfill to be returned.</param>
-	/// <param name="queryFilter">The function used to filter the entities.</param>
-	/// <param name="ignoreQueryFilters">Should model-level entity query filters be applied?</param>
-	/// <param name="orderBy">The function used to order the entities.</param>
-	/// <param name="take">The number of records to limit the results to.</param>
-	/// <param name="skip">The number of records to skip.</param>
-	/// <param name="trackChanges">Should the fetched entities be tracked?</param>
-	/// <param name="includeProperties">Any other navigation properties to include when returning the collection.</param>
-	/// <returns>A <see cref="IQueryable"/> of type <typeparamref name="TEntity"/>.</returns>
-	protected IQueryable<TEntity> PrepareQuery(Expression<Func<TEntity, bool>>? expression = null, Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = null, bool ignoreQueryFilters = false, Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null, int? skip = null, int? take = null, bool trackChanges = false, params string[] includeProperties)
-	{
-		IQueryable<TEntity> query = !trackChanges ? DbSet.AsNoTracking() : DbSet;
-
-		if (expression is not null)
-			query = query.Where(expression);
-
-		if (queryFilter is not null)
-			query = queryFilter(query);
-
-		if (ignoreQueryFilters)
-			query = query.IgnoreQueryFilters();
-
-		if (includeProperties.Length > 0)
-			query = includeProperties.Aggregate(query, (theQuery, theInclude) => theQuery.Include(theInclude));
-
-		if (orderBy is not null)
-			query = orderBy(query);
-
-		if (skip.HasValue)
-			query = query.Skip(skip.Value);
-
-		if (take.HasValue)
-			query = query.Take(take.Value);
-
-		return query;
-	}
-
-	/// <summary>
-	/// Projects the elements of the source query to a new form using the specified selector, and optionally
-	/// applies a secondary projection to the result.
-	/// </summary>
-	/// <remarks>
-	/// Use this method to perform flexible projections on a query, allowing for both an initial and an optional
-	/// secondary transformation. This can be useful when you need to shape the result set dynamically based on
-	/// additional criteria.
-	/// </remarks>
-	/// <typeparam name="TResult">The type of the result elements after projection.</typeparam>
-	/// <param name="query">The source query containing the elements to project.</param>
-	/// <param name="selector">
-	/// An expression that defines the initial projection from the source entity to the result type.
+	/// <param name="query">The query to apply. Applies nothing when omitted.</param>
+	/// <param name="forCount">
+	/// Whether the query is being composed for a count, in which case the options that cannot
+	/// change how many rows match are skipped.
 	/// </param>
-	/// <param name="fieldSelector">
-	/// An optional expression that further projects the result type. If provided, it is applied to each element
-	/// after the initial projection.
-	/// </param>
-	/// <returns>
-	/// An IQueryable containing the projected elements, optionally further transformed by the secondary selector.
-	/// </returns>
+	/// <returns>The composed query.</returns>
+	protected IQueryable<TEntity> PrepareQuery(Query<TEntity>? query, bool forCount = false)
+	{
+		IQueryable<TEntity> queryable = query?.TrackChanges == true && !forCount
+			? _dbSet
+			: _dbSet.AsNoTracking();
+
+		if (query is null)
+			return queryable;
+
+		if (query.Where is not null)
+			queryable = queryable.Where(query.Where);
+
+		if (query.QueryFilter is not null)
+			queryable = query.QueryFilter(queryable);
+
+		if (query.IgnoreQueryFilters)
+			queryable = queryable.IgnoreQueryFilters();
+
+		// Ordering, paging and includes cannot change how many rows match, and an ORDER BY
+		// without a paging clause is invalid inside a count on some providers.
+		if (forCount)
+			return queryable;
+
+		if (query.Include is not null)
+			queryable = query.Include.Aggregate(queryable, (current, include) => current.Include(include));
+
+		if (query.OrderBy is not null)
+			queryable = query.OrderBy(queryable);
+
+		if (query.Skip.HasValue)
+			queryable = queryable.Skip(query.Skip.Value);
+
+		if (query.Take.HasValue)
+			queryable = queryable.Take(query.Take.Value);
+
+		return queryable;
+	}
+
+	/// <summary>
+	/// Projects the elements of the source query into <typeparamref name="TResult"/>.
+	/// </summary>
+	/// <typeparam name="TResult">The type to project into.</typeparam>
+	/// <param name="query">The query to project.</param>
+	/// <param name="selector">The projection to apply.</param>
+	/// <returns>The projected query.</returns>
 	protected static IQueryable<TResult> ApplyProjection<TResult>(
 		IQueryable<TEntity> query,
-		Expression<Func<TEntity, TResult>> selector,
-		Expression<Func<TResult, TResult>>? fieldSelector)
+		Expression<Func<TEntity, TResult>> selector)
+		=> query.Select(selector);
+
+	/// <summary>
+	/// Returns the specified <paramref name="query"/> with an additional condition applied.
+	/// </summary>
+	/// <remarks>
+	/// The condition is appended rather than replacing anything, so a caller supplied
+	/// <see cref="Query{TEntity}.Where"/> keeps applying alongside it. Used by the derived
+	/// repositories to add their key or name condition.
+	/// </remarks>
+	/// <param name="query">The query to extend.</param>
+	/// <param name="condition">The condition to add.</param>
+	/// <returns>The extended query.</returns>
+	protected static Query<TEntity> WithCondition(Query<TEntity>? query, Expression<Func<TEntity, bool>> condition)
 	{
-		IQueryable<TResult> projected = query.Select(selector);
+		Func<IQueryable<TEntity>, IQueryable<TEntity>>? queryFilter = query?.QueryFilter;
 
-		if (fieldSelector is not null)
-			projected = projected.Select(fieldSelector);
-
-		return projected;
+		return (query ?? new Query<TEntity>()) with
+		{
+			QueryFilter = queryFilter is null
+				? source => source.Where(condition)
+				: source => queryFilter(source).Where(condition)
+		};
 	}
 }

--- a/src/BB84.EntityFrameworkCore.Repositories/IdentityRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/IdentityRepository.cs
@@ -1,4 +1,4 @@
-// Copyright: 2024 Robert Peter Meyer
+﻿// Copyright: 2024 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -36,44 +36,44 @@ public abstract class IdentityRepository<TEntity, TKey>(IDbContext dbContext) : 
 		=> Delete(ByIds(ids));
 
 	/// <inheritdoc/>
-	public async Task<int> DeleteAsync(TKey id, CancellationToken token = default)
-		=> await DeleteAsync(ById(id), token).ConfigureAwait(false);
+	public async Task<int> DeleteAsync(TKey id, CancellationToken cancellationToken = default)
+		=> await DeleteAsync(ById(id), cancellationToken).ConfigureAwait(false);
 
 	/// <inheritdoc/>
-	public async Task<int> DeleteAsync(IEnumerable<TKey> ids, CancellationToken token = default)
-		=> await DeleteAsync(ByIds(ids), token).ConfigureAwait(false);
+	public async Task<int> DeleteAsync(IEnumerable<TKey> ids, CancellationToken cancellationToken = default)
+		=> await DeleteAsync(ByIds(ids), cancellationToken).ConfigureAwait(false);
 
 	/// <inheritdoc/>
-	public TEntity? GetById(TKey id, bool ignoreQueryFilters = false, bool trackChanges = false, params string[] includeProperties)
-		=> QuerySingle(expression: ById(id), ignoreQueryFilters: ignoreQueryFilters, trackChanges: trackChanges, includeProperties: includeProperties);
+	public TEntity? GetById(TKey id, Query<TEntity>? query = null)
+		=> GetSingle(WithCondition(query, ById(id)));
 
 	/// <inheritdoc/>
-	public TResult? GetById<TResult>(TKey id, Expression<Func<TEntity, TResult>> selector, Expression<Func<TResult, TResult>>? fieldSelector = null, bool ignoreQueryFilters = false)
-		=> QuerySingle(selector: selector, fieldSelector: fieldSelector, expression: ById(id), ignoreQueryFilters: ignoreQueryFilters);
+	public TResult? GetById<TResult>(TKey id, Expression<Func<TEntity, TResult>> selector, Query<TEntity>? query = null)
+		=> GetSingle(selector, WithCondition(query, ById(id)));
 
 	/// <inheritdoc/>
-	public async Task<TEntity?> GetByIdAsync(TKey id, bool ignoreQueryFilters = false, bool trackChanges = false, CancellationToken token = default, params string[] includeProperties)
-		=> await QuerySingleAsync(expression: ById(id), ignoreQueryFilters: ignoreQueryFilters, trackChanges: trackChanges, token: token, includeProperties: includeProperties).ConfigureAwait(false);
+	public async Task<TEntity?> GetByIdAsync(TKey id, Query<TEntity>? query = null, CancellationToken cancellationToken = default)
+		=> await GetSingleAsync(WithCondition(query, ById(id)), cancellationToken).ConfigureAwait(false);
 
 	/// <inheritdoc/>
-	public async Task<TResult?> GetByIdAsync<TResult>(TKey id, Expression<Func<TEntity, TResult>> selector, Expression<Func<TResult, TResult>>? fieldSelector = null, bool ignoreQueryFilters = false, CancellationToken token = default)
-		=> await QuerySingleAsync(selector: selector, fieldSelector: fieldSelector, expression: ById(id), ignoreQueryFilters: ignoreQueryFilters, token: token).ConfigureAwait(false);
+	public async Task<TResult?> GetByIdAsync<TResult>(TKey id, Expression<Func<TEntity, TResult>> selector, Query<TEntity>? query = null, CancellationToken cancellationToken = default)
+		=> await GetSingleAsync(selector, WithCondition(query, ById(id)), cancellationToken).ConfigureAwait(false);
 
 	/// <inheritdoc/>
-	public IReadOnlyList<TEntity> GetByIds(IEnumerable<TKey> ids, bool ignoreQueryFilters = false, bool trackChanges = false, params string[] includeProperties)
-		=> QueryMany(expression: ByIds(ids), ignoreQueryFilters: ignoreQueryFilters, trackChanges: trackChanges, includeProperties: includeProperties);
+	public IReadOnlyList<TEntity> GetByIds(IEnumerable<TKey> ids, Query<TEntity>? query = null)
+		=> GetList(WithCondition(query, ByIds(ids)));
 
 	/// <inheritdoc/>
-	public IReadOnlyList<TResult> GetByIds<TResult>(IEnumerable<TKey> ids, Expression<Func<TEntity, TResult>> selector, Expression<Func<TResult, TResult>>? fieldSelector = null, bool ignoreQueryFilters = false)
-		=> QueryMany(selector: selector, fieldSelector: fieldSelector, expression: ByIds(ids), ignoreQueryFilters: ignoreQueryFilters);
+	public IReadOnlyList<TResult> GetByIds<TResult>(IEnumerable<TKey> ids, Expression<Func<TEntity, TResult>> selector, Query<TEntity>? query = null)
+		=> GetList(selector, WithCondition(query, ByIds(ids)));
 
 	/// <inheritdoc/>
-	public async Task<IReadOnlyList<TEntity>> GetByIdsAsync(IEnumerable<TKey> ids, bool ignoreQueryFilters = false, bool trackChanges = false, CancellationToken token = default, params string[] includeProperties)
-		=> await QueryManyAsync(expression: ByIds(ids), ignoreQueryFilters: ignoreQueryFilters, trackChanges: trackChanges, token: token, includeProperties: includeProperties).ConfigureAwait(false);
+	public async Task<IReadOnlyList<TEntity>> GetByIdsAsync(IEnumerable<TKey> ids, Query<TEntity>? query = null, CancellationToken cancellationToken = default)
+		=> await GetListAsync(WithCondition(query, ByIds(ids)), cancellationToken).ConfigureAwait(false);
 
 	/// <inheritdoc/>
-	public async Task<IReadOnlyList<TResult>> GetByIdsAsync<TResult>(IEnumerable<TKey> ids, Expression<Func<TEntity, TResult>> selector, Expression<Func<TResult, TResult>>? fieldSelector = null, bool ignoreQueryFilters = false, CancellationToken token = default)
-		=> await QueryManyAsync(selector: selector, fieldSelector: fieldSelector, expression: ByIds(ids), ignoreQueryFilters: ignoreQueryFilters, token: token).ConfigureAwait(false);
+	public async Task<IReadOnlyList<TResult>> GetByIdsAsync<TResult>(IEnumerable<TKey> ids, Expression<Func<TEntity, TResult>> selector, Query<TEntity>? query = null, CancellationToken cancellationToken = default)
+		=> await GetListAsync(selector, WithCondition(query, ByIds(ids)), cancellationToken).ConfigureAwait(false);
 
 	/// <inheritdoc/>
 	public int Update(
@@ -91,15 +91,15 @@ public abstract class IdentityRepository<TEntity, TKey>(IDbContext dbContext) : 
 	public async Task<int> UpdateAsync(
 		TKey id,
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls,
-		CancellationToken token = default)
-		=> await UpdateAsync(ById(id), setPropertyCalls, token).ConfigureAwait(false);
+		CancellationToken cancellationToken = default)
+		=> await UpdateAsync(ById(id), setPropertyCalls, cancellationToken).ConfigureAwait(false);
 
 	/// <inheritdoc/>
 	public async Task<int> UpdateAsync(
 		IEnumerable<TKey> ids,
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls,
-		CancellationToken token = default)
-		=> await UpdateAsync(ByIds(ids), setPropertyCalls, token).ConfigureAwait(false);
+		CancellationToken cancellationToken = default)
+		=> await UpdateAsync(ByIds(ids), setPropertyCalls, cancellationToken).ConfigureAwait(false);
 
 	/// <summary>
 	/// Returns the condition that matches the <typeparamref name="TEntity"/> with the provided <paramref name="id"/>.

--- a/src/BB84.EntityFrameworkCore.Repositories/README.md
+++ b/src/BB84.EntityFrameworkCore.Repositories/README.md
@@ -1,4 +1,4 @@
-[![net100](https://img.shields.io/badge/net10.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
+﻿[![net100](https://img.shields.io/badge/net10.0-5C2D91?logo=.NET&labelColor=gray)](https://github.com/BoBoBaSs84/BB84.Extensions)
 [![NuGet](https://img.shields.io/nuget/v/BB84.EntityFrameworkCore.Repositories.svg?logo=nuget&logoColor=white)](https://www.nuget.org/packages/BB84.EntityFrameworkCore.Repositories)
 
 # BB84.EntityFrameworkCore.Repositories
@@ -19,28 +19,34 @@ dotnet add package BB84.EntityFrameworkCore.Repositories
 
 ### `GenericRepository<TEntity>`
 
-Abstract base for all repositories. Accepts `IDbContext` as a constructor parameter. All query methods delegate to `PrepareQuery(...)`, which composes `Where`, `IgnoreQueryFilters`, `Include`, `OrderBy`, `Skip`, `Take`, and `AsNoTracking` into a single `IQueryable<TEntity>`. Projection overloads use the protected `ApplyProjection(query, selector, fieldSelector)` helper.
+Abstract base for all repositories. Accepts `IDbContext` as a constructor parameter. Every read method takes a single `Query<TEntity>` and delegates to the protected `PrepareQuery(query, forCount)`, which composes `Where`, `QueryFilter`, `IgnoreQueryFilters`, `Include`, `OrderBy`, `Skip`, `Take` and `AsNoTracking` into one `IQueryable<TEntity>`. Projections go through the protected `ApplyProjection(query, selector)`.
+
+Two protected helpers are worth knowing when writing a repository method the interface does not cover:
+
+- `PrepareQuery(query, forCount)` — the single place a `Query<TEntity>` becomes a query. Pass `forCount: true` to skip the options that cannot change how many rows match.
+- `WithCondition(query, condition)` — appends a condition to a query without discarding what the caller already set. This is how `GetById` and `GetByName` add their key or name filter.
 
 #### Streaming reads
 
-`StreamAll` and `StreamByCondition` return `IAsyncEnumerable<T>` instead of `IReadOnlyList<T>`. They take the same parameters as their `GetAllAsync` / `GetManyByConditionAsync` counterparts and go through the same `PrepareQuery(...)` composition, but the result set is not buffered — rows are yielded as they arrive. Use them for exports, batch jobs and other unbounded reads:
+`Stream` returns `IAsyncEnumerable<T>` instead of `IReadOnlyList<T>`. It takes the same `Query<TEntity>` as `GetListAsync` and goes through the same composition, but the result set is not buffered — rows are yielded as they arrive. Use it for exports, batch jobs and other unbounded reads:
 
 ```csharp
-await foreach (Product product in repository.StreamByCondition(
-    p => p.IsActive,
-    orderBy: q => q.OrderBy(p => p.Name),
-    token: token))
+await foreach (Product product in repository.Stream(
+    new()
+    {
+        Where = p => p.IsActive,
+        OrderBy = q => q.OrderBy(p => p.Name),
+    },
+    cancellationToken))
 {
-    await writer.WriteAsync(product, token);
+    await writer.WriteAsync(product, cancellationToken);
 }
 ```
 
 Two things to keep in mind:
 
 - The sequence is lazy. It must be enumerated within the lifetime of the `IDbContext`, and EF Core allows only one active stream per context at a time.
-- `trackChanges` defaults to `false` and should stay that way for large reads — with tracking enabled the change tracker grows with every yielded entity, which defeats the purpose of streaming.
-
-Subclasses can build their own streaming methods on the `protected QueryManyStream(...)` helpers, which mirror `QueryMany` / `QueryManyAsync` in both the entity and the projection flavour.
+- `TrackChanges` defaults to `false` and should stay that way for large reads — with tracking enabled the change tracker grows with every yielded entity, which defeats the purpose of streaming.
 
 ### `IdentityRepository<TEntity, TKey>` / `IdentityRepository<TEntity>`
 
@@ -60,11 +66,14 @@ public class ProductRepository : IdentityRepository<Product>, IProductRepository
     public ProductRepository(IDbContext dbContext) : base(dbContext) { }
 
     public async Task<IReadOnlyList<Product>> GetByCategoryAsync(
-        int categoryId, CancellationToken token = default)
-        => await GetManyByConditionAsync(
-            p => p.CategoryId == categoryId,
-            orderBy: q => q.OrderBy(p => p.Name),
-            token: token);
+        int categoryId, CancellationToken cancellationToken = default)
+        => await GetListAsync(
+            new()
+            {
+                Where = p => p.CategoryId == categoryId,
+                OrderBy = q => q.OrderBy(p => p.Name),
+            },
+            cancellationToken);
 }
 
 public class CategoryRepository : EnumeratorRepository<ProductCategory>, ICategoryRepository
@@ -85,7 +94,7 @@ Calling save changes is the responsibility of the caller (unit-of-work pattern):
 
 ```csharp
 repository.Create(entity);
-await dbContext.SaveChangesAsync(token);
+await dbContext.SaveChangesAsync(cancellationToken);
 ```
 
 ## Configuration base classes

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonJobTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonJobTests.cs
@@ -61,7 +61,7 @@ public sealed class PersonJobTests : UnitTestBase
 	{
 		PersonJobRepository repository = new(DbContext);
 
-		int count = repository.CountAll(false);
+		int count = repository.Count();
 
 		Assert.AreEqual(0, count);
 	}
@@ -71,7 +71,7 @@ public sealed class PersonJobTests : UnitTestBase
 	{
 		PersonJobRepository repository = new(DbContext);
 
-		int count = repository.CountByCondition(x => x.PersonId.Equals(Guid.Empty));
+		int count = repository.Count(new() { Where = x => x.PersonId.Equals(Guid.Empty) });
 
 		Assert.AreEqual(0, count);
 	}
@@ -81,7 +81,7 @@ public sealed class PersonJobTests : UnitTestBase
 	{
 		PersonJobRepository repository = new(DbContext);
 
-		int count = await repository.CountAllAsync(false)
+		int count = await repository.CountAsync()
 			.ConfigureAwait(false);
 
 		Assert.AreEqual(0, count);
@@ -92,7 +92,7 @@ public sealed class PersonJobTests : UnitTestBase
 	{
 		PersonJobRepository repository = new(DbContext);
 
-		int count = await repository.CountByConditionAsync(expression: x => x.PersonId.Equals(Guid.Empty))
+		int count = await repository.CountAsync(new() { Where = x => x.PersonId.Equals(Guid.Empty) })
 			.ConfigureAwait(false);
 
 		Assert.AreEqual(0, count);

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonTests.cs
@@ -101,7 +101,7 @@ public sealed class PersonTests : UnitTestBase
 	{
 		PersonRepository repository = new(DbContext);
 
-		IEnumerable<PersonEntity> persons = repository.GetAll(true, true);
+		IEnumerable<PersonEntity> persons = repository.GetList(new() { IgnoreQueryFilters = true, TrackChanges = true });
 
 		Assert.IsFalse(persons.Any());
 	}
@@ -111,7 +111,7 @@ public sealed class PersonTests : UnitTestBase
 	{
 		PersonRepository repository = new(DbContext);
 
-		IEnumerable<PersonEntity> persons = await repository.GetAllAsync(true, true)
+		IEnumerable<PersonEntity> persons = await repository.GetListAsync(new() { IgnoreQueryFilters = true, TrackChanges = true })
 			.ConfigureAwait(false);
 
 		Assert.IsFalse(persons.Any());
@@ -122,11 +122,14 @@ public sealed class PersonTests : UnitTestBase
 	{
 		PersonRepository repository = new(DbContext);
 
-		IEnumerable<PersonEntity> persons = repository.GetManyByCondition(
-			x => x.Id.Equals(Guid.Empty),
-			x => x.Where(x => x.Id.Equals(Guid.Empty)),
-			false, x => x.OrderBy(x => x.Id), 1, 1, false
-			);
+		IEnumerable<PersonEntity> persons = repository.GetList(new()
+		{
+			Where = x => x.Id.Equals(Guid.Empty),
+			QueryFilter = x => x.Where(x => x.Id.Equals(Guid.Empty)),
+			OrderBy = x => x.OrderBy(x => x.Id),
+			Skip = 1,
+			Take = 1
+		});
 
 		Assert.IsFalse(persons.Any());
 	}
@@ -136,11 +139,14 @@ public sealed class PersonTests : UnitTestBase
 	{
 		PersonRepository repository = new(DbContext);
 
-		IEnumerable<PersonEntity> persons = await repository.GetManyByConditionAsync(
-			x => x.Id.Equals(Guid.Empty),
-			x => x.Where(x => x.Id.Equals(Guid.Empty)),
-			false, x => x.OrderBy(x => x.Id), 1, 1, false
-			).ConfigureAwait(false);
+		IEnumerable<PersonEntity> persons = await repository.GetListAsync(new()
+		{
+			Where = x => x.Id.Equals(Guid.Empty),
+			QueryFilter = x => x.Where(x => x.Id.Equals(Guid.Empty)),
+			OrderBy = x => x.OrderBy(x => x.Id),
+			Skip = 1,
+			Take = 1
+		}).ConfigureAwait(false);
 
 		Assert.IsFalse(persons.Any());
 	}
@@ -151,7 +157,7 @@ public sealed class PersonTests : UnitTestBase
 		PersonRepository repository = new(DbContext);
 		int count = 0;
 
-		await foreach (PersonEntity person in repository.StreamAll(true, true).ConfigureAwait(false))
+		await foreach (PersonEntity person in repository.Stream(new() { IgnoreQueryFilters = true, TrackChanges = true }).ConfigureAwait(false))
 			count++;
 
 		Assert.AreEqual(0, count);
@@ -163,11 +169,14 @@ public sealed class PersonTests : UnitTestBase
 		PersonRepository repository = new(DbContext);
 		int count = 0;
 
-		IAsyncEnumerable<PersonEntity> persons = repository.StreamByCondition(
-			x => x.Id.Equals(Guid.Empty),
-			x => x.Where(x => x.Id.Equals(Guid.Empty)),
-			false, x => x.OrderBy(x => x.Id), 1, 1, false
-			);
+		IAsyncEnumerable<PersonEntity> persons = repository.Stream(new()
+		{
+			Where = x => x.Id.Equals(Guid.Empty),
+			QueryFilter = x => x.Where(x => x.Id.Equals(Guid.Empty)),
+			OrderBy = x => x.OrderBy(x => x.Id),
+			Skip = 1,
+			Take = 1
+		});
 
 		await foreach (PersonEntity person in persons.ConfigureAwait(false))
 			count++;

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonTypeTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonTypeTests.cs
@@ -63,10 +63,11 @@ public sealed class PersonTypeTests : UnitTestBase
 	{
 		PersonRepository repository = new(DbContext);
 
-		PersonEntity? person = repository.GetByCondition(
-			expression: x => x.Id.Equals(Guid.Empty),
-			includeProperties: [nameof(PersonEntity.Type)]
-			);
+		PersonEntity? person = repository.GetSingle(new()
+		{
+			Where = x => x.Id.Equals(Guid.Empty),
+			Include = [x => x.Type]
+		});
 
 		Assert.IsNull(person);
 	}
@@ -76,10 +77,11 @@ public sealed class PersonTypeTests : UnitTestBase
 	{
 		PersonRepository repository = new(DbContext);
 
-		PersonEntity? person = await repository.GetByConditionAsync(
-			expression: x => x.Id.Equals(Guid.Empty),
-			includeProperties: [nameof(PersonEntity.Type)]
-			).ConfigureAwait(false);
+		PersonEntity? person = await repository.GetSingleAsync(new()
+		{
+			Where = x => x.Id.Equals(Guid.Empty),
+			Include = [x => x.Type]
+		}).ConfigureAwait(false);
 
 		Assert.IsNull(person);
 	}
@@ -98,7 +100,7 @@ public sealed class PersonTypeTests : UnitTestBase
 
 		Assert.IsTrue(entity.IsDeleted);
 		Assert.IsNull(repository.GetById(entity.Id));
-		Assert.IsNotNull(repository.GetById(entity.Id, ignoreQueryFilters: true));
+		Assert.IsNotNull(repository.GetById(entity.Id, new() { IgnoreQueryFilters = true }));
 
 		Purge(entity);
 	}
@@ -117,7 +119,7 @@ public sealed class PersonTypeTests : UnitTestBase
 
 		Assert.IsTrue(entity.IsDeleted);
 		Assert.IsNull(await repository.GetByIdAsync(entity.Id));
-		Assert.IsNotNull(await repository.GetByIdAsync(entity.Id, ignoreQueryFilters: true));
+		Assert.IsNotNull(await repository.GetByIdAsync(entity.Id, new() { IgnoreQueryFilters = true }));
 
 		Purge(entity);
 	}

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/RepositoryOverloadTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/RepositoryOverloadTests.cs
@@ -5,6 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 #pragma warning disable CA1866 // Use char overload
 #pragma warning disable CA1847 // Use char literal for a single character lookup
+using BB84.EntityFrameworkCore.Repositories.Abstractions;
 using BB84.EntityFrameworkCore.Repositories.Tests.Persistence;
 using BB84.EntityFrameworkCore.Repositories.Tests.Persistence.Entities;
 using BB84.EntityFrameworkCore.Repositories.Tests.Persistence.Repositories;
@@ -24,22 +25,28 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 		PersonTypeRepository repository = new(DbContext);
 
 		int count = repository
-			.CountByCondition(
-				queryFilter: query => query.Where(x => x.Name.Contains("ale")),
-				ignoreQueryFilters: true);
+			.Count(new()
+			{
+				QueryFilter = query => query.Where(x => x.Name.Contains("ale")),
+				IgnoreQueryFilters = true
+			});
 
 		PersonTypeEntity? single = repository
-			.GetByCondition(
-				queryFilter: query => query.Where(x => x.Name == "Male"),
-				ignoreQueryFilters: true);
+			.GetSingle(new()
+			{
+				QueryFilter = query => query.Where(x => x.Name == "Male"),
+				IgnoreQueryFilters = true
+			});
 
 		IReadOnlyList<PersonTypeEntity> many = repository
-			.GetManyByCondition(
-				queryFilter: query => query.Where(x => x.Name.Contains("e")),
-				ignoreQueryFilters: true,
-				orderBy: query => query.OrderBy(x => x.Name),
-				skip: 1,
-				take: 1);
+			.GetList(new()
+			{
+				QueryFilter = query => query.Where(x => x.Name.Contains("e")),
+				IgnoreQueryFilters = true,
+				OrderBy = query => query.OrderBy(x => x.Name),
+				Skip = 1,
+				Take = 1
+			});
 
 		Assert.AreEqual(2, count);
 		Assert.IsNotNull(single);
@@ -54,26 +61,36 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 		PersonTypeRepository repository = new(DbContext);
 
 		int count = await repository
-			.CountByConditionAsync(
-				queryFilter: query => query.Where(x => x.Name.StartsWith("D")),
-				ignoreQueryFilters: true,
-				token: _cancellationToken)
+			.CountAsync(
+				new()
+				{
+					QueryFilter = query => query.Where(x => x.Name.StartsWith("D")),
+					IgnoreQueryFilters = true
+				},
+				_cancellationToken)
 			.ConfigureAwait(false);
+
 		PersonTypeEntity? single = await repository
-			.GetByConditionAsync(
-				queryFilter: query => query.Where(x => x.Name == "Female"),
-				ignoreQueryFilters: true,
-				token: _cancellationToken)
+			.GetSingleAsync(
+				new()
+				{
+					QueryFilter = query => query.Where(x => x.Name == "Female"),
+					IgnoreQueryFilters = true
+				},
+				_cancellationToken)
 			.ConfigureAwait(false);
 
 		IReadOnlyList<PersonTypeEntity> many = await repository
-			.GetManyByConditionAsync(
-				queryFilter: query => query.Where(x => x.Name.Contains("e")),
-				ignoreQueryFilters: true,
-				orderBy: query => query.OrderByDescending(x => x.Name),
-				skip: 1,
-				take: 1,
-				token: _cancellationToken)
+			.GetListAsync(
+				new()
+				{
+					QueryFilter = query => query.Where(x => x.Name.Contains("e")),
+					IgnoreQueryFilters = true,
+					OrderBy = query => query.OrderByDescending(x => x.Name),
+					Skip = 1,
+					Take = 1
+				},
+				_cancellationToken)
 			.ConfigureAwait(false);
 
 		Assert.AreEqual(1, count);
@@ -87,22 +104,17 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 	public void ProjectionOverloadsSyncTest()
 	{
 		PersonTypeRepository repository = new(DbContext);
+		Query<PersonTypeEntity> unfiltered = new() { IgnoreQueryFilters = true };
 
 		IReadOnlyList<PersonTypeProjection> all = repository
-			.GetAll(
+			.GetList(
 				selector: x => new PersonTypeProjection
-				{
-					Id = x.Id,
-					Name = x.Name,
-					Description = x.Description
-				},
-				fieldSelector: x => new PersonTypeProjection
 				{
 					Id = x.Id,
 					Name = x.Name.ToUpperInvariant(),
 					Description = null
 				},
-				ignoreQueryFilters: true);
+				query: unfiltered);
 
 		PersonTypeProjection? byId = repository
 			.GetById(
@@ -110,16 +122,10 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 				selector: x => new PersonTypeProjection
 				{
 					Id = x.Id,
-					Name = x.Name,
-					Description = x.Description
-				},
-				fieldSelector: x => new PersonTypeProjection
-				{
-					Id = x.Id,
 					Name = x.Name.ToLowerInvariant(),
 					Description = x.Description
 				},
-				ignoreQueryFilters: true);
+				query: unfiltered);
 
 		IReadOnlyList<PersonTypeProjection> byIds = repository
 			.GetByIds(
@@ -128,50 +134,33 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 				{
 					Id = x.Id,
 					Name = x.Name,
-					Description = x.Description
-				},
-				fieldSelector: x => new PersonTypeProjection
-				{
-					Id = x.Id,
-					Name = x.Name,
 					Description = null
 				},
-				ignoreQueryFilters: true);
+				query: unfiltered);
 
 		PersonTypeProjection? byCondition = repository
-				.GetByCondition(
-				expression: x => x.Id == 1,
+			.GetSingle(
 				selector: x => new PersonTypeProjection
-				{
-					Id = x.Id,
-					Name = x.Name,
-					Description = x.Description
-				},
-				fieldSelector: x => new PersonTypeProjection
 				{
 					Id = x.Id,
 					Name = $"Type:{x.Name}",
 					Description = null
 				},
-				ignoreQueryFilters: true);
+				query: unfiltered with { Where = x => x.Id == 1 });
 
 		IReadOnlyList<PersonTypeProjection> manyByCondition = repository
-			.GetManyByCondition(
-				expression: x => x.Id > 1,
+			.GetList(
 				selector: x => new PersonTypeProjection
-				{
-					Id = x.Id,
-					Name = x.Name,
-					Description = x.Description
-				},
-				fieldSelector: x => new PersonTypeProjection
 				{
 					Id = x.Id,
 					Name = x.Name,
 					Description = null
 				},
-				ignoreQueryFilters: true,
-				orderBy: query => query.OrderBy(x => x.Id));
+				query: unfiltered with
+				{
+					Where = x => x.Id > 1,
+					OrderBy = query => query.OrderBy(x => x.Id)
+				});
 
 		Assert.HasCount(3, all);
 		Assert.IsTrue(all.All(x => x.Description is null));
@@ -195,23 +184,18 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 	public async Task ProjectionOverloadsAsyncTest()
 	{
 		PersonTypeRepository repository = new(DbContext);
+		Query<PersonTypeEntity> unfiltered = new() { IgnoreQueryFilters = true };
 
 		IReadOnlyList<PersonTypeProjection> all = await repository
-			.GetAllAsync(
+			.GetListAsync(
 				selector: x => new PersonTypeProjection
-				{
-					Id = x.Id,
-					Name = x.Name,
-					Description = x.Description
-				},
-				fieldSelector: x => new PersonTypeProjection
 				{
 					Id = x.Id,
 					Name = x.Name.ToUpperInvariant(),
 					Description = null
 				},
-				ignoreQueryFilters: true,
-				token: _cancellationToken)
+				query: unfiltered,
+				cancellationToken: _cancellationToken)
 			.ConfigureAwait(false);
 
 		PersonTypeProjection? byId = await repository
@@ -220,17 +204,11 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 				selector: x => new PersonTypeProjection
 				{
 					Id = x.Id,
-					Name = x.Name,
-					Description = x.Description
-				},
-				fieldSelector: x => new PersonTypeProjection
-				{
-					Id = x.Id,
 					Name = x.Name.ToLowerInvariant(),
 					Description = x.Description
 				},
-				ignoreQueryFilters: true,
-				token: _cancellationToken)
+				query: unfiltered,
+				cancellationToken: _cancellationToken)
 			.ConfigureAwait(false);
 
 		IReadOnlyList<PersonTypeProjection> byIds = await repository
@@ -240,56 +218,38 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 				{
 					Id = x.Id,
 					Name = x.Name,
-					Description = x.Description
-				},
-				fieldSelector: x => new PersonTypeProjection
-				{
-					Id = x.Id,
-					Name = x.Name,
 					Description = null
 				},
-				ignoreQueryFilters: true,
-				token: _cancellationToken)
+				query: unfiltered,
+				cancellationToken: _cancellationToken)
 			.ConfigureAwait(false);
 
 		PersonTypeProjection? byCondition = await repository
-			.GetByConditionAsync(
-				expression: x => x.Id == 1,
+			.GetSingleAsync(
 				selector: x => new PersonTypeProjection
-				{
-					Id = x.Id,
-					Name = x.Name,
-					Description = x.Description
-				},
-				fieldSelector: x => new PersonTypeProjection
 				{
 					Id = x.Id,
 					Name = $"Type:{x.Name}",
 					Description = null
 				},
-				ignoreQueryFilters: true,
-				token: _cancellationToken)
+				query: unfiltered with { Where = x => x.Id == 1 },
+				cancellationToken: _cancellationToken)
 			.ConfigureAwait(false);
 
 		IReadOnlyList<PersonTypeProjection> manyByCondition = await repository
-			.GetManyByConditionAsync(
-				expression: x => x.Id > 1,
+			.GetListAsync(
 				selector: x => new PersonTypeProjection
-				{
-					Id = x.Id,
-					Name = x.Name,
-					Description = x.Description
-				},
-				fieldSelector: x => new PersonTypeProjection
 				{
 					Id = x.Id,
 					Name = x.Name,
 					Description = null
 				},
-				ignoreQueryFilters: true,
-				orderBy: query => query.OrderBy(x => x.Id),
-				token: _cancellationToken
-				)
+				query: unfiltered with
+				{
+					Where = x => x.Id > 1,
+					OrderBy = query => query.OrderBy(x => x.Id)
+				},
+				cancellationToken: _cancellationToken)
 			.ConfigureAwait(false);
 
 		Assert.HasCount(3, all);
@@ -300,6 +260,37 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 		Assert.IsNotNull(byCondition);
 		Assert.AreEqual("Type:Female", byCondition.Name);
 		Assert.HasCount(2, manyByCondition);
+	}
+
+	[TestMethod]
+	public void QueryConditionsCombineRatherThanReplaceTest()
+	{
+		PersonTypeRepository repository = new(DbContext);
+
+		// The identifier and the caller supplied condition both have to hold, so a mismatched
+		// pair matches nothing rather than the identifier silently winning.
+		PersonTypeEntity? matching = repository.GetById(2, new() { Where = x => x.Name == "Male" });
+		PersonTypeEntity? conflicting = repository.GetById(2, new() { Where = x => x.Name == "Female" });
+
+		Assert.IsNotNull(matching);
+		Assert.IsNull(conflicting);
+	}
+
+	[TestMethod]
+	public void CountIgnoresOrderingAndPagingTest()
+	{
+		PersonTypeRepository repository = new(DbContext);
+
+		// Ordering and paging cannot change how many rows match, so a count has to ignore them.
+		int count = repository.Count(new()
+		{
+			IgnoreQueryFilters = true,
+			OrderBy = query => query.OrderBy(x => x.Name),
+			Skip = 1,
+			Take = 1
+		});
+
+		Assert.AreEqual(3, count);
 	}
 
 	[TestMethod]
@@ -323,9 +314,7 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 		{
 			int deleted = repository.Delete(x => x.Name == uniqueName);
 
-			SkillEntity? result = repository.GetByCondition(
-				expression: x => x.Name == uniqueName,
-				trackChanges: false);
+			SkillEntity? result = repository.GetSingle(new() { Where = x => x.Name == uniqueName });
 
 			Assert.AreEqual(1, deleted);
 			Assert.IsNull(result);
@@ -373,10 +362,7 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 				setPropertyCalls: s => s.SetProperty(p => p.Name, "Updated")
 				);
 
-			IReadOnlyList<JobEntity> jobs = repository.GetByIds(
-				ids: [first.Id, second.Id],
-				trackChanges: false
-				);
+			IReadOnlyList<JobEntity> jobs = repository.GetByIds([first.Id, second.Id]);
 
 			Assert.AreEqual(2, updatedByCondition);
 			Assert.AreEqual(2, updatedByIds);
@@ -396,10 +382,11 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 	public async Task StreamOverloadsAsyncTest()
 	{
 		PersonTypeRepository repository = new(DbContext);
+		Query<PersonTypeEntity> unfiltered = new() { IgnoreQueryFilters = true };
 
 		List<PersonTypeEntity> all = [];
 		await foreach (PersonTypeEntity entity in repository
-			.StreamAll(ignoreQueryFilters: true, token: _cancellationToken)
+			.Stream(unfiltered, _cancellationToken)
 			.ConfigureAwait(false))
 		{
 			all.Add(entity);
@@ -407,13 +394,15 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 
 		List<PersonTypeEntity> byQueryFilter = [];
 		await foreach (PersonTypeEntity entity in repository
-			.StreamByCondition(
-				queryFilter: query => query.Where(x => x.Name.Contains("e")),
-				ignoreQueryFilters: true,
-				orderBy: query => query.OrderBy(x => x.Name),
-				skip: 1,
-				take: 1,
-				token: _cancellationToken)
+			.Stream(
+				unfiltered with
+				{
+					QueryFilter = query => query.Where(x => x.Name.Contains("e")),
+					OrderBy = query => query.OrderBy(x => x.Name),
+					Skip = 1,
+					Take = 1
+				},
+				_cancellationToken)
 			.ConfigureAwait(false))
 		{
 			byQueryFilter.Add(entity);
@@ -421,11 +410,13 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 
 		List<PersonTypeEntity> byExpression = [];
 		await foreach (PersonTypeEntity entity in repository
-			.StreamByCondition(
-				expression: x => x.Id > 1,
-				ignoreQueryFilters: true,
-				orderBy: query => query.OrderBy(x => x.Id),
-				token: _cancellationToken)
+			.Stream(
+				unfiltered with
+				{
+					Where = x => x.Id > 1,
+					OrderBy = query => query.OrderBy(x => x.Id)
+				},
+				_cancellationToken)
 			.ConfigureAwait(false))
 		{
 			byExpression.Add(entity);
@@ -433,23 +424,19 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 
 		List<PersonTypeProjection> projected = [];
 		await foreach (PersonTypeProjection projection in repository
-			.StreamByCondition(
-				expression: x => x.Id > 1,
+			.Stream(
 				selector: x => new PersonTypeProjection
-				{
-					Id = x.Id,
-					Name = x.Name,
-					Description = x.Description
-				},
-				fieldSelector: x => new PersonTypeProjection
 				{
 					Id = x.Id,
 					Name = x.Name.ToUpperInvariant(),
 					Description = null
 				},
-				ignoreQueryFilters: true,
-				orderBy: query => query.OrderBy(x => x.Id),
-				token: _cancellationToken)
+				query: unfiltered with
+				{
+					Where = x => x.Id > 1,
+					OrderBy = query => query.OrderBy(x => x.Id)
+				},
+				cancellationToken: _cancellationToken)
 			.ConfigureAwait(false))
 		{
 			projected.Add(projection);
@@ -479,7 +466,7 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 		await Assert.ThrowsAsync<OperationCanceledException>(async () =>
 		{
 			await foreach (PersonTypeEntity entity in repository
-				.StreamAll(ignoreQueryFilters: true, token: tokenSource.Token)
+				.Stream(new() { IgnoreQueryFilters = true }, tokenSource.Token)
 				.ConfigureAwait(false))
 			{
 				Assert.IsNotNull(entity);
@@ -494,7 +481,7 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 		List<int> trackedAfterEachEntity = [];
 
 		await foreach (PersonTypeEntity entity in repository
-			.StreamAll(ignoreQueryFilters: true, trackChanges: true, token: _cancellationToken)
+			.Stream(new() { IgnoreQueryFilters = true, TrackChanges = true }, _cancellationToken)
 			.ConfigureAwait(false))
 		{
 			Assert.IsNotNull(entity);

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/SkillTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/SkillTests.cs
@@ -27,7 +27,7 @@ public sealed class SkillTests : UnitTestBase
 		int result = DbContext.SaveChanges();
 		Assert.AreEqual(1, result);
 
-		SkillEntity? dbSkill = repository.GetByCondition(x => x.Name == newSkill.Name, trackChanges: true);
+		SkillEntity? dbSkill = repository.GetSingle(new() { Where = x => x.Name == newSkill.Name, TrackChanges = true });
 		Assert.IsNotNull(dbSkill);
 		Assert.AreNotEqual(DateTimeOffset.MinValue, dbSkill.CreatedAt);
 
@@ -35,7 +35,7 @@ public sealed class SkillTests : UnitTestBase
 		result = DbContext.SaveChanges();
 		Assert.AreEqual(1, result);
 
-		dbSkill = repository.GetByCondition(x => x.Name == newSkill.Name, trackChanges: true);
+		dbSkill = repository.GetSingle(new() { Where = x => x.Name == newSkill.Name, TrackChanges = true });
 		Assert.IsNotNull(dbSkill);
 		Assert.AreNotEqual(DateTimeOffset.MinValue, dbSkill.EditedAt);
 	}


### PR DESCRIPTION
**BREAKING CHANGE:** every read method on the repository abstractions has a new signature.

- Naming now follows one axis, so cardinality is always in the same place: `Count`, `GetSingle`, `GetList` and `Stream`, each with an `Async` twin and a projection overload.
- The `All` variants are gone; an absent `Where` is what "all" means, so `GetList()` reads everything.
- That takes the read surface from 28 methods to 14, and the two interfaces plus their implementations from 1377 lines to 623.
- `Include` is now `Expression<Func<TEntity, object?>>` rather than `params string[]`, so renaming a navigation is a compile error instead of a runtime one.
- EF Core strips the conversion node these lambdas carry, verified before committing to the shape.
- `QueryFilter` remains the escape hatch for what the properties cannot express, `ThenInclude` included.

Two sub-issues close with this, since they touch the same signatures: the projection `fieldSelector` is removed, having never been able to change the result type and never exercised by a test; and the cancellation token is named `cancellationToken` everywhere and moved last on every async method, which the `params` array had made impossible.

- `GetById` and `GetByName` keep their names, being unambiguous already.
- Their key or name condition is now appended to the caller's query through the new protected `WithCondition` rather than replacing it, so a `Where` passed alongside an id keeps applying.
- The protected `Query*` helper family collapses into `PrepareQuery`, which is the single place a `Query<TEntity>` becomes a query.
- It skips ordering, paging and includes when composing for a count, since none of them can change how many rows match.
- A migration table mapping every old signature to its replacement is in the abstractions `README`.

closes #224 & closes #225 & closes #228 & closes #239 & closes #240 