### PR TITLE
fix(entities): make the concurrency token assignable

### DIFF
--- a/src/BB84.EntityFrameworkCore.Entities.Abstractions/Components/IConcurrency.cs
+++ b/src/BB84.EntityFrameworkCore.Entities.Abstractions/Components/IConcurrency.cs
@@ -16,7 +16,26 @@ namespace BB84.EntityFrameworkCore.Entities.Abstractions.Components;
 public interface IConcurrency
 {
 	/// <summary>
-	/// Gets the timestamp associated with the current entity.
+	/// Gets or sets the timestamp associated with the current entity.
 	/// </summary>
-	byte[] Timestamp { get; }
+	/// <remarks>
+	/// <para>
+	/// The setter exists for the disconnected update scenario the token is there for: an entity
+	/// is read, mapped to a data transfer object, sent over the wire and posted back. Assign the
+	/// original value onto the reconstructed entity before updating it, so that it reaches the
+	/// <c>WHERE</c> predicate of the update statement and a concurrent modification raises a
+	/// <see href="https://learn.microsoft.com/dotnet/api/microsoft.entityframeworkcore.dbupdateconcurrencyexception">
+	/// DbUpdateConcurrencyException</see>. Leaving it unset means the update is not guarded.
+	/// </para>
+	/// <para>
+	/// The value is store generated, so there is no reason to assign it on a newly created
+	/// entity, and assigning anything other than a previously read value only makes the update
+	/// fail to match.
+	/// </para>
+	/// <para>
+	/// The token is shaped for SQL Server <c>rowversion</c>. Providers without an eight byte row
+	/// version need their own mapping for this property.
+	/// </para>
+	/// </remarks>
+	byte[] Timestamp { get; set; }
 }

--- a/src/BB84.EntityFrameworkCore.Entities.Abstractions/README.md
+++ b/src/BB84.EntityFrameworkCore.Entities.Abstractions/README.md
@@ -18,7 +18,7 @@ These fine-grained interfaces are the building blocks composed by the entity-lev
 | Interface                         | Members                                                |
 | --------------------------------- | ------------------------------------------------------ |
 | `IIdentity<TKey>`                 | `TKey Id`                                              |
-| `IConcurrency`                    | `byte[]? Timestamp` (rowversion)                       |
+| `IConcurrency`                    | `byte[] Timestamp` (rowversion)                        |
 | `ITimeAudited`                    | `DateTimeOffset CreatedAt`, `DateTimeOffset? EditedAt` |
 | `IUserAudited<TCreator, TEditor>` | `TCreator CreatedBy`, `TEditor EditedBy`               |
 | `IUserAudited`                    | Shorthand: `IUserAudited<string, string?>`             |
@@ -86,6 +86,36 @@ Lookup/reference data. Extends `IIdentityEntity<TKey>` with `IEnumerator` and `I
 public interface IEnumeratorEntity<TKey> : IIdentityEntity<TKey>, IEnumerator, ISoftDeletable
     where TKey : IEquatable<TKey>
 ```
+
+## Concurrency tokens
+
+`IConcurrency.Timestamp` is settable, which is what makes the disconnected update work. An entity is read, mapped to a DTO, sent over the wire and posted back; assign the original token onto the reconstructed entity before updating it, so it reaches the `WHERE` predicate:
+
+```csharp
+OrderEntity entity = new()
+{
+    Id = dto.Id,
+    TotalAmount = dto.TotalAmount,
+    Timestamp = dto.Timestamp   // the value read earlier
+};
+
+repository.Update(entity);
+
+try
+{
+    await context.SaveChangesAsync(cancellationToken);
+}
+catch (DbUpdateConcurrencyException)
+{
+    // another transaction changed the row in the meantime
+}
+```
+
+Leave `Timestamp` unset and the update is not guarded — it succeeds regardless of what happened to the row in between. The value is store generated, so never assign it on a newly created entity, and never assign anything other than a value read from the database.
+
+The token is shaped for SQL Server `rowversion`. Providers without an eight byte row version need their own mapping for the property.
+
+> **Changed in 5.0:** `Timestamp` was get-only before, so the original value could not be restored on a detached entity and optimistic concurrency never fired for the case it exists for. Hand-written implementations of `IConcurrency` need a setter added. The shipped entities also start out with an empty array rather than `null`.
 
 ## Usage
 

--- a/src/BB84.EntityFrameworkCore.Entities/AuditedCompositeEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities/AuditedCompositeEntity.cs
@@ -18,7 +18,7 @@ public abstract class AuditedCompositeEntity<TCreator, TEdited> : IAuditedCompos
 	where TCreator : notnull
 {
 	/// <inheritdoc/>
-	public byte[] Timestamp { get; } = default!;
+	public byte[] Timestamp { get; set; } = [];
 
 	/// <inheritdoc/>
 	public TCreator CreatedBy { get; set; } = default!;

--- a/src/BB84.EntityFrameworkCore.Entities/CompositeEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities/CompositeEntity.cs
@@ -14,5 +14,5 @@ namespace BB84.EntityFrameworkCore.Entities;
 public abstract class CompositeEntity : ICompositeEntity
 {
 	/// <inheritdoc/>
-	public byte[] Timestamp { get; } = default!;
+	public byte[] Timestamp { get; set; } = [];
 }

--- a/src/BB84.EntityFrameworkCore.Entities/EnumeratorEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities/EnumeratorEntity.cs
@@ -20,7 +20,7 @@ public abstract class EnumeratorEntity<TKey> : IEnumeratorEntity<TKey>
 	public TKey Id { get; set; } = default!;
 
 	/// <inheritdoc/>
-	public byte[] Timestamp { get; } = default!;
+	public byte[] Timestamp { get; set; } = [];
 
 	/// <inheritdoc/>
 	public required string Name { get; set; }

--- a/src/BB84.EntityFrameworkCore.Entities/IdentityEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities/IdentityEntity.cs
@@ -19,7 +19,7 @@ public abstract class IdentityEntity<TKey> : IIdentityEntity<TKey>
 	public TKey Id { get; set; } = default!;
 
 	/// <inheritdoc/>
-	public byte[] Timestamp { get; } = default!;
+	public byte[] Timestamp { get; set; } = [];
 }
 
 /// <inheritdoc cref="IdentityEntity{TKey}"/>

--- a/src/BB84.EntityFrameworkCore.Entities/README.md
+++ b/src/BB84.EntityFrameworkCore.Entities/README.md
@@ -78,3 +78,5 @@ public class LedgerEntry : IdentityEntity<long>
 ```
 
 > **Note:** `FullAuditedEntity` adds time auditing (`CreatedAt`/`EditedAt`) to the identity and user-audit features. Soft delete (`IsDeleted`) is a separate concern — it is provided by `IEnumeratorEntity` (and thus `EnumeratorEntity`), not by `FullAuditedEntity`. Add `ISoftDeletable` manually to your entity if you need soft delete combined with full auditing.
+
+> **Changed in 5.0:** `Timestamp` is now settable and starts out as an empty array rather than `null`. Assign the previously read value onto a reconstructed entity before updating it, or the update is not guarded by the concurrency token — see the [abstractions README](../BB84.EntityFrameworkCore.Entities.Abstractions/README.md#concurrency-tokens).

--- a/tests/BB84.EntityFrameworkCore.Entities.Tests/IdentityEntityTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Entities.Tests/IdentityEntityTests.cs
@@ -23,7 +23,21 @@ public sealed class IdentityEntityTests
 
 		Assert.IsNotNull(entity);
 		Assert.AreEqual(id, entity.Id);
-		Assert.IsNull(entity.Timestamp);
+		Assert.IsEmpty(entity.Timestamp);
+	}
+
+	[TestMethod]
+	public void IdentityEntityTimestampIsAssignableTest()
+	{
+		byte[] timestamp = [1, 2, 3, 4, 5, 6, 7, 8];
+
+		IIdentityEntity entity = new TestClass()
+		{
+			Id = Guid.NewGuid(),
+			Timestamp = timestamp
+		};
+
+		Assert.AreSequenceEqual(timestamp, entity.Timestamp);
 	}
 
 	private sealed class TestClass : IdentityEntity

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/ConcurrencyTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/ConcurrencyTests.cs
@@ -1,0 +1,181 @@
+// Copyright: 2024 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using BB84.EntityFrameworkCore.Repositories.Tests.Persistence;
+using BB84.EntityFrameworkCore.Repositories.Tests.Persistence.Entities;
+using BB84.EntityFrameworkCore.Repositories.Tests.Persistence.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace BB84.EntityFrameworkCore.Repositories.Tests;
+
+/// <summary>
+/// Covers the disconnected update scenario the concurrency token exists for: an entity is read,
+/// mapped to a data transfer object, sent over the wire and posted back.
+/// </summary>
+/// <remarks>
+/// The token was get-only before 5.0, so the original value could not be restored onto the
+/// reconstructed entity and the <c>WHERE</c> predicate never guarded anything.
+/// </remarks>
+[TestClass]
+public sealed class ConcurrencyTests : UnitTestBase
+{
+	[TestMethod]
+	public void StaleTimestampRaisesConcurrencyExceptionTest()
+	{
+		Guid id = Guid.NewGuid();
+		string uniqueName = $"Skill-{Guid.NewGuid():N}";
+
+		byte[] staleTimestamp = CreateSkill(id, uniqueName);
+
+		try
+		{
+			// Another transaction changes the row, which moves the row version on.
+			using (TestDbContext other = GetTestContext())
+			{
+				_ = other.Set<SkillEntity>()
+					.Where(x => x.Id == id)
+					.ExecuteUpdate(s => s.SetProperty(p => p.Description, "Changed elsewhere."));
+			}
+
+			using TestDbContext posting = GetTestContext();
+			SkillRepository repository = new(posting);
+
+			SkillEntity detached = new()
+			{
+				Id = id,
+				Name = uniqueName,
+				Description = "Posted back.",
+				Timestamp = staleTimestamp
+			};
+
+			repository.Update(detached);
+
+			_ = Assert.ThrowsExactly<DbUpdateConcurrencyException>(() => posting.SaveChanges());
+		}
+		finally
+		{
+			DeleteSkill(id);
+		}
+	}
+
+	[TestMethod]
+	public void CurrentTimestampUpdatesTest()
+	{
+		Guid id = Guid.NewGuid();
+		string uniqueName = $"Skill-{Guid.NewGuid():N}";
+
+		_ = CreateSkill(id, uniqueName);
+
+		try
+		{
+			SkillEntity read;
+
+			using (TestDbContext reading = GetTestContext())
+			{
+				SkillEntity? entity = new SkillRepository(reading).GetById(id);
+
+				Assert.IsNotNull(entity);
+				read = entity;
+			}
+
+			using TestDbContext posting = GetTestContext();
+			SkillRepository repository = new(posting);
+
+			// A fresh instance standing in for what comes back over the wire. Every column has
+			// to be carried, not just the token: the update marks them all as modified, so a
+			// partial entity writes nulls over whatever it left out.
+			SkillEntity detached = new()
+			{
+				Id = read.Id,
+				Name = read.Name,
+				Description = "Posted back.",
+				IsCritical = read.IsCritical,
+				Reference = read.Reference,
+				CreatedBy = read.CreatedBy,
+				CreatedAt = read.CreatedAt,
+				Timestamp = read.Timestamp
+			};
+
+			repository.Update(detached);
+
+			Assert.AreEqual(1, posting.SaveChanges());
+
+			using TestDbContext verifying = GetTestContext();
+			SkillEntity? reloaded = new SkillRepository(verifying).GetById(id);
+
+			Assert.IsNotNull(reloaded);
+			Assert.AreEqual("Posted back.", reloaded.Description);
+		}
+		finally
+		{
+			DeleteSkill(id);
+		}
+	}
+
+	[TestMethod]
+	public void MissingTimestampRaisesConcurrencyExceptionTest()
+	{
+		Guid id = Guid.NewGuid();
+		string uniqueName = $"Skill-{Guid.NewGuid():N}";
+
+		_ = CreateSkill(id, uniqueName);
+
+		try
+		{
+			using TestDbContext posting = GetTestContext();
+			SkillRepository repository = new(posting);
+
+			// The token is left at its default, which is what a data transfer object that
+			// dropped the property on the way out and back produces.
+			SkillEntity detached = new()
+			{
+				Id = id,
+				Name = uniqueName,
+				Description = "Posted back without a token."
+			};
+
+			repository.Update(detached);
+
+			_ = Assert.ThrowsExactly<DbUpdateConcurrencyException>(() => posting.SaveChanges());
+		}
+		finally
+		{
+			DeleteSkill(id);
+		}
+	}
+
+	/// <summary>
+	/// Creates a skill and returns the store generated concurrency token it came back with.
+	/// </summary>
+	private static byte[] CreateSkill(Guid id, string name)
+	{
+		using TestDbContext dbContext = GetTestContext();
+
+		SkillEntity entity = new()
+		{
+			Id = id,
+			Name = name,
+			Description = "Created for the concurrency test.",
+			IsCritical = false
+		};
+
+		new SkillRepository(dbContext).Create(entity);
+		_ = dbContext.SaveChanges();
+
+		Assert.IsNotEmpty(entity.Timestamp, "the store generated token should be materialized onto the entity");
+
+		return entity.Timestamp;
+	}
+
+	private static void DeleteSkill(Guid id)
+	{
+		using TestDbContext dbContext = GetTestContext();
+
+		_ = dbContext.Set<SkillEntity>()
+			.Where(x => x.Id == id)
+			.ExecuteDelete();
+	}
+}


### PR DESCRIPTION
**Changes:**

- Make `IConcurrency.Timestamp` get/set with remarks for concurrency scenarios
- Entities now settable `Timestamp`, default to empty array (not null)
- Update `README` for `Timestamp` mutability and v5.0 change
- Update `IdentityEntity` tests for default and assignable `Timestamp`
- Add `ConcurrencyTests`: stale/missing `Timestamp` triggers exception, current allows update
- Add test helpers for entity creation/deletion

closes #220 