### PR TITLE
feat(repositories): rename the immediate bulk operations to `ExecuteDelete`/`ExecuteUpdate`

### DIFF
--- a/src/BB84.EntityFrameworkCore.Repositories.Abstractions/IWriteIdentityRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.Abstractions/IWriteIdentityRepository.cs
@@ -43,7 +43,7 @@ public interface IWriteIdentityRepository<TEntity, TKey> : IWriteRepository<TEnt
 	/// </remarks>
 	/// <param name="id">The primary key of the <typeparamref name="TEntity"/>.</param>
 	/// <returns>The total number of rows deleted in the database.</returns>
-	int Delete(TKey id);
+	int ExecuteDelete(TKey id);
 
 	/// <summary>
 	/// Deletes all database rows for the <typeparamref name="TEntity"/> instances which matches
@@ -64,24 +64,31 @@ public interface IWriteIdentityRepository<TEntity, TKey> : IWriteRepository<TEnt
 	/// </remarks>
 	/// <param name="ids">The primary keys of the <typeparamref name="TEntity"/>.</param>
 	/// <returns>The total number of rows deleted in the database.</returns>
-	int Delete(IEnumerable<TKey> ids);
+	int ExecuteDelete(IEnumerable<TKey> ids);
 
-	/// <inheritdoc cref="Delete(TKey)"/>
+	/// <inheritdoc cref="ExecuteDelete(TKey)"/>
 	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
-	Task<int> DeleteAsync(TKey id, CancellationToken cancellationToken = default);
+	Task<int> ExecuteDeleteAsync(TKey id, CancellationToken cancellationToken = default);
 
-	/// <inheritdoc cref="Delete(IEnumerable{TKey})"/>
+	/// <inheritdoc cref="ExecuteDelete(IEnumerable{TKey})"/>
 	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
-	Task<int> DeleteAsync(IEnumerable<TKey> ids, CancellationToken cancellationToken = default);
+	Task<int> ExecuteDeleteAsync(IEnumerable<TKey> ids, CancellationToken cancellationToken = default);
 
 	/// <summary>
 	/// Updates the entity identified by the specified identifier with the provided property changes.
 	/// </summary>
 	/// <remarks>
+	/// <para>
 	/// This operation executes immediately against the database, rather than being deferred
 	/// until save changes is called. It also does not interact with the EF change tracker in
 	/// any way: entity instances which happen to be tracked when this operation is invoked
 	/// aren't taken into account, and aren't updated to reflect the changes.
+	/// </para>
+	/// <para>
+	/// <b>Auditing does not happen for this operation.</b> Because no save operation takes
+	/// place, save changes interceptors never run, so the audit columns are left untouched
+	/// unless <paramref name="setPropertyCalls"/> sets them explicitly.
+	/// </para>
 	/// </remarks>
 	/// <param name="id">The unique identifier of the entity to update.</param>
 	/// <param name="setPropertyCalls">A lambda expression specifying the properties to update and their new values.</param>
@@ -89,7 +96,7 @@ public interface IWriteIdentityRepository<TEntity, TKey> : IWriteRepository<TEnt
 	/// The number of entities updated. Typically, this will be 1 if the update is successful,
 	/// or 0 if no entity matches the specified <paramref name="id"/>.
 	/// </returns>
-	int Update(
+	int ExecuteUpdate(
 		TKey id,
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls);
 
@@ -97,10 +104,17 @@ public interface IWriteIdentityRepository<TEntity, TKey> : IWriteRepository<TEnt
 	/// Updates the entities identified by the specified identifiers with the provided property changes.
 	/// </summary>
 	/// <remarks>
+	/// <para>
 	/// This operation executes immediately against the database, rather than being deferred
 	/// until save changes is called. It also does not interact with the EF change tracker in
 	/// any way: entity instances which happen to be tracked when this operation is invoked
 	/// aren't taken into account, and aren't updated to reflect the changes.
+	/// </para>
+	/// <para>
+	/// <b>Auditing does not happen for this operation.</b> Because no save operation takes
+	/// place, save changes interceptors never run, so the audit columns are left untouched
+	/// unless <paramref name="setPropertyCalls"/> sets them explicitly.
+	/// </para>
 	/// </remarks>
 	/// <param name="ids">The unique identifiers of the entities to update.</param>
 	/// <param name="setPropertyCalls">A lambda expression specifying the properties to update and their new values.</param>
@@ -108,20 +122,20 @@ public interface IWriteIdentityRepository<TEntity, TKey> : IWriteRepository<TEnt
 	/// The number of entities updated. Typically, this will be 1 if the update is successful,
 	/// or 0 if no entity matches the specified <paramref name="ids"/>.
 	/// </returns>
-	int Update(
+	int ExecuteUpdate(
 		IEnumerable<TKey> ids,
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls);
 
-	/// <inheritdoc cref="Update(TKey, Action{UpdateSettersBuilder{TEntity}})"/>
+	/// <inheritdoc cref="ExecuteUpdate(TKey, Action{UpdateSettersBuilder{TEntity}})"/>
 	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
-	Task<int> UpdateAsync(
+	Task<int> ExecuteUpdateAsync(
 		TKey id,
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls,
 		CancellationToken cancellationToken = default);
 
-	/// <inheritdoc cref="Update(IEnumerable{TKey}, Action{UpdateSettersBuilder{TEntity}})"/>
+	/// <inheritdoc cref="ExecuteUpdate(IEnumerable{TKey}, Action{UpdateSettersBuilder{TEntity}})"/>
 	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
-	Task<int> UpdateAsync(
+	Task<int> ExecuteUpdateAsync(
 		IEnumerable<TKey> ids,
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls,
 		CancellationToken cancellationToken = default);

--- a/src/BB84.EntityFrameworkCore.Repositories.Abstractions/IWriteRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.Abstractions/IWriteRepository.cs
@@ -15,8 +15,9 @@ namespace BB84.EntityFrameworkCore.Repositories.Abstractions;
 /// <remarks>
 /// <para>
 /// The entity based methods stage their change in the change tracker and take effect on the
-/// next save operation, which is the caller's responsibility. The expression based methods
-/// execute immediately and bypass the change tracker entirely, so no interceptor runs for them.
+/// next save operation, which is the caller's responsibility. The <c>Execute</c> prefixed
+/// methods execute immediately and bypass the change tracker entirely, so no interceptor runs
+/// for them.
 /// </para>
 /// <para>
 /// Depend on this rather than on <see cref="IGenericRepository{TEntity}"/> wherever a component
@@ -103,7 +104,7 @@ public interface IWriteRepository<TEntity>
 	/// </remarks>
 	/// <param name="expression">The condition to fulfill to be deleted.</param>
 	/// <returns>The total number of rows deleted in the database.</returns>
-	int Delete(Expression<Func<TEntity, bool>> expression);
+	int ExecuteDelete(Expression<Func<TEntity, bool>> expression);
 
 	/// <inheritdoc cref="Delete(TEntity)"/>
 	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
@@ -119,9 +120,9 @@ public interface IWriteRepository<TEntity>
 		IEnumerable<TEntity> entities,
 		CancellationToken cancellationToken = default);
 
-	/// <inheritdoc cref="Delete(Expression{Func{TEntity, bool}})"/>
+	/// <inheritdoc cref="ExecuteDelete(Expression{Func{TEntity, bool}})"/>
 	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
-	Task<int> DeleteAsync(
+	Task<int> ExecuteDeleteAsync(
 		Expression<Func<TEntity, bool>> expression,
 		CancellationToken cancellationToken = default);
 
@@ -166,7 +167,7 @@ public interface IWriteRepository<TEntity>
 	/// <param name="expression">The condition to fulfill to be updated.</param>
 	/// <param name="setPropertyCalls">A collection of set property statements specifying properties to update.</param>
 	/// <returns>The total number of rows updated in the database.</returns>
-	int Update(
+	int ExecuteUpdate(
 		Expression<Func<TEntity, bool>> expression,
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls);
 
@@ -184,9 +185,9 @@ public interface IWriteRepository<TEntity>
 		IEnumerable<TEntity> entities,
 		CancellationToken cancellationToken = default);
 
-	/// <inheritdoc cref="Update(Expression{Func{TEntity, bool}}, Action{UpdateSettersBuilder{TEntity}})"/>
+	/// <inheritdoc cref="ExecuteUpdate(Expression{Func{TEntity, bool}}, Action{UpdateSettersBuilder{TEntity}})"/>
 	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
-	Task<int> UpdateAsync(
+	Task<int> ExecuteUpdateAsync(
 		Expression<Func<TEntity, bool>> expression,
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls,
 		CancellationToken cancellationToken = default);

--- a/src/BB84.EntityFrameworkCore.Repositories.Abstractions/README.md
+++ b/src/BB84.EntityFrameworkCore.Repositories.Abstractions/README.md
@@ -119,12 +119,14 @@ Streaming yields rows as they arrive. The sequence is lazy, so it has to be enum
 **Update** — declared on `IWriteRepository<TEntity>`
 
 - `Update(entity)` / `Update(entities)` — marks entity/entities as `Modified`
-- `Update(expression, setPropertyCalls)` — bulk `ExecuteUpdate` (bypasses change tracker)
+- `ExecuteUpdate(expression, setPropertyCalls)` — immediate bulk `UPDATE` (bypasses change tracker)
 
 **Delete** — declared on `IWriteRepository<TEntity>`
 
 - `Delete(entity)` / `Delete(entities)` — marks entity/entities as `Deleted`
-- `Delete(expression)` — bulk `ExecuteDelete` (bypasses change tracker)
+- `ExecuteDelete(expression)` — immediate bulk `DELETE` (bypasses change tracker)
+
+The `Execute` prefix marks the immediate operations, matching EF Core's own `IQueryable.ExecuteDelete()` / `ExecuteUpdate()`. They run against the database there and then, so no save changes interceptor fires for them — auditing is skipped, and `ExecuteDelete` deletes permanently even for soft deletable entities.
 
 ## `IIdentityRepository<TEntity, TKey>` / `IIdentityRepository<TEntity>`
 
@@ -140,11 +142,13 @@ The key condition is **added** to the query rather than replacing it, so a `Wher
 
 **Additional delete methods** — declared on `IWriteIdentityRepository<TEntity, TKey>`
 
-- `Delete(id)` / `Delete(ids)` — bulk `ExecuteDelete` by key(s)
+- `ExecuteDelete(id)` / `ExecuteDelete(ids)` — immediate bulk `DELETE` by key(s)
 
 **Additional update methods** — declared on `IWriteIdentityRepository<TEntity, TKey>`
 
-- `Update(id, setPropertyCalls)` / `Update(ids, setPropertyCalls)` — bulk `ExecuteUpdate` by key(s)
+- `ExecuteUpdate(id, setPropertyCalls)` / `ExecuteUpdate(ids, setPropertyCalls)` — immediate bulk `UPDATE` by key(s)
+
+Every method on `IWriteIdentityRepository<TEntity, TKey>` is of the immediate kind — there is no key-based deferred operation.
 
 ## `IEnumeratorRepository<TEntity, TKey>` / `IEnumeratorRepository<TEntity>`
 
@@ -174,8 +178,18 @@ Extends `IIdentityRepository` with name-based lookups, declared on `IReadEnumera
 | `includeProperties: [nameof(X.Nav)]`                        | `Include = [x => x.Nav]`                                        |
 | `fieldSelector: …`                                          | removed — compose it into `selector`                            |
 | `token:`                                                    | `cancellationToken:`                                            |
+| `Delete(expression)`                                        | `ExecuteDelete(expression)`                                     |
+| `DeleteAsync(expression, …)`                                | `ExecuteDeleteAsync(expression, …)`                             |
+| `Delete(id)` / `Delete(ids)`                                | `ExecuteDelete(id)` / `ExecuteDelete(ids)`                      |
+| `DeleteAsync(id, …)` / `DeleteAsync(ids, …)`                | `ExecuteDeleteAsync(id, …)` / `ExecuteDeleteAsync(ids, …)`      |
+| `Update(expression, setPropertyCalls)`                      | `ExecuteUpdate(expression, setPropertyCalls)`                   |
+| `UpdateAsync(expression, setPropertyCalls, …)`              | `ExecuteUpdateAsync(expression, setPropertyCalls, …)`           |
+| `Update(id, …)` / `Update(ids, …)`                          | `ExecuteUpdate(id, …)` / `ExecuteUpdate(ids, …)`                |
+| `UpdateAsync(id, …)` / `UpdateAsync(ids, …)`                | `ExecuteUpdateAsync(id, …)` / `ExecuteUpdateAsync(ids, …)`      |
 
 Every `Async` method now takes its cancellation token **last**. Call sites that passed arguments positionally around the old token position need checking, not just recompiling.
+
+The `Execute` renames cover the immediate operations only; the entity based `Delete(entity)`, `Delete(entities)`, `Update(entity)` and `Update(entities)` keep their names. Both sets used to share a name while differing in whether they defer to a save operation and whether interceptors run — the rename makes that difference visible at the call site. Each rename is mechanical, but it breaks every call site of the immediate overloads; there are no `[Obsolete]` forwarders.
 
 ## `ICurrentUserProvider<TUser>` / `ICurrentUserProvider`
 

--- a/src/BB84.EntityFrameworkCore.Repositories/GenericRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/GenericRepository.cs
@@ -48,7 +48,7 @@ public abstract class GenericRepository<TEntity>(IDbContext dbContext) : IGeneri
 		=> _dbSet.RemoveRange(entities);
 
 	/// <inheritdoc/>
-	public int Delete(Expression<Func<TEntity, bool>> expression)
+	public int ExecuteDelete(Expression<Func<TEntity, bool>> expression)
 		=> _dbSet.Where(expression).ExecuteDelete();
 
 	/// <inheritdoc/>
@@ -74,7 +74,7 @@ public abstract class GenericRepository<TEntity>(IDbContext dbContext) : IGeneri
 	}
 
 	/// <inheritdoc/>
-	public async Task<int> DeleteAsync(Expression<Func<TEntity, bool>> expression, CancellationToken cancellationToken = default)
+	public async Task<int> ExecuteDeleteAsync(Expression<Func<TEntity, bool>> expression, CancellationToken cancellationToken = default)
 		=> await _dbSet.Where(expression).ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
 
 	/// <inheritdoc/>
@@ -140,7 +140,7 @@ public abstract class GenericRepository<TEntity>(IDbContext dbContext) : IGeneri
 		=> _dbSet.UpdateRange(entities);
 
 	/// <inheritdoc/>
-	public int Update(
+	public int ExecuteUpdate(
 		Expression<Func<TEntity, bool>> expression,
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls)
 		=> _dbSet.Where(expression).ExecuteUpdate(setPropertyCalls);
@@ -168,7 +168,7 @@ public abstract class GenericRepository<TEntity>(IDbContext dbContext) : IGeneri
 	}
 
 	/// <inheritdoc/>
-	public async Task<int> UpdateAsync(
+	public async Task<int> ExecuteUpdateAsync(
 		Expression<Func<TEntity, bool>> expression,
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls,
 		CancellationToken cancellationToken = default)

--- a/src/BB84.EntityFrameworkCore.Repositories/IdentityRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/IdentityRepository.cs
@@ -28,20 +28,20 @@ public abstract class IdentityRepository<TEntity, TKey>(IDbContext dbContext) : 
 	where TKey : IEquatable<TKey>
 {
 	/// <inheritdoc/>
-	public int Delete(TKey id)
-		=> Delete(ById(id));
+	public int ExecuteDelete(TKey id)
+		=> ExecuteDelete(ById(id));
 
 	/// <inheritdoc/>
-	public int Delete(IEnumerable<TKey> ids)
-		=> Delete(ByIds(ids));
+	public int ExecuteDelete(IEnumerable<TKey> ids)
+		=> ExecuteDelete(ByIds(ids));
 
 	/// <inheritdoc/>
-	public async Task<int> DeleteAsync(TKey id, CancellationToken cancellationToken = default)
-		=> await DeleteAsync(ById(id), cancellationToken).ConfigureAwait(false);
+	public async Task<int> ExecuteDeleteAsync(TKey id, CancellationToken cancellationToken = default)
+		=> await ExecuteDeleteAsync(ById(id), cancellationToken).ConfigureAwait(false);
 
 	/// <inheritdoc/>
-	public async Task<int> DeleteAsync(IEnumerable<TKey> ids, CancellationToken cancellationToken = default)
-		=> await DeleteAsync(ByIds(ids), cancellationToken).ConfigureAwait(false);
+	public async Task<int> ExecuteDeleteAsync(IEnumerable<TKey> ids, CancellationToken cancellationToken = default)
+		=> await ExecuteDeleteAsync(ByIds(ids), cancellationToken).ConfigureAwait(false);
 
 	/// <inheritdoc/>
 	public TEntity? GetById(TKey id, Query<TEntity>? query = null)
@@ -76,30 +76,30 @@ public abstract class IdentityRepository<TEntity, TKey>(IDbContext dbContext) : 
 		=> await GetListAsync(selector, WithCondition(query, ByIds(ids)), cancellationToken).ConfigureAwait(false);
 
 	/// <inheritdoc/>
-	public int Update(
+	public int ExecuteUpdate(
 		TKey id,
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls)
-		=> Update(ById(id), setPropertyCalls);
+		=> ExecuteUpdate(ById(id), setPropertyCalls);
 
 	/// <inheritdoc/>
-	public int Update(
+	public int ExecuteUpdate(
 		IEnumerable<TKey> ids,
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls)
-		=> Update(ByIds(ids), setPropertyCalls);
+		=> ExecuteUpdate(ByIds(ids), setPropertyCalls);
 
 	/// <inheritdoc/>
-	public async Task<int> UpdateAsync(
+	public async Task<int> ExecuteUpdateAsync(
 		TKey id,
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls,
 		CancellationToken cancellationToken = default)
-		=> await UpdateAsync(ById(id), setPropertyCalls, cancellationToken).ConfigureAwait(false);
+		=> await ExecuteUpdateAsync(ById(id), setPropertyCalls, cancellationToken).ConfigureAwait(false);
 
 	/// <inheritdoc/>
-	public async Task<int> UpdateAsync(
+	public async Task<int> ExecuteUpdateAsync(
 		IEnumerable<TKey> ids,
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls,
 		CancellationToken cancellationToken = default)
-		=> await UpdateAsync(ByIds(ids), setPropertyCalls, cancellationToken).ConfigureAwait(false);
+		=> await ExecuteUpdateAsync(ByIds(ids), setPropertyCalls, cancellationToken).ConfigureAwait(false);
 
 	/// <summary>
 	/// Returns the condition that matches the <typeparamref name="TEntity"/> with the provided <paramref name="id"/>.

--- a/src/BB84.EntityFrameworkCore.Repositories/README.md
+++ b/src/BB84.EntityFrameworkCore.Repositories/README.md
@@ -50,7 +50,7 @@ Two things to keep in mind:
 
 ### `IdentityRepository<TEntity, TKey>` / `IdentityRepository<TEntity>`
 
-Extends `GenericRepository<TEntity>` with key-based `GetById`, `GetByIds`, and bulk `Delete`/`Update` by ID. The non-generic overload defaults `TKey` to `Guid`.
+Extends `GenericRepository<TEntity>` with key-based `GetById`, `GetByIds`, and immediate bulk `ExecuteDelete`/`ExecuteUpdate` by ID. The non-generic overload defaults `TKey` to `Guid`.
 
 ### `EnumeratorRepository<TEntity, TKey>` / `EnumeratorRepository<TEntity>`
 
@@ -176,4 +176,4 @@ public sealed class HttpCurrentUserProvider(IHttpContextAccessor accessor) : ICu
 
 For audit columns that are not `string`, use the generic `UserAuditedInterceptor<TUser>` with a matching `ICurrentUserProvider<TUser>`.
 
-All three interceptors run on save. The expression-based `Delete` / `Update` repository overloads execute immediately and bypass the change tracker, so none of them fire for those.
+All three interceptors run on save. The `ExecuteDelete` / `ExecuteUpdate` repository methods execute immediately and bypass the change tracker, so none of them fire for those.

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/JobTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/JobTests.cs
@@ -11,42 +11,42 @@ namespace BB84.EntityFrameworkCore.Repositories.Tests;
 public sealed class JobTests : UnitTestBase
 {
 	[TestMethod]
-	public void UpdateByIdTest()
+	public void ExecuteUpdateByIdTest()
 	{
 		JobRepository repository = new(DbContext);
 
-		int updated = repository.Update(Guid.NewGuid(), s => s.SetProperty(p => p.Name, "Tester"));
+		int updated = repository.ExecuteUpdate(Guid.NewGuid(), s => s.SetProperty(p => p.Name, "Tester"));
 
 		Assert.AreEqual(0, updated);
 	}
 
 	[TestMethod]
-	public void UpdateByIdsTest()
+	public void ExecuteUpdateByIdsTest()
 	{
 		JobRepository repository = new(DbContext);
 
-		int updated = repository.Update([Guid.NewGuid(), Guid.NewGuid()], s => s.SetProperty(p => p.Name, "Tester"));
+		int updated = repository.ExecuteUpdate([Guid.NewGuid(), Guid.NewGuid()], s => s.SetProperty(p => p.Name, "Tester"));
 
 		Assert.AreEqual(0, updated);
 	}
 
 	[TestMethod]
-	public async Task UpdateByIdAsyncTest()
+	public async Task ExecuteUpdateByIdAsyncTest()
 	{
 		JobRepository repository = new(DbContext);
 
-		int updated = await repository.UpdateAsync(Guid.NewGuid(), s => s.SetProperty(p => p.Name, "Tester"), TestContext.CancellationToken)
+		int updated = await repository.ExecuteUpdateAsync(Guid.NewGuid(), s => s.SetProperty(p => p.Name, "Tester"), TestContext.CancellationToken)
 			.ConfigureAwait(false);
 
 		Assert.AreEqual(0, updated);
 	}
 
 	[TestMethod]
-	public async Task UpdateByIdsAsyncTest()
+	public async Task ExecuteUpdateByIdsAsyncTest()
 	{
 		JobRepository repository = new(DbContext);
 
-		int updated = await repository.UpdateAsync([Guid.NewGuid(), Guid.NewGuid()], s => s.SetProperty(p => p.Name, "Tester"), TestContext.CancellationToken)
+		int updated = await repository.ExecuteUpdateAsync([Guid.NewGuid(), Guid.NewGuid()], s => s.SetProperty(p => p.Name, "Tester"), TestContext.CancellationToken)
 			.ConfigureAwait(false);
 
 		Assert.AreEqual(0, updated);

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonTests.cs
@@ -12,42 +12,42 @@ namespace BB84.EntityFrameworkCore.Repositories.Tests;
 public sealed class PersonTests : UnitTestBase
 {
 	[TestMethod]
-	public void DeleteByIdTest()
+	public void ExecuteDeleteByIdTest()
 	{
 		PersonRepository repository = new(DbContext);
 
-		int deleted = repository.Delete(Guid.NewGuid());
+		int deleted = repository.ExecuteDelete(Guid.NewGuid());
 
 		Assert.AreEqual(0, deleted);
 	}
 
 	[TestMethod]
-	public void DeleteByIdsTest()
+	public void ExecuteDeleteByIdsTest()
 	{
 		PersonRepository repository = new(DbContext);
 
-		int deleted = repository.Delete([Guid.NewGuid(), Guid.NewGuid()]);
+		int deleted = repository.ExecuteDelete([Guid.NewGuid(), Guid.NewGuid()]);
 
 		Assert.AreEqual(0, deleted);
 	}
 
 	[TestMethod]
-	public async Task DeleteByIdAsyncTest()
+	public async Task ExecuteDeleteByIdAsyncTest()
 	{
 		PersonRepository repository = new(DbContext);
 
-		int deleted = await repository.DeleteAsync(Guid.NewGuid(), TestContext.CancellationToken)
+		int deleted = await repository.ExecuteDeleteAsync(Guid.NewGuid(), TestContext.CancellationToken)
 			.ConfigureAwait(false);
 
 		Assert.AreEqual(0, deleted);
 	}
 
 	[TestMethod]
-	public async Task DeleteByIdsAsyncTest()
+	public async Task ExecuteDeleteByIdsAsyncTest()
 	{
 		PersonRepository repository = new(DbContext);
 
-		int deleted = await repository.DeleteAsync([Guid.NewGuid(), Guid.NewGuid()], TestContext.CancellationToken)
+		int deleted = await repository.ExecuteDeleteAsync([Guid.NewGuid(), Guid.NewGuid()], TestContext.CancellationToken)
 			.ConfigureAwait(false);
 
 		Assert.AreEqual(0, deleted);

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/RepositoryOverloadTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/RepositoryOverloadTests.cs
@@ -293,7 +293,7 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 	}
 
 	[TestMethod]
-	public void DeleteByConditionRemovesMatchingEntitiesTest()
+	public void ExecuteDeleteByConditionRemovesMatchingEntitiesTest()
 	{
 		SkillRepository repository = new(DbContext);
 		string uniqueName = $"Skill-{Guid.NewGuid():N}";
@@ -311,7 +311,7 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 
 		try
 		{
-			int deleted = repository.Delete(x => x.Name == uniqueName);
+			int deleted = repository.ExecuteDelete(x => x.Name == uniqueName);
 
 			SkillEntity? result = repository.GetSingle(new() { Where = x => x.Name == uniqueName });
 
@@ -327,7 +327,7 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 	}
 
 	[TestMethod]
-	public void UpdateByConditionAndIdsModifyMatchingEntitiesTest()
+	public void ExecuteUpdateByConditionAndIdsModifyMatchingEntitiesTest()
 	{
 		JobRepository repository = new(DbContext);
 		string uniquePrefix = $"Job-{Guid.NewGuid():N}";
@@ -351,12 +351,12 @@ public sealed class RepositoryOverloadTests : UnitTestBase
 
 		try
 		{
-			int updatedByCondition = repository.Update(
+			int updatedByCondition = repository.ExecuteUpdate(
 				expression: x => x.Name.StartsWith(uniquePrefix),
 				setPropertyCalls: s => s.SetProperty(p => p.Description, "AfterCondition")
 				);
 
-			int updatedByIds = repository.Update(
+			int updatedByIds = repository.ExecuteUpdate(
 				ids: [first.Id, second.Id],
 				setPropertyCalls: s => s.SetProperty(p => p.Name, "Updated")
 				);


### PR DESCRIPTION
**Changes:**

- Renamed all delete/update repository methods to use `ExecuteDelete`/`ExecuteUpdate` prefixes across interfaces, implementations, and tests.
- Updated XML docs and `README` to clarify immediate execution, bypassing EF change tracker and interceptors.
- Adjusted migration guidance and test method names to reflect these changes.

closes #226 