### PR TITLE
refactor(entities): clean up the abstraction naming

### DIFF
--- a/src/BB84.EntityFrameworkCore.Entities.Abstractions/Components/IEnumeration.cs
+++ b/src/BB84.EntityFrameworkCore.Entities.Abstractions/Components/IEnumeration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright: 2024 Robert Peter Meyer
+// Copyright: 2024 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -9,11 +9,11 @@ namespace BB84.EntityFrameworkCore.Entities.Abstractions.Components;
 /// Defines a contract for entities that support enumerator functionality.
 /// </summary>
 /// <remarks>
-/// The <see cref="IEnumerator"/> interface is designed to provide a standardized way to
+/// The <see cref="IEnumeration"/> interface is designed to provide a standardized way to
 /// define enumerators within entities. It includes properties for the name and description
 /// so that each enumerator can be clearly identified and documented.
 /// </remarks>
-public interface IEnumerator
+public interface IEnumeration
 {
 	/// <summary>
 	/// Gets or sets the name of the enumerator.

--- a/src/BB84.EntityFrameworkCore.Entities.Abstractions/IAuditedEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities.Abstractions/IAuditedEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright: 2024 Robert Peter Meyer
+// Copyright: 2024 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -13,32 +13,26 @@ namespace BB84.EntityFrameworkCore.Entities.Abstractions;
 /// </summary>
 /// <typeparam name="TKey">The type of the unique identifier for the entity.</typeparam>
 /// <typeparam name="TCreator">The type representing the user or entity that created this entity.</typeparam>
-/// <typeparam name="TEdited">The type representing the user or entity that last modified this entity.</typeparam>
-public interface IAuditedEntity<TKey, TCreator, TEdited> : IIdentityEntity<TKey>, IUserAudited<TCreator, TEdited>
+/// <typeparam name="TEditor">The type representing the user or entity that last modified this entity.</typeparam>
+public interface IAuditedEntity<TKey, TCreator, TEditor> : IIdentityEntity<TKey>, IUserAudited<TCreator, TEditor>
 	where TKey : IEquatable<TKey>
 	where TCreator : notnull
 { }
 
-/// <inheritdoc cref="IAuditedEntity{TKey, TCreator, TEdited}"/>
+/// <inheritdoc cref="IAuditedEntity{TKey, TCreator, TEditor}"/>
 /// <remarks>
-/// The creator and editor types default to <see cref="string"/>.
+/// <typeparamref name="TKey"/> is supplied; <c>TCreator</c> defaults to <see cref="string"/>
+/// and <c>TEditor</c> to <see cref="string"/>. For a custom creator or editor type use
+/// <see cref="IAuditedEntity{TKey, TCreator, TEditor}"/> and name all three.
 /// </remarks>
 public interface IAuditedEntity<TKey> : IAuditedEntity<TKey, string, string?>, IUserAudited
 	where TKey : IEquatable<TKey>
 { }
 
-/// <inheritdoc cref="IAuditedEntity{TKey, TCreator, TEdited}"/>
+/// <inheritdoc cref="IAuditedEntity{TKey, TCreator, TEditor}"/>
 /// <remarks>
-/// The unique identifier type defaults to <see cref="Guid"/>.
-/// </remarks>
-public interface IAuditedEntity<TCreator, TEdited> : IAuditedEntity<Guid, TCreator, TEdited>, IIdentityEntity
-	where TCreator : notnull
-{ }
-
-/// <inheritdoc cref="IAuditedEntity{TKey, TCreator, TEdited}"/>
-/// <remarks>
-/// The unique identifier type defaults to <see cref="Guid"/> and the creator and editor
-/// types default to <see cref="string"/>.
+/// Nothing is supplied; <c>TKey</c> defaults to <see cref="Guid"/>, <c>TCreator</c> to
+/// <see cref="string"/> and <c>TEditor</c> to <see cref="string"/>.
 /// </remarks>
 public interface IAuditedEntity : IAuditedEntity<Guid, string, string?>, IIdentityEntity, IUserAudited
 { }

--- a/src/BB84.EntityFrameworkCore.Entities.Abstractions/IEnumeratorEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities.Abstractions/IEnumeratorEntity.cs
@@ -13,7 +13,7 @@ namespace BB84.EntityFrameworkCore.Entities.Abstractions;
 /// soft deletion functionality.
 /// </summary>
 /// <typeparam name="TKey">The type of the unique identifier for the entity.</typeparam>
-public interface IEnumeratorEntity<TKey> : IIdentityEntity<TKey>, IEnumerator, ISoftDeletable
+public interface IEnumeratorEntity<TKey> : IIdentityEntity<TKey>, IEnumeration, ISoftDeletable
 	where TKey : IEquatable<TKey>
 { }
 

--- a/src/BB84.EntityFrameworkCore.Entities.Abstractions/IFullAuditedEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities.Abstractions/IFullAuditedEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright: 2024 Robert Peter Meyer
+// Copyright: 2024 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -19,26 +19,20 @@ public interface IFullAuditedEntity<TKey, TCreator, TEditor> : IIdentityEntity<T
 	where TCreator : notnull
 { }
 
-/// <inheritdoc cref="IFullAuditedEntity{TKey, TCreator, TEdited}"/>
+/// <inheritdoc cref="IFullAuditedEntity{TKey, TCreator, TEditor}"/>
 /// <remarks>
-/// The creator and editor columns are of type <see cref="string"/>.
+/// <typeparamref name="TKey"/> is supplied; <c>TCreator</c> defaults to <see cref="string"/>
+/// and <c>TEditor</c> to <see cref="string"/>. For a custom creator or editor type use
+/// <see cref="IFullAuditedEntity{TKey, TCreator, TEditor}"/> and name all three.
 /// </remarks>
 public interface IFullAuditedEntity<TKey> : IFullAuditedEntity<TKey, string, string?>, IUserAudited
 	where TKey : IEquatable<TKey>
 { }
 
-/// <inheritdoc cref="IFullAuditedEntity{TKey, TCreator, TEdited}"/>
+/// <inheritdoc cref="IFullAuditedEntity{TKey, TCreator, TEditor}"/>
 /// <remarks>
-/// The identity column is of type <see cref="Guid"/>.
-/// </remarks>
-public interface IFullAuditedEntity<TCreator, TEdited> : IFullAuditedEntity<Guid, TCreator, TEdited>, IIdentityEntity
-	where TCreator : notnull
-{ }
-
-/// <inheritdoc cref="IFullAuditedEntity{TKey, TCreator, TEdited}"/>
-/// <remarks>
-/// The identity column is of type <see cref="Guid"/> and the creator and editor columns are
-/// of type <see cref="string"/>.
+/// Nothing is supplied; <c>TKey</c> defaults to <see cref="Guid"/>, <c>TCreator</c> to
+/// <see cref="string"/> and <c>TEditor</c> to <see cref="string"/>.
 /// </remarks>
 public interface IFullAuditedEntity : IFullAuditedEntity<Guid, string, string?>, IIdentityEntity, IUserAudited
 { }

--- a/src/BB84.EntityFrameworkCore.Entities.Abstractions/README.md
+++ b/src/BB84.EntityFrameworkCore.Entities.Abstractions/README.md
@@ -23,7 +23,7 @@ These fine-grained interfaces are the building blocks composed by the entity-lev
 | `IUserAudited<TCreator, TEditor>` | `TCreator CreatedBy`, `TEditor EditedBy`               |
 | `IUserAudited`                    | Shorthand: `IUserAudited<string, string?>`             |
 | `ISoftDeletable`                  | `bool IsDeleted`                                       |
-| `IEnumerator`                     | `string Name`, `string? Description`                   |
+| `IEnumeration`                    | `string Name`, `string? Description`                   |
 
 ## Entity interfaces
 
@@ -80,10 +80,10 @@ Extends `ICompositeEntity` with `IUserAudited`. The non-generic overload default
 
 ### `IEnumeratorEntity<TKey>` / `IEnumeratorEntity`
 
-Lookup/reference data. Extends `IIdentityEntity<TKey>` with `IEnumerator` and `ISoftDeletable`. The non-generic overload defaults `TKey` to `int`.
+Lookup/reference data. Extends `IIdentityEntity<TKey>` with `IEnumeration` and `ISoftDeletable`. The non-generic overload defaults `TKey` to `int`.
 
 ```csharp
-public interface IEnumeratorEntity<TKey> : IIdentityEntity<TKey>, IEnumerator, ISoftDeletable
+public interface IEnumeratorEntity<TKey> : IIdentityEntity<TKey>, IEnumeration, ISoftDeletable
     where TKey : IEquatable<TKey>
 ```
 

--- a/src/BB84.EntityFrameworkCore.Entities/AuditedCompositeEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities/AuditedCompositeEntity.cs
@@ -13,8 +13,8 @@ namespace BB84.EntityFrameworkCore.Entities;
 /// editor, and a concurrency timestamp.
 /// </summary>
 /// <typeparam name="TCreator">The type of the entity or user responsible for creating the entity.</typeparam>
-/// <typeparam name="TEdited">The type of the entity or user responsible for editing the entity.</typeparam>
-public abstract class AuditedCompositeEntity<TCreator, TEdited> : IAuditedCompositeEntity<TCreator, TEdited>
+/// <typeparam name="TEditor">The type of the entity or user responsible for editing the entity.</typeparam>
+public abstract class AuditedCompositeEntity<TCreator, TEditor> : IAuditedCompositeEntity<TCreator, TEditor>
 	where TCreator : notnull
 {
 	/// <inheritdoc/>
@@ -24,10 +24,10 @@ public abstract class AuditedCompositeEntity<TCreator, TEdited> : IAuditedCompos
 	public TCreator CreatedBy { get; set; } = default!;
 
 	/// <inheritdoc/>
-	public TEdited EditedBy { get; set; } = default!;
+	public TEditor EditedBy { get; set; } = default!;
 }
 
-/// <inheritdoc cref="AuditedCompositeEntity{TCreator, TEdited}"/>
+/// <inheritdoc cref="AuditedCompositeEntity{TCreator, TEditor}"/>
 /// <remarks>
 /// The creator and editor types default to <see cref="string"/>.
 /// </remarks>

--- a/src/BB84.EntityFrameworkCore.Entities/AuditedEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities/AuditedEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright: 2024 Robert Peter Meyer
+// Copyright: 2024 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -14,8 +14,8 @@ namespace BB84.EntityFrameworkCore.Entities;
 /// </summary>
 /// <typeparam name="TKey">The type of the unique identifier for the entity.</typeparam>
 /// <typeparam name="TCreator">The type representing the creator of the entity.</typeparam>
-/// <typeparam name="TEdited">The type representing the last editor of the entity.</typeparam>
-public abstract class AuditedEntity<TKey, TCreator, TEdited> : IdentityEntity<TKey>, IAuditedEntity<TKey, TCreator, TEdited>
+/// <typeparam name="TEditor">The type representing the last editor of the entity.</typeparam>
+public abstract class AuditedEntity<TKey, TCreator, TEditor> : IdentityEntity<TKey>, IAuditedEntity<TKey, TCreator, TEditor>
 	where TKey : IEquatable<TKey>
 	where TCreator : notnull
 {
@@ -23,29 +23,23 @@ public abstract class AuditedEntity<TKey, TCreator, TEdited> : IdentityEntity<TK
 	public TCreator CreatedBy { get; set; } = default!;
 
 	/// <inheritdoc/>
-	public TEdited EditedBy { get; set; } = default!;
+	public TEditor EditedBy { get; set; } = default!;
 }
 
-/// <inheritdoc cref="AuditedEntity{TKey, TCreator, TEdited}"/>
+/// <inheritdoc cref="AuditedEntity{TKey, TCreator, TEditor}"/>
 /// <remarks>
-/// The creator and editor types default to <see cref="string"/>.
+/// <typeparamref name="TKey"/> is supplied; <c>TCreator</c> defaults to <see cref="string"/>
+/// and <c>TEditor</c> to <see cref="string"/>. For a custom creator or editor type use
+/// <see cref="AuditedEntity{TKey, TCreator, TEditor}"/> and name all three.
 /// </remarks>
 public abstract class AuditedEntity<TKey> : AuditedEntity<TKey, string, string?>, IAuditedEntity<TKey>
 	where TKey : IEquatable<TKey>
 { }
 
-/// <inheritdoc cref="AuditedEntity{TKey, TCreator, TEdited}"/>
+/// <inheritdoc cref="AuditedEntity{TKey, TCreator, TEditor}"/>
 /// <remarks>
-/// The unique identifier is of type <see cref="Guid"/>.
-/// </remarks>
-public abstract class AuditedEntity<TCreator, TEdited> : AuditedEntity<Guid, TCreator, TEdited>, IAuditedEntity<TCreator, TEdited>
-	where TCreator : notnull
-{ }
-
-/// <inheritdoc cref="AuditedEntity{TKey, TCreator, TEdited}"/>
-/// <remarks>
-/// The unique identifier type defaults to <see cref="Guid"/> and the creator and editor
-/// types default to <see cref="string"/>.
+/// Nothing is supplied; <c>TKey</c> defaults to <see cref="Guid"/>, <c>TCreator</c> to
+/// <see cref="string"/> and <c>TEditor</c> to <see cref="string"/>.
 /// </remarks>
 public abstract class AuditedEntity : AuditedEntity<Guid, string, string?>, IAuditedEntity
 { }

--- a/src/BB84.EntityFrameworkCore.Entities/FullAuditedEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities/FullAuditedEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright: 2024 Robert Peter Meyer
+// Copyright: 2024 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -13,8 +13,8 @@ namespace BB84.EntityFrameworkCore.Entities;
 /// </summary>
 /// <typeparam name="TKey">The type of the unique identifier for the entity.</typeparam>
 /// <typeparam name="TCreator">The type representing the creator of the entity.</typeparam>
-/// <typeparam name="TEdited">The type representing the editor of the entity.</typeparam>
-public abstract class FullAuditedEntity<TKey, TCreator, TEdited> : IdentityEntity<TKey>, IFullAuditedEntity<TKey, TCreator, TEdited>
+/// <typeparam name="TEditor">The type representing the editor of the entity.</typeparam>
+public abstract class FullAuditedEntity<TKey, TCreator, TEditor> : IdentityEntity<TKey>, IFullAuditedEntity<TKey, TCreator, TEditor>
 	where TKey : IEquatable<TKey>
 	where TCreator : notnull
 {
@@ -23,28 +23,25 @@ public abstract class FullAuditedEntity<TKey, TCreator, TEdited> : IdentityEntit
 	/// <inheritdoc/>
 	public DateTimeOffset CreatedAt { get; set; } = default!;
 	/// <inheritdoc/>
-	public TEdited EditedBy { get; set; } = default!;
+	public TEditor EditedBy { get; set; } = default!;
 	/// <inheritdoc/>
 	public DateTimeOffset? EditedAt { get; set; } = default!;
 }
 
-/// <inheritdoc cref="FullAuditedEntity{TKey, TCreator, TEdited}"/>
+/// <inheritdoc cref="FullAuditedEntity{TKey, TCreator, TEditor}"/>
 /// <remarks>
-/// The creator and editor columns are of type <see cref="string"/>.
+/// <typeparamref name="TKey"/> is supplied; <c>TCreator</c> defaults to <see cref="string"/>
+/// and <c>TEditor</c> to <see cref="string"/>. For a custom creator or editor type use
+/// <see cref="FullAuditedEntity{TKey, TCreator, TEditor}"/> and name all three.
 /// </remarks>
 public abstract class FullAuditedEntity<TKey> : FullAuditedEntity<TKey, string, string?>, IFullAuditedEntity<TKey>
 	where TKey : IEquatable<TKey>
 { }
 
-
-/// <inheritdoc cref="FullAuditedEntity{TKey, TCreator, TEdited}"/>
+/// <inheritdoc cref="FullAuditedEntity{TKey, TCreator, TEditor}"/>
 /// <remarks>
-/// The identity column is of type <see cref="Guid"/>.
+/// Nothing is supplied; <c>TKey</c> defaults to <see cref="Guid"/>, <c>TCreator</c> to
+/// <see cref="string"/> and <c>TEditor</c> to <see cref="string"/>.
 /// </remarks>
-public abstract class FullAuditedEntity<TCreator, TEdited> : FullAuditedEntity<Guid, TCreator, TEdited>, IFullAuditedEntity<TCreator, TEdited>
-	where TCreator : notnull
-{ }
-
-/// <inheritdoc cref="FullAuditedEntity{TKey, TCreator, TEdited}"/>
 public abstract class FullAuditedEntity : FullAuditedEntity<Guid, string, string?>, IFullAuditedEntity
 { }

--- a/src/BB84.EntityFrameworkCore.Entities/README.md
+++ b/src/BB84.EntityFrameworkCore.Entities/README.md
@@ -13,21 +13,21 @@ dotnet add package BB84.EntityFrameworkCore.Entities
 
 ## Implementations
 
-Each abstract class mirrors the interface hierarchy. Convenience overloads follow the same defaulting pattern as the interfaces (`TKey` → `Guid`, `TCreator`/`TEdited` → `string`/`string?`).
+Each abstract class mirrors the interface hierarchy. Convenience overloads follow the same defaulting pattern as the interfaces (`TKey` → `Guid`, `TCreator`/`TEditor` → `string`/`string?`).
 
 | Abstract class                               | Implements                                    | Notes                                     |
 | -------------------------------------------- | --------------------------------------------- | ----------------------------------------- |
 | `IdentityEntity<TKey>`                       | `IIdentityEntity<TKey>`                       |                                           |
 | `IdentityEntity`                             | `IIdentityEntity`                             | `TKey` = `Guid`                           |
-| `AuditedEntity<TKey, TCreator, TEdited>`     | `IAuditedEntity<TKey, TCreator, TEdited>`     |                                           |
-| `AuditedEntity<TKey>`                        | `IAuditedEntity<TKey>`                        | `TCreator`/`TEdited` = `string`/`string?` |
+| `AuditedEntity<TKey, TCreator, TEditor>`     | `IAuditedEntity<TKey, TCreator, TEditor>`     |                                           |
+| `AuditedEntity<TKey>`                        | `IAuditedEntity<TKey>`                        | `TCreator`/`TEditor` = `string`/`string?` |
 | `AuditedEntity`                              | `IAuditedEntity`                              | `TKey` = `Guid`                           |
-| `FullAuditedEntity<TKey, TCreator, TEdited>` | `IFullAuditedEntity<TKey, TCreator, TEdited>` | Adds `CreatedAt`, `EditedAt`              |
+| `FullAuditedEntity<TKey, TCreator, TEditor>` | `IFullAuditedEntity<TKey, TCreator, TEditor>` | Adds `CreatedAt`, `EditedAt`              |
 | `FullAuditedEntity<TKey>`                    | `IFullAuditedEntity<TKey>`                    |                                           |
 | `FullAuditedEntity`                          | `IFullAuditedEntity`                          | `TKey` = `Guid`                           |
 | `CompositeEntity`                            | `ICompositeEntity`                            |                                           |
-| `AuditedCompositeEntity<TCreator, TEdited>`  | `IAuditedCompositeEntity<TCreator, TEdited>`  |                                           |
-| `AuditedCompositeEntity`                     | `IAuditedCompositeEntity`                     | `TCreator`/`TEdited` = `string`/`string?` |
+| `AuditedCompositeEntity<TCreator, TEditor>`  | `IAuditedCompositeEntity<TCreator, TEditor>`  |                                           |
+| `AuditedCompositeEntity`                     | `IAuditedCompositeEntity`                     | `TCreator`/`TEditor` = `string`/`string?` |
 | `EnumeratorEntity<TKey>`                     | `IEnumeratorEntity<TKey>`                     |                                           |
 | `EnumeratorEntity`                           | `IEnumeratorEntity`                           | `TKey` = `int`                            |
 
@@ -67,7 +67,7 @@ public class OrderItem : CompositeEntity
 // Lookup table (int PK, Name unique, soft-deletable)
 public class ProductCategory : EnumeratorEntity
 {
-    // Name and Description come from IEnumerator via EnumeratorEntity
+    // Name and Description come from IEnumeration via EnumeratorEntity
 }
 
 // Custom key type

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/AuditedCompositeConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/AuditedCompositeConfiguration.cs
@@ -12,17 +12,17 @@ using Base = BB84.EntityFrameworkCore.Repositories.Configurations;
 
 namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations;
 
-/// <inheritdoc cref="Base.AuditedCompositeConfiguration{TEntity, TCreator, TEdited}"/>
+/// <inheritdoc cref="Base.AuditedCompositeConfiguration{TEntity, TCreator, TEditor}"/>
 /// <remarks>
 /// Nothing in this rung is SQL Server specific. The type exists so that the ladder is complete
 /// in both namespaces and a consumer can pick the namespace rather than the type.
 /// </remarks>
-public abstract class AuditedCompositeConfiguration<TEntity, TCreator, TEdited> : Base.AuditedCompositeConfiguration<TEntity, TCreator, TEdited>, IEntityTypeConfiguration<TEntity>
-	where TEntity : class, IAuditedCompositeEntity<TCreator, TEdited>
+public abstract class AuditedCompositeConfiguration<TEntity, TCreator, TEditor> : Base.AuditedCompositeConfiguration<TEntity, TCreator, TEditor>, IEntityTypeConfiguration<TEntity>
+	where TEntity : class, IAuditedCompositeEntity<TCreator, TEditor>
 	where TCreator : notnull
 { }
 
-/// <inheritdoc cref="AuditedCompositeConfiguration{TEntity, TCreator, TEdited}"/>
+/// <inheritdoc cref="AuditedCompositeConfiguration{TEntity, TCreator, TEditor}"/>
 /// <remarks>
 /// The creator and editor columns are mapped as <b>sysname</b>.
 /// </remarks>

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/AuditedConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/AuditedConfiguration.cs
@@ -12,14 +12,14 @@ using Base = BB84.EntityFrameworkCore.Repositories.Configurations;
 
 namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations;
 
-/// <inheritdoc cref="Base.AuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/>
+/// <inheritdoc cref="Base.AuditedConfiguration{TEntity, TKey, TCreator, TEditor}"/>
 /// <remarks>
 /// Applies the provider-agnostic configuration of
-/// <see cref="Base.AuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/> and tunes it for
+/// <see cref="Base.AuditedConfiguration{TEntity, TKey, TCreator, TEditor}"/> and tunes it for
 /// SQL Server by declaring the primary key as non clustered.
 /// </remarks>
-public abstract class AuditedConfiguration<TEntity, TKey, TCreator, TEdited> : Base.AuditedConfiguration<TEntity, TKey, TCreator, TEdited>, IEntityTypeConfiguration<TEntity>
-	where TEntity : class, IAuditedEntity<TKey, TCreator, TEdited>
+public abstract class AuditedConfiguration<TEntity, TKey, TCreator, TEditor> : Base.AuditedConfiguration<TEntity, TKey, TCreator, TEditor>, IEntityTypeConfiguration<TEntity>
+	where TEntity : class, IAuditedEntity<TKey, TCreator, TEditor>
 	where TKey : IEquatable<TKey>
 	where TCreator : notnull
 {
@@ -32,9 +32,12 @@ public abstract class AuditedConfiguration<TEntity, TKey, TCreator, TEdited> : B
 	}
 }
 
-/// <inheritdoc cref="AuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/>
+/// <inheritdoc cref="AuditedConfiguration{TEntity, TKey, TCreator, TEditor}"/>
 /// <remarks>
-/// The creator and editor columns are mapped as <b>sysname</b>.
+/// <typeparamref name="TKey"/> is supplied; <c>TCreator</c> and <c>TEditor</c> default to
+/// <see cref="string"/> and their columns are mapped as <b>sysname</b>. For a custom creator
+/// or editor type use <see cref="AuditedConfiguration{TEntity, TKey, TCreator, TEditor}"/> and
+/// name all four.
 /// </remarks>
 public abstract class AuditedConfiguration<TEntity, TKey> : AuditedConfiguration<TEntity, TKey, string, string?>, IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IAuditedEntity<TKey>
@@ -49,27 +52,11 @@ public abstract class AuditedConfiguration<TEntity, TKey> : AuditedConfiguration
 	}
 }
 
-/// <inheritdoc cref="AuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/>
+/// <inheritdoc cref="AuditedConfiguration{TEntity, TKey, TCreator, TEditor}"/>
 /// <remarks>
-/// The identifier column defaults to <c>NEWID()</c>.
-/// </remarks>
-public abstract class AuditedConfiguration<TEntity, TCreator, TEdited> : AuditedConfiguration<TEntity, Guid, TCreator, TEdited>, IEntityTypeConfiguration<TEntity>
-	where TEntity : class, IAuditedEntity<TCreator, TEdited>
-	where TCreator : notnull
-{
-	/// <inheritdoc/>
-	public override void Configure(EntityTypeBuilder<TEntity> builder)
-	{
-		base.Configure(builder);
-
-		EntityTypeBuilderDefaults.ApplyGuidIdDefault(builder);
-	}
-}
-
-/// <inheritdoc cref="AuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/>
-/// <remarks>
-/// The identifier column defaults to <c>NEWID()</c> and the creator and editor columns are
-/// mapped as <b>sysname</b>.
+/// Only <typeparamref name="TEntity"/> is supplied; <c>TKey</c> defaults to <see cref="Guid"/>
+/// and the identifier column defaults to <c>NEWID()</c>, while <c>TCreator</c> and
+/// <c>TEditor</c> default to <see cref="string"/> and are mapped as <b>sysname</b>.
 /// </remarks>
 public abstract class AuditedConfiguration<TEntity> : AuditedConfiguration<TEntity, Guid, string, string?>,
 	IEntityTypeConfiguration<TEntity> where TEntity : class, IAuditedEntity

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/FullAuditedConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Configurations/FullAuditedConfiguration.cs
@@ -12,14 +12,14 @@ using Base = BB84.EntityFrameworkCore.Repositories.Configurations;
 
 namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations;
 
-/// <inheritdoc cref="Base.FullAuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/>
+/// <inheritdoc cref="Base.FullAuditedConfiguration{TEntity, TKey, TCreator, TEditor}"/>
 /// <remarks>
 /// Applies the provider-agnostic configuration of
-/// <see cref="Base.FullAuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/> and tunes it for
+/// <see cref="Base.FullAuditedConfiguration{TEntity, TKey, TCreator, TEditor}"/> and tunes it for
 /// SQL Server by declaring the primary key as non clustered.
 /// </remarks>
-public abstract class FullAuditedConfiguration<TEntity, TKey, TCreator, TEdited> : Base.FullAuditedConfiguration<TEntity, TKey, TCreator, TEdited>, IEntityTypeConfiguration<TEntity>
-	where TEntity : class, IFullAuditedEntity<TKey, TCreator, TEdited>
+public abstract class FullAuditedConfiguration<TEntity, TKey, TCreator, TEditor> : Base.FullAuditedConfiguration<TEntity, TKey, TCreator, TEditor>, IEntityTypeConfiguration<TEntity>
+	where TEntity : class, IFullAuditedEntity<TKey, TCreator, TEditor>
 	where TKey : IEquatable<TKey>
 	where TCreator : notnull
 {
@@ -32,9 +32,12 @@ public abstract class FullAuditedConfiguration<TEntity, TKey, TCreator, TEdited>
 	}
 }
 
-/// <inheritdoc cref="FullAuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/>
+/// <inheritdoc cref="FullAuditedConfiguration{TEntity, TKey, TCreator, TEditor}"/>
 /// <remarks>
-/// The creator and editor columns are mapped as <b>sysname</b>.
+/// <typeparamref name="TKey"/> is supplied; <c>TCreator</c> and <c>TEditor</c> default to
+/// <see cref="string"/> and their columns are mapped as <b>sysname</b>. For a custom creator
+/// or editor type use <see cref="FullAuditedConfiguration{TEntity, TKey, TCreator, TEditor}"/>
+/// and name all four.
 /// </remarks>
 public abstract class FullAuditedConfiguration<TEntity, TKey> : FullAuditedConfiguration<TEntity, TKey, string, string?>, IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IFullAuditedEntity<TKey>
@@ -49,27 +52,11 @@ public abstract class FullAuditedConfiguration<TEntity, TKey> : FullAuditedConfi
 	}
 }
 
-/// <inheritdoc cref="FullAuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/>
+/// <inheritdoc cref="FullAuditedConfiguration{TEntity, TKey, TCreator, TEditor}"/>
 /// <remarks>
-/// The identifier column defaults to <c>NEWID()</c>.
-/// </remarks>
-public abstract class FullAuditedConfiguration<TEntity, TCreator, TEdited> : FullAuditedConfiguration<TEntity, Guid, TCreator, TEdited>, IEntityTypeConfiguration<TEntity>
-	where TEntity : class, IFullAuditedEntity<TCreator, TEdited>
-	where TCreator : notnull
-{
-	/// <inheritdoc/>
-	public override void Configure(EntityTypeBuilder<TEntity> builder)
-	{
-		base.Configure(builder);
-
-		EntityTypeBuilderDefaults.ApplyGuidIdDefault(builder);
-	}
-}
-
-/// <inheritdoc cref="FullAuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/>
-/// <remarks>
-/// The identifier column defaults to <c>NEWID()</c> and the creator and editor columns are
-/// mapped as <b>sysname</b>.
+/// Only <typeparamref name="TEntity"/> is supplied; <c>TKey</c> defaults to <see cref="Guid"/>
+/// and the identifier column defaults to <c>NEWID()</c>, while <c>TCreator</c> and
+/// <c>TEditor</c> default to <see cref="string"/> and are mapped as <b>sysname</b>.
 /// </remarks>
 public abstract class FullAuditedConfiguration<TEntity> : FullAuditedConfiguration<TEntity, Guid, string, string?>, IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IFullAuditedEntity

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/README.md
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/README.md
@@ -19,10 +19,10 @@ dotnet add package BB84.EntityFrameworkCore.Repositories.SqlServer
 
 Each configuration ladder exists twice, under the **same type names**:
 
-| Namespace                                                | Applies                                                                     |
-| -------------------------------------------------------- | --------------------------------------------------------------------------- |
-| `BB84.EntityFrameworkCore.Repositories.Configurations`   | Key declaration, column order, concurrency token, audit columns, soft delete filter |
-| `BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations` | The above, plus clustering, `NEWID()` defaults and `sysname` audit columns |
+| Namespace                                                        | Applies                                                                             |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `BB84.EntityFrameworkCore.Repositories.Configurations`           | Key declaration, column order, concurrency token, audit columns, soft delete filter |
+| `BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations` | The above, plus clustering, `NEWID()` defaults and `sysname` audit columns          |
 
 Pick the namespace, not the type. On SQL Server, keep importing this package's namespace and nothing changes. On any other provider, import the agnostic one and you get everything except the three SQL Server calls.
 
@@ -36,14 +36,14 @@ using SqlServerConfigurations = BB84.EntityFrameworkCore.Repositories.SqlServer.
 
 Inherit from these in your `IEntityTypeConfiguration<TEntity>` implementations and call `base.Configure(builder)` to apply the standard column order, constraints, concurrency tokens, and indexes. Override before or after the base call to add entity-specific configuration.
 
-| Configuration class                                          | For entity type                               | What `base.Configure` applies                                                                                                                                        |
-| ------------------------------------------------------------ | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `IdentityConfiguration<TEntity, TKey>`                       | `IIdentityEntity<TKey>`                       | Non-clustered PK, `Id` (`ValueGeneratedOnAdd`), `Timestamp` as concurrency token                                                                                     |
-| `AuditedConfiguration<TEntity, TKey, TCreator, TEdited>`     | `IAuditedEntity<TKey, TCreator, TEdited>`     | Above + `CreatedBy` (required), `EditedBy` (optional); `string` overload maps both as `sysname`                                                                      |
-| `FullAuditedConfiguration<TEntity, TKey, TCreator, TEdited>` | `IFullAuditedEntity<TKey, TCreator, TEdited>` | Above + `CreatedAt` (required), `EditedAt` (optional); `Guid` overload adds `NEWID()` default                                                                        |
-| `CompositeConfiguration<TEntity>`                            | `ICompositeEntity`                            | `Timestamp` as concurrency token                                                                                                                                     |
-| `AuditedCompositeConfiguration<TEntity, TCreator, TEdited>`  | `IAuditedCompositeEntity<TCreator, TEdited>`  | Above + audit user columns                                                                                                                                           |
-| `EnumeratorConfiguration<TEntity, TKey>`                     | `IEnumeratorEntity<TKey>`                     | Non-clustered PK, `Name` (`nvarchar(64)`, unique index, non-unicode), `Description` (`nvarchar(256)`), `IsDeleted` default `false`; `int` overload uses clustered PK |
+| Configuration class                                          | For entity type                               | What `base.Configure` applies                                                                                                                                         |
+| ------------------------------------------------------------ | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `IdentityConfiguration<TEntity, TKey>`                       | `IIdentityEntity<TKey>`                       | Non-clustered PK, `Id` (`ValueGeneratedOnAdd`), `Timestamp` as concurrency token                                                                                      |
+| `AuditedConfiguration<TEntity, TKey, TCreator, TEditor>`     | `IAuditedEntity<TKey, TCreator, TEditor>`     | Above + `CreatedBy` (required), `EditedBy` (optional); the `<TEntity, TKey>` overload maps both as `sysname`, the `<TEntity>` overload adds the `NEWID()` default too |
+| `FullAuditedConfiguration<TEntity, TKey, TCreator, TEditor>` | `IFullAuditedEntity<TKey, TCreator, TEditor>` | Above + `CreatedAt` (required), `EditedAt` (optional); same overload behaviour                                                                                        |
+| `CompositeConfiguration<TEntity>`                            | `ICompositeEntity`                            | `Timestamp` as concurrency token                                                                                                                                      |
+| `AuditedCompositeConfiguration<TEntity, TCreator, TEditor>`  | `IAuditedCompositeEntity<TCreator, TEditor>`  | Above + audit user columns                                                                                                                                            |
+| `EnumeratorConfiguration<TEntity, TKey>`                     | `IEnumeratorEntity<TKey>`                     | Non-clustered PK, `Name` (`nvarchar(64)`, unique index, non-unicode), `Description` (`nvarchar(256)`), `IsDeleted` default `false`; `int` overload uses clustered PK  |
 
 ```csharp
 public class ProductConfiguration : IdentityConfiguration<Product>

--- a/src/BB84.EntityFrameworkCore.Repositories/Configurations/AuditedCompositeConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Configurations/AuditedCompositeConfiguration.cs
@@ -12,7 +12,7 @@ namespace BB84.EntityFrameworkCore.Repositories.Configurations;
 
 /// <summary>
 /// Provides a base configuration for entities that implement the
-/// <see cref="IAuditedCompositeEntity{TCreator, TEdited}"/> interface.
+/// <see cref="IAuditedCompositeEntity{TCreator, TEditor}"/> interface.
 /// </summary>
 /// <remarks>
 /// This abstract class provides a reusable configuration for audited composite entities,
@@ -23,20 +23,20 @@ namespace BB84.EntityFrameworkCore.Repositories.Configurations;
 /// </remarks>
 /// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
 /// <typeparam name="TCreator">The type representing the creator of the entity.</typeparam>
-/// <typeparam name="TEdited">The type representing the editor of the entity.</typeparam>
-public abstract class AuditedCompositeConfiguration<TEntity, TCreator, TEdited> : IEntityTypeConfiguration<TEntity>
-	where TEntity : class, IAuditedCompositeEntity<TCreator, TEdited>
+/// <typeparam name="TEditor">The type representing the editor of the entity.</typeparam>
+public abstract class AuditedCompositeConfiguration<TEntity, TCreator, TEditor> : IEntityTypeConfiguration<TEntity>
+	where TEntity : class, IAuditedCompositeEntity<TCreator, TEditor>
 	where TCreator : notnull
 {
 	/// <inheritdoc/>
 	public virtual void Configure(EntityTypeBuilder<TEntity> builder)
 	{
 		EntityTypeBuilderDefaults.ApplyConcurrencyToken(builder, columnOrder: 3);
-		EntityTypeBuilderDefaults.ApplyUserAuditColumns<TEntity, TCreator, TEdited>(builder, createdByOrder: 4, editedByOrder: 5);
+		EntityTypeBuilderDefaults.ApplyUserAuditColumns<TEntity, TCreator, TEditor>(builder, createdByOrder: 4, editedByOrder: 5);
 	}
 }
 
-/// <inheritdoc cref="AuditedCompositeConfiguration{TEntity, TCreator, TEdited}"/>
+/// <inheritdoc cref="AuditedCompositeConfiguration{TEntity, TCreator, TEditor}"/>
 public abstract class AuditedCompositeConfiguration<TEntity> : AuditedCompositeConfiguration<TEntity, string, string?>, IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IAuditedCompositeEntity
 { }

--- a/src/BB84.EntityFrameworkCore.Repositories/Configurations/AuditedConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Configurations/AuditedConfiguration.cs
@@ -12,7 +12,7 @@ namespace BB84.EntityFrameworkCore.Repositories.Configurations;
 
 /// <summary>
 /// Represents an abstract base class for configuring the entities of type
-/// <see cref="IAuditedEntity{TKey, TCreator, TEdited}"/> for identity-related and time audited
+/// <see cref="IAuditedEntity{TKey, TCreator, TEditor}"/> for identity-related and time audited
 /// entities in the Entity Framework Core model.
 /// </summary>
 /// <remarks>
@@ -23,9 +23,9 @@ namespace BB84.EntityFrameworkCore.Repositories.Configurations;
 /// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
 /// <typeparam name="TKey">The type of the primary key for the entity.</typeparam>
 /// <typeparam name="TCreator">The type representing the creator of the entity.</typeparam>
-/// <typeparam name="TEdited">The type representing the editor of the entity.</typeparam>
-public abstract class AuditedConfiguration<TEntity, TKey, TCreator, TEdited> : IEntityTypeConfiguration<TEntity>
-	where TEntity : class, IAuditedEntity<TKey, TCreator, TEdited>
+/// <typeparam name="TEditor">The type representing the editor of the entity.</typeparam>
+public abstract class AuditedConfiguration<TEntity, TKey, TCreator, TEditor> : IEntityTypeConfiguration<TEntity>
+	where TEntity : class, IAuditedEntity<TKey, TCreator, TEditor>
 	where TKey : IEquatable<TKey>
 	where TCreator : notnull
 {
@@ -34,23 +34,26 @@ public abstract class AuditedConfiguration<TEntity, TKey, TCreator, TEdited> : I
 	{
 		EntityTypeBuilderDefaults.ApplyIdentityKey<TEntity, TKey>(builder);
 		EntityTypeBuilderDefaults.ApplyConcurrencyToken(builder, columnOrder: 2);
-		EntityTypeBuilderDefaults.ApplyUserAuditColumns<TEntity, TCreator, TEdited>(builder, createdByOrder: 3, editedByOrder: 4);
+		EntityTypeBuilderDefaults.ApplyUserAuditColumns<TEntity, TCreator, TEditor>(builder, createdByOrder: 3, editedByOrder: 4);
 	}
 }
 
-/// <inheritdoc cref="AuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/>
+/// <inheritdoc cref="AuditedConfiguration{TEntity, TKey, TCreator, TEditor}"/>
+/// <remarks>
+/// <typeparamref name="TKey"/> is supplied; <c>TCreator</c> defaults to <see cref="string"/>
+/// and <c>TEditor</c> to <see cref="string"/>. For a custom creator or editor type use
+/// <see cref="AuditedConfiguration{TEntity, TKey, TCreator, TEditor}"/> and name all four.
+/// </remarks>
 public abstract class AuditedConfiguration<TEntity, TKey> : AuditedConfiguration<TEntity, TKey, string, string?>, IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IAuditedEntity<TKey>
 	where TKey : IEquatable<TKey>
 { }
 
-/// <inheritdoc cref="AuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/>
-public abstract class AuditedConfiguration<TEntity, TCreator, TEdited> : AuditedConfiguration<TEntity, Guid, TCreator, TEdited>, IEntityTypeConfiguration<TEntity>
-	where TEntity : class, IAuditedEntity<TCreator, TEdited>
-	where TCreator : notnull
-{ }
-
-/// <inheritdoc cref="AuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/>
+/// <inheritdoc cref="AuditedConfiguration{TEntity, TKey, TCreator, TEditor}"/>
+/// <remarks>
+/// Only <typeparamref name="TEntity"/> is supplied; <c>TKey</c> defaults to <see cref="Guid"/>,
+/// <c>TCreator</c> to <see cref="string"/> and <c>TEditor</c> to <see cref="string"/>.
+/// </remarks>
 public abstract class AuditedConfiguration<TEntity> : AuditedConfiguration<TEntity, Guid, string, string?>,
 	IEntityTypeConfiguration<TEntity> where TEntity : class, IAuditedEntity
 { }

--- a/src/BB84.EntityFrameworkCore.Repositories/Configurations/EntityTypeBuilderDefaults.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Configurations/EntityTypeBuilderDefaults.cs
@@ -60,12 +60,12 @@ internal static class EntityTypeBuilderDefaults
 	/// </summary>
 	/// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
 	/// <typeparam name="TCreator">The type representing the creator of the entity.</typeparam>
-	/// <typeparam name="TEdited">The type representing the editor of the entity.</typeparam>
+	/// <typeparam name="TEditor">The type representing the editor of the entity.</typeparam>
 	/// <param name="builder">The builder for the entity type being configured.</param>
 	/// <param name="createdByOrder">The ordering of the creator column within the table.</param>
 	/// <param name="editedByOrder">The ordering of the editor column within the table.</param>
-	internal static void ApplyUserAuditColumns<TEntity, TCreator, TEdited>(EntityTypeBuilder<TEntity> builder, int createdByOrder, int editedByOrder)
-		where TEntity : class, IUserAudited<TCreator, TEdited>
+	internal static void ApplyUserAuditColumns<TEntity, TCreator, TEditor>(EntityTypeBuilder<TEntity> builder, int createdByOrder, int editedByOrder)
+		where TEntity : class, IUserAudited<TCreator, TEditor>
 		where TCreator : notnull
 	{
 		builder.Property(e => e.CreatedBy)

--- a/src/BB84.EntityFrameworkCore.Repositories/Configurations/FullAuditedConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Configurations/FullAuditedConfiguration.cs
@@ -14,7 +14,7 @@ namespace BB84.EntityFrameworkCore.Repositories.Configurations;
 
 /// <summary>
 /// Provides a base configuration for entities that implement the
-/// <see cref="IFullAuditedEntity{TKey, TCreator, TEdited}"/> interface.
+/// <see cref="IFullAuditedEntity{TKey, TCreator, TEditor}"/> interface.
 /// </summary>
 /// <remarks>
 /// This configuration defines common properties for audited entities, including primary key,
@@ -24,10 +24,10 @@ namespace BB84.EntityFrameworkCore.Repositories.Configurations;
 /// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
 /// <typeparam name="TKey">The type of the primary key for the entity.</typeparam>
 /// <typeparam name="TCreator">The type representing the creator of the entity.</typeparam>
-/// <typeparam name="TEdited">The type representing the editor of the entity.</typeparam>
+/// <typeparam name="TEditor">The type representing the editor of the entity.</typeparam>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
-public abstract class FullAuditedConfiguration<TEntity, TKey, TCreator, TEdited> : IEntityTypeConfiguration<TEntity>
-	where TEntity : class, IFullAuditedEntity<TKey, TCreator, TEdited>
+public abstract class FullAuditedConfiguration<TEntity, TKey, TCreator, TEditor> : IEntityTypeConfiguration<TEntity>
+	where TEntity : class, IFullAuditedEntity<TKey, TCreator, TEditor>
 	where TKey : IEquatable<TKey>
 	where TCreator : notnull
 {
@@ -36,7 +36,7 @@ public abstract class FullAuditedConfiguration<TEntity, TKey, TCreator, TEdited>
 	{
 		EntityTypeBuilderDefaults.ApplyIdentityKey<TEntity, TKey>(builder);
 		EntityTypeBuilderDefaults.ApplyConcurrencyToken(builder, columnOrder: 2);
-		EntityTypeBuilderDefaults.ApplyUserAuditColumns<TEntity, TCreator, TEdited>(builder, createdByOrder: 3, editedByOrder: 5);
+		EntityTypeBuilderDefaults.ApplyUserAuditColumns<TEntity, TCreator, TEditor>(builder, createdByOrder: 3, editedByOrder: 5);
 
 		builder.Property(p => p.CreatedAt)
 			.HasColumnOrder(4)
@@ -48,19 +48,22 @@ public abstract class FullAuditedConfiguration<TEntity, TKey, TCreator, TEdited>
 	}
 }
 
-/// <inheritdoc cref="FullAuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/>
+/// <inheritdoc cref="FullAuditedConfiguration{TEntity, TKey, TCreator, TEditor}"/>
+/// <remarks>
+/// <typeparamref name="TKey"/> is supplied; <c>TCreator</c> defaults to <see cref="string"/>
+/// and <c>TEditor</c> to <see cref="string"/>. For a custom creator or editor type use
+/// <see cref="FullAuditedConfiguration{TEntity, TKey, TCreator, TEditor}"/> and name all four.
+/// </remarks>
 public abstract class FullAuditedConfiguration<TEntity, TKey> : FullAuditedConfiguration<TEntity, TKey, string, string?>, IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IFullAuditedEntity<TKey>
 	where TKey : IEquatable<TKey>
 { }
 
-/// <inheritdoc cref="FullAuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/>
-public abstract class FullAuditedConfiguration<TEntity, TCreator, TEdited> : FullAuditedConfiguration<TEntity, Guid, TCreator, TEdited>, IEntityTypeConfiguration<TEntity>
-	where TEntity : class, IFullAuditedEntity<TCreator, TEdited>
-	where TCreator : notnull
-{ }
-
-/// <inheritdoc cref="FullAuditedConfiguration{TEntity, TKey, TCreator, TEdited}"/>
+/// <inheritdoc cref="FullAuditedConfiguration{TEntity, TKey, TCreator, TEditor}"/>
+/// <remarks>
+/// Only <typeparamref name="TEntity"/> is supplied; <c>TKey</c> defaults to <see cref="Guid"/>,
+/// <c>TCreator</c> to <see cref="string"/> and <c>TEditor</c> to <see cref="string"/>.
+/// </remarks>
 public abstract class FullAuditedConfiguration<TEntity> : FullAuditedConfiguration<TEntity, Guid, string, string?>, IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IFullAuditedEntity
 { }

--- a/src/BB84.EntityFrameworkCore.Repositories/README.md
+++ b/src/BB84.EntityFrameworkCore.Repositories/README.md
@@ -111,13 +111,13 @@ Provider-agnostic `IEntityTypeConfiguration<TEntity>` base classes in `BB84.Enti
 | Configuration class                                          | For entity type                               |
 | ------------------------------------------------------------ | --------------------------------------------- |
 | `IdentityConfiguration<TEntity, TKey>`                       | `IIdentityEntity<TKey>`                       |
-| `AuditedConfiguration<TEntity, TKey, TCreator, TEdited>`     | `IAuditedEntity<TKey, TCreator, TEdited>`     |
-| `FullAuditedConfiguration<TEntity, TKey, TCreator, TEdited>` | `IFullAuditedEntity<TKey, TCreator, TEdited>` |
+| `AuditedConfiguration<TEntity, TKey, TCreator, TEditor>`     | `IAuditedEntity<TKey, TCreator, TEditor>`     |
+| `FullAuditedConfiguration<TEntity, TKey, TCreator, TEditor>` | `IFullAuditedEntity<TKey, TCreator, TEditor>` |
 | `CompositeConfiguration<TEntity>`                            | `ICompositeEntity`                            |
-| `AuditedCompositeConfiguration<TEntity, TCreator, TEdited>`  | `IAuditedCompositeEntity<TCreator, TEdited>`  |
+| `AuditedCompositeConfiguration<TEntity, TCreator, TEditor>`  | `IAuditedCompositeEntity<TCreator, TEditor>`  |
 | `EnumeratorConfiguration<TEntity, TKey>`                     | `IEnumeratorEntity<TKey>`                     |
 
-Each ladder has narrower generic aliases that default the key to `Guid` (`int` for the enumerator) and the creator/editor to `string`.
+Each ladder has narrower generic aliases: one that supplies the key and defaults the creator/editor to `string`, and one that supplies nothing and defaults the key to `Guid` (`int` for the enumerator) as well. There is deliberately no alias that defaults the key alone — pick the full form and name every parameter when the creator or editor type is not `string`.
 
 On SQL Server, use the same type names from `BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations` instead — those derive from these and add clustering, `NEWID()` defaults and `sysname` audit columns.
 


### PR DESCRIPTION
**Changes:**

- Renamed the `IEnumerator` component to `IEnumeration`.
- Surrounding `Enumerator*` vocabulary (`IEnumeratorEntity`, `EnumeratorEntity`, `EnumeratorRepository`, `EnumeratorConfiguration`) is deliberately kept.
- Standardise the audit type parameter on `TEditor`. `TCreator` is the agent that created the row; its counterpart is the agent that edited it, not the thing that was edited.
- Droped the ambiguous two-argument rungs. `IAuditedEntity<int, string>` read as "int key, string creator" but meant "int creator, string editor" with the key silently defaulted to `Guid`.
- Removed from `IAuditedEntity`, `IFullAuditedEntity`, `AuditedEntity`, `FullAuditedEntity` and, because their constraints named the removed interfaces, from the `AuditedConfiguration` and `FullAuditedConfiguration` ladders in both the agnostic and the SqlServer package.
- Composite ladders keep their two-argument rung: they are keyless by design and have no `<TKey>` sibling to be confused with.
- Surviving rungs now state in their remarks exactly which parameters are defaulted.

closes #229 & closes #230 & closes #231 