### PR TITLE
refactor(repositories): drop the fake-async entity overloads

### DIFF
--- a/src/BB84.EntityFrameworkCore.Entities/README.md
+++ b/src/BB84.EntityFrameworkCore.Entities/README.md
@@ -49,7 +49,7 @@ public class Order : AuditedEntity
     public decimal TotalAmount { get; set; }
 }
 
-// Fully audited entity — tracks who and when, plus supports soft delete
+// Fully audited entity — tracks who and when
 public class Invoice : FullAuditedEntity
 {
     public string Number { get; set; } = string.Empty;

--- a/src/BB84.EntityFrameworkCore.Repositories.Abstractions/IWriteRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.Abstractions/IWriteRepository.cs
@@ -20,6 +20,13 @@ namespace BB84.EntityFrameworkCore.Repositories.Abstractions;
 /// for them.
 /// </para>
 /// <para>
+/// <see cref="Delete(TEntity)"/> and <see cref="Update(TEntity)"/> have no asynchronous
+/// counterpart, because marking an entity in the change tracker is a synchronous in memory
+/// operation with nothing to await. Call them and then await the save operation. The exception
+/// is <see cref="CreateAsync(TEntity, CancellationToken)"/>, which does await when the entity
+/// uses a value generator that queries the store.
+/// </para>
+/// <para>
 /// Depend on this rather than on <see cref="IGenericRepository{TEntity}"/> wherever a component
 /// only writes, such as an importer or the command side of a CQRS split.
 /// </para>
@@ -106,20 +113,6 @@ public interface IWriteRepository<TEntity>
 	/// <returns>The total number of rows deleted in the database.</returns>
 	int ExecuteDelete(Expression<Func<TEntity, bool>> expression);
 
-	/// <inheritdoc cref="Delete(TEntity)"/>
-	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
-	/// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-	Task DeleteAsync(
-		TEntity entity,
-		CancellationToken cancellationToken = default);
-
-	/// <inheritdoc cref="Delete(IEnumerable{TEntity})"/>
-	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
-	/// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-	Task DeleteAsync(
-		IEnumerable<TEntity> entities,
-		CancellationToken cancellationToken = default);
-
 	/// <inheritdoc cref="ExecuteDelete(Expression{Func{TEntity, bool}})"/>
 	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
 	Task<int> ExecuteDeleteAsync(
@@ -170,20 +163,6 @@ public interface IWriteRepository<TEntity>
 	int ExecuteUpdate(
 		Expression<Func<TEntity, bool>> expression,
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls);
-
-	/// <inheritdoc cref="Update(TEntity)"/>
-	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
-	/// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-	Task UpdateAsync(
-		TEntity entity,
-		CancellationToken cancellationToken = default);
-
-	/// <inheritdoc cref="Update(IEnumerable{TEntity})"/>
-	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>
-	/// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-	Task UpdateAsync(
-		IEnumerable<TEntity> entities,
-		CancellationToken cancellationToken = default);
 
 	/// <inheritdoc cref="ExecuteUpdate(Expression{Func{TEntity, bool}}, Action{UpdateSettersBuilder{TEntity}})"/>
 	/// <param name="cancellationToken">The cancellation token to cancel the request.</param>

--- a/src/BB84.EntityFrameworkCore.Repositories.Abstractions/README.md
+++ b/src/BB84.EntityFrameworkCore.Repositories.Abstractions/README.md
@@ -93,7 +93,9 @@ There is no `IWriteEnumeratorRepository`: an enumerator repository adds only nam
 
 ## `IGenericRepository<TEntity>`
 
-The base repository interface, composing `IReadRepository<TEntity>` and `IWriteRepository<TEntity>`. All methods have synchronous and asynchronous variants, and every `Async` variant takes `CancellationToken cancellationToken` last.
+The base repository interface, composing `IReadRepository<TEntity>` and `IWriteRepository<TEntity>`. Every `Async` variant takes `CancellationToken cancellationToken` last.
+
+An `Async` variant exists only where there is something to await. Marking an entity in the change tracker is a synchronous in-memory operation, so `Delete(entity)` and `Update(entity)` have no asynchronous counterpart — call them and then await the save. `CreateAsync` is the exception, because `DbSet.AddAsync` genuinely awaits when the entity uses a value generator that queries the store, such as HiLo.
 
 **Create** — declared on `IWriteRepository<TEntity>`
 
@@ -118,12 +120,12 @@ Streaming yields rows as they arrive. The sequence is lazy, so it has to be enum
 
 **Update** — declared on `IWriteRepository<TEntity>`
 
-- `Update(entity)` / `Update(entities)` — marks entity/entities as `Modified`
+- `Update(entity)` / `Update(entities)` — marks entity/entities as `Modified`; no `Async` variant
 - `ExecuteUpdate(expression, setPropertyCalls)` — immediate bulk `UPDATE` (bypasses change tracker)
 
 **Delete** — declared on `IWriteRepository<TEntity>`
 
-- `Delete(entity)` / `Delete(entities)` — marks entity/entities as `Deleted`
+- `Delete(entity)` / `Delete(entities)` — marks entity/entities as `Deleted`; no `Async` variant
 - `ExecuteDelete(expression)` — immediate bulk `DELETE` (bypasses change tracker)
 
 The `Execute` prefix marks the immediate operations, matching EF Core's own `IQueryable.ExecuteDelete()` / `ExecuteUpdate()`. They run against the database there and then, so no save changes interceptor fires for them — auditing is skipped, and `ExecuteDelete` deletes permanently even for soft deletable entities.
@@ -186,8 +188,12 @@ Extends `IIdentityRepository` with name-based lookups, declared on `IReadEnumera
 | `UpdateAsync(expression, setPropertyCalls, …)`              | `ExecuteUpdateAsync(expression, setPropertyCalls, …)`           |
 | `Update(id, …)` / `Update(ids, …)`                          | `ExecuteUpdate(id, …)` / `ExecuteUpdate(ids, …)`                |
 | `UpdateAsync(id, …)` / `UpdateAsync(ids, …)`                | `ExecuteUpdateAsync(id, …)` / `ExecuteUpdateAsync(ids, …)`      |
+| `await DeleteAsync(entity)` / `await DeleteAsync(entities)` | removed — `Delete(entity)` / `Delete(entities)`                 |
+| `await UpdateAsync(entity)` / `await UpdateAsync(entities)` | removed — `Update(entity)` / `Update(entities)`                 |
 
 Every `Async` method now takes its cancellation token **last**. Call sites that passed arguments positionally around the old token position need checking, not just recompiling.
+
+The four removed entity overloads were `Async` in name only: they checked the token, mutated the change tracker synchronously and returned a completed task. Migration is dropping the `await` and the `Async` suffix. Nothing is lost, because the database work always happened in the save operation, not in these methods.
 
 The `Execute` renames cover the immediate operations only; the entity based `Delete(entity)`, `Delete(entities)`, `Update(entity)` and `Update(entities)` keep their names. Both sets used to share a name while differing in whether they defer to a save operation and whether interceptors run — the rename makes that difference visible at the call site. Each rename is mechanical, but it breaks every call site of the immediate overloads; there are no `[Obsolete]` forwarders.
 

--- a/src/BB84.EntityFrameworkCore.Repositories/GenericRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/GenericRepository.cs
@@ -52,28 +52,6 @@ public abstract class GenericRepository<TEntity>(IDbContext dbContext) : IGeneri
 		=> _dbSet.Where(expression).ExecuteDelete();
 
 	/// <inheritdoc/>
-	public Task DeleteAsync(TEntity entity, CancellationToken cancellationToken = default)
-	{
-		if (cancellationToken.IsCancellationRequested)
-			return Task.FromCanceled(cancellationToken);
-
-		_ = _dbSet.Remove(entity);
-
-		return Task.CompletedTask;
-	}
-
-	/// <inheritdoc/>
-	public Task DeleteAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
-	{
-		if (cancellationToken.IsCancellationRequested)
-			return Task.FromCanceled(cancellationToken);
-
-		_dbSet.RemoveRange(entities);
-
-		return Task.CompletedTask;
-	}
-
-	/// <inheritdoc/>
 	public async Task<int> ExecuteDeleteAsync(Expression<Func<TEntity, bool>> expression, CancellationToken cancellationToken = default)
 		=> await _dbSet.Where(expression).ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
 
@@ -144,28 +122,6 @@ public abstract class GenericRepository<TEntity>(IDbContext dbContext) : IGeneri
 		Expression<Func<TEntity, bool>> expression,
 		Action<UpdateSettersBuilder<TEntity>> setPropertyCalls)
 		=> _dbSet.Where(expression).ExecuteUpdate(setPropertyCalls);
-
-	/// <inheritdoc/>
-	public Task UpdateAsync(TEntity entity, CancellationToken cancellationToken = default)
-	{
-		if (cancellationToken.IsCancellationRequested)
-			return Task.FromCanceled(cancellationToken);
-
-		_ = _dbSet.Update(entity);
-
-		return Task.CompletedTask;
-	}
-
-	/// <inheritdoc/>
-	public Task UpdateAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
-	{
-		if (cancellationToken.IsCancellationRequested)
-			return Task.FromCanceled(cancellationToken);
-
-		_dbSet.UpdateRange(entities);
-
-		return Task.CompletedTask;
-	}
 
 	/// <inheritdoc/>
 	public async Task<int> ExecuteUpdateAsync(

--- a/src/BB84.EntityFrameworkCore.Repositories/README.md
+++ b/src/BB84.EntityFrameworkCore.Repositories/README.md
@@ -97,6 +97,13 @@ repository.Create(entity);
 await dbContext.SaveChangesAsync(cancellationToken);
 ```
 
+`Delete(entity)` and `Update(entity)` are synchronous on purpose — they only mark the entity in the change tracker, and the database work happens in the save:
+
+```csharp
+repository.Delete(entity);
+await dbContext.SaveChangesAsync(cancellationToken);
+```
+
 ## Configuration base classes
 
 Provider-agnostic `IEntityTypeConfiguration<TEntity>` base classes in `BB84.EntityFrameworkCore.Repositories.Configurations`. They apply key declaration, column ordering, the concurrency token, audit columns and — for enumerator entities — the name/description constraints, unique index and soft delete query filter. Everything they do is EF Core or EF Core Relational, so they work on PostgreSQL, SQLite, MySQL and Oracle.

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonJobTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonJobTests.cs
@@ -105,6 +105,8 @@ public sealed class PersonJobTests : UnitTestBase
 		PersonJobEntity personJob = new() { PersonId = Guid.NewGuid(), JobId = Guid.NewGuid() };
 
 		repository.Delete(personJob);
+
+		Assert.AreEqual(EntityState.Deleted, DbContext.Entry(personJob).State);
 	}
 
 	[TestMethod]
@@ -115,30 +117,6 @@ public sealed class PersonJobTests : UnitTestBase
 		List<PersonJobEntity> personJobs = [new() { PersonId = Guid.NewGuid(), JobId = Guid.NewGuid() }];
 
 		repository.Delete(personJobs);
-	}
-
-	[TestMethod]
-	public async Task DeleteAsyncTest()
-	{
-		PersonJobRepository repository = new(DbContext);
-
-		PersonJobEntity personJob = new() { PersonId = Guid.NewGuid(), JobId = Guid.NewGuid() };
-
-		await repository.DeleteAsync(personJob, TestContext.CancellationToken)
-			.ConfigureAwait(false);
-
-		Assert.AreEqual(EntityState.Deleted, DbContext.Entry(personJob).State);
-	}
-
-	[TestMethod]
-	public async Task DeleteRangeAsyncTest()
-	{
-		PersonJobRepository repository = new(DbContext);
-
-		List<PersonJobEntity> personJobs = [new() { PersonId = Guid.NewGuid(), JobId = Guid.NewGuid() }];
-
-		await repository.DeleteAsync(personJobs, TestContext.CancellationToken)
-			.ConfigureAwait(false);
 
 		Assert.AreEqual(EntityState.Deleted, DbContext.Entry(personJobs[0]).State);
 	}
@@ -151,6 +129,8 @@ public sealed class PersonJobTests : UnitTestBase
 		PersonJobEntity personJob = new() { PersonId = Guid.NewGuid(), JobId = Guid.NewGuid() };
 
 		repository.Update(personJob);
+
+		Assert.AreEqual(EntityState.Modified, DbContext.Entry(personJob).State);
 	}
 
 	[TestMethod]
@@ -161,46 +141,8 @@ public sealed class PersonJobTests : UnitTestBase
 		List<PersonJobEntity> personJobs = [new() { PersonId = Guid.NewGuid(), JobId = Guid.NewGuid() }];
 
 		repository.Update(personJobs);
-	}
-
-	[TestMethod]
-	public async Task UpdateAsyncTest()
-	{
-		PersonJobRepository repository = new(DbContext);
-
-		PersonJobEntity personJob = new() { PersonId = Guid.NewGuid(), JobId = Guid.NewGuid() };
-
-		await repository.UpdateAsync(personJob, TestContext.CancellationToken)
-			.ConfigureAwait(false);
-
-		Assert.AreEqual(EntityState.Modified, DbContext.Entry(personJob).State);
-	}
-
-	[TestMethod]
-	public async Task UpdateRangeAsyncTest()
-	{
-		PersonJobRepository repository = new(DbContext);
-
-		List<PersonJobEntity> personJobs = [new() { PersonId = Guid.NewGuid(), JobId = Guid.NewGuid() }];
-
-		await repository.UpdateAsync(personJobs, TestContext.CancellationToken)
-			.ConfigureAwait(false);
 
 		Assert.AreEqual(EntityState.Modified, DbContext.Entry(personJobs[0]).State);
-	}
-
-	[TestMethod]
-	public async Task DeleteAsyncCancelledTest()
-	{
-		PersonJobRepository repository = new(DbContext);
-
-		PersonJobEntity personJob = new() { PersonId = Guid.NewGuid(), JobId = Guid.NewGuid() };
-
-		_ = await Assert.ThrowsExactlyAsync<TaskCanceledException>(
-			() => repository.DeleteAsync(personJob, new CancellationToken(true)))
-			.ConfigureAwait(false);
-
-		Assert.AreEqual(EntityState.Detached, DbContext.Entry(personJob).State);
 	}
 
 	public TestContext TestContext { get; set; }

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonTypeTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/PersonTypeTests.cs
@@ -113,7 +113,7 @@ public sealed class PersonTypeTests : UnitTestBase
 		await repository.CreateAsync(entity, TestContext.CancellationToken);
 		_ = await DbContext.SaveChangesAsync(TestContext.CancellationToken);
 
-		await repository.DeleteAsync(entity, TestContext.CancellationToken);
+		repository.Delete(entity);
 		_ = await DbContext.SaveChangesAsync(TestContext.CancellationToken);
 
 		Assert.IsTrue(entity.IsDeleted);


### PR DESCRIPTION
**Changes:**

- `DeleteAsync(TEntity)`, `DeleteAsync(IEnumerable<TEntity>)`, `UpdateAsync(TEntity)` and `UpdateAsync(IEnumerable<TEntity>)` were Async in name only: check the token, mutate the change tracker synchronously, return a completed task.
- Awaiting them suggested deferred or parallel work where there was none, and reinforced the wrong mental model that they reach the database. `SaveChangesAsync` does.
- `CreateAsync` stays - `DbSet.AddAsync` genuinely awaits when the entity uses a value generator that queries the store, such as HiLo.
- The four removed tests held the only change tracker state assertions, so those move onto the synchronous tests, which asserted nothing before.
- `DeleteAsyncCancelledTest` covered the removed cancellation contract and goes with it.

closes #227 