### PR TITLE
feat(sqlserver): add generic property builder overloads

### DIFF
--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Extensions/EntityTypeBuilderExtensions.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Extensions/EntityTypeBuilderExtensions.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Extensions;
 
 /// <summary>
-/// Provides extension methods for configuring entity types in a relational database context.
+/// Provides extension methods for configuring entity types against SQL Server.
 /// </summary>
 /// <remarks>
 /// The <see cref="EntityTypeBuilderExtensions"/> class contains methods to simplify the

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Extensions/PropertyBuilderExtensions.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/Extensions/PropertyBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright: 2024 Robert Peter Meyer
+// Copyright: 2024 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -9,40 +9,59 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 namespace BB84.EntityFrameworkCore.Repositories.SqlServer.Extensions;
 
 /// <summary>
-/// Provides extension methods for configuring property data types in a relational
-/// database using the <see cref="PropertyBuilder"/> class.
+/// Provides extension methods for configuring SQL Server column types using the
+/// <see cref="PropertyBuilder"/> and <see cref="PropertyBuilder{TProperty}"/> classes.
 /// </summary>
 /// <remarks>
+/// <para>
 /// The <see cref="PropertyBuilderExtensions"/> class provides extension methods that allow
-/// developers to specify the SQL data type for a property when using Entity Framework Core
-/// to map their domain models to a relational database. Each method configures the column
-/// type for the property being built, enabling precise control over the database schema.
+/// developers to specify the SQL Server data type for a property when using Entity Framework
+/// Core to map their domain models to the database. Each method configures the column type for
+/// the property being built, enabling precise control over the database schema.
+/// </para>
+/// <para>
+/// Every method comes in two forms. The generic form extends
+/// <see cref="PropertyBuilder{TProperty}"/> and returns it unchanged, so the property type
+/// survives the call and anything typed further along the chain — <c>HasDefaultValue</c>,
+/// <c>HasConversion</c>, <c>HasValueGenerator</c> — stays compile-time checked. The non-generic
+/// form exists for the <see cref="EntityTypeBuilder.Property(string)"/> path used by shadow
+/// properties, where no property type is available.
+/// </para>
 /// </remarks>
 public static class PropertyBuilderExtensions
 {
 	/// <summary>
-	/// Configures the data type of the column to <c>binary</c> when targeting a relational database.
+	/// Configures the data type of the column to <c>binary</c>.
 	/// </summary>
 	/// <param name="builder">The builder for the property being configured.</param>
-	/// <param name="length">This can be a value from 1 through 8,000. max indicates that the maximum
-	/// storage size is <c>2^31-1</c> bytes.</param>
+	/// <param name="length">This can be a value from 1 through 8,000.</param>
 	/// <returns>The same builder instance so that multiple calls can be chained.</returns>
+	/// <exception cref="ArgumentOutOfRangeException">
+	/// <paramref name="length"/> is less than 1 or greater than 8,000.
+	/// </exception>
 	public static PropertyBuilder IsBinaryColumn(this PropertyBuilder builder, int length = 8000)
-		=> length is < 1 or > 8000
-			? throw new ArgumentOutOfRangeException(nameof(length), "Must be between 1 and 8000.")
-			: builder.HasColumnType($"binary({length})");
+		=> builder.HasColumnType(BinaryColumnType(length));
+
+	/// <inheritdoc cref="IsBinaryColumn(PropertyBuilder, int)"/>
+	/// <typeparam name="TProperty">The type of the property being configured.</typeparam>
+	public static PropertyBuilder<TProperty> IsBinaryColumn<TProperty>(this PropertyBuilder<TProperty> builder, int length = 8000)
+		=> builder.HasColumnType(BinaryColumnType(length));
 
 	/// <summary>
-	/// Configures the data type of the column to <b>date</b> when targeting a relational database.
+	/// Configures the data type of the column to <c>date</c>.
 	/// </summary>
 	/// <param name="builder">The builder for the property being configured.</param>
 	/// <returns>The same builder instance so that multiple calls can be chained.</returns>
 	public static PropertyBuilder IsDateColumn(this PropertyBuilder builder)
 		=> builder.HasColumnType("date");
 
+	/// <inheritdoc cref="IsDateColumn(PropertyBuilder)"/>
+	/// <typeparam name="TProperty">The type of the property being configured.</typeparam>
+	public static PropertyBuilder<TProperty> IsDateColumn<TProperty>(this PropertyBuilder<TProperty> builder)
+		=> builder.HasColumnType("date");
+
 	/// <summary>
-	/// Configures the data type of the column to <c>datetime</c> or <c>smalldatetime</c> when targeting a
-	/// relational database.
+	/// Configures the data type of the column to <c>datetime</c> or <c>smalldatetime</c>.
 	/// </summary>
 	/// <param name="builder">The builder for the property being configured.</param>
 	/// <param name="small">Indicates if <b>small date time</b> should be used.</param>
@@ -50,48 +69,68 @@ public static class PropertyBuilderExtensions
 	public static PropertyBuilder IsDateTimeColumn(this PropertyBuilder builder, bool small = false)
 		=> builder.HasColumnType(small ? "smalldatetime" : "datetime");
 
+	/// <inheritdoc cref="IsDateTimeColumn(PropertyBuilder, bool)"/>
+	/// <typeparam name="TProperty">The type of the property being configured.</typeparam>
+	public static PropertyBuilder<TProperty> IsDateTimeColumn<TProperty>(this PropertyBuilder<TProperty> builder, bool small = false)
+		=> builder.HasColumnType(small ? "smalldatetime" : "datetime");
+
 	/// <summary>
-	/// Configures the data type of the column to <c>datetime2</c> when targeting a relational database.
+	/// Configures the data type of the column to <c>datetime2</c>.
 	/// </summary>
 	/// <param name="builder">The builder for the property being configured.</param>
 	/// <param name="precision">The optional type parameter fractional seconds precision specifies the number
 	/// of digits for the fractional part of the seconds.</param>
 	/// <returns>The same builder instance so that multiple calls can be chained.</returns>
+	/// <exception cref="ArgumentOutOfRangeException">
+	/// <paramref name="precision"/> is less than 0 or greater than 7.
+	/// </exception>
 	public static PropertyBuilder IsDateTime2Column(this PropertyBuilder builder, int precision = 7)
-		=> precision is < 0 or > 7
-			? throw new ArgumentOutOfRangeException(nameof(precision), "Must be between 0 and 7.")
-			: builder.HasColumnType($"datetime2({precision})");
+		=> builder.HasColumnType(DateTime2ColumnType(precision));
+
+	/// <inheritdoc cref="IsDateTime2Column(PropertyBuilder, int)"/>
+	/// <typeparam name="TProperty">The type of the property being configured.</typeparam>
+	public static PropertyBuilder<TProperty> IsDateTime2Column<TProperty>(this PropertyBuilder<TProperty> builder, int precision = 7)
+		=> builder.HasColumnType(DateTime2ColumnType(precision));
 
 	/// <summary>
-	/// Configures the data type of the column to <c>datetimeoffset</c> when targeting a relational database.
+	/// Configures the data type of the column to <c>datetimeoffset</c>.
 	/// </summary>
 	/// <param name="builder">The builder for the property being configured.</param>
 	/// <param name="precision">The optional type parameter fractional seconds precision specifies the number
 	/// of digits for the fractional part of the seconds.</param>
 	/// <returns>The same builder instance so that multiple calls can be chained.</returns>
-	/// <exception cref="ArgumentOutOfRangeException"></exception>
+	/// <exception cref="ArgumentOutOfRangeException">
+	/// <paramref name="precision"/> is less than 0 or greater than 7.
+	/// </exception>
 	public static PropertyBuilder IsDateTimeOffsetColumn(this PropertyBuilder builder, int precision = 7)
-		=> precision is < 0 or > 7
-			? throw new ArgumentOutOfRangeException(nameof(precision), "Must be between 0 and 7.")
-			: builder.HasColumnType($"datetimeoffset({precision})");
+		=> builder.HasColumnType(DateTimeOffsetColumnType(precision));
+
+	/// <inheritdoc cref="IsDateTimeOffsetColumn(PropertyBuilder, int)"/>
+	/// <typeparam name="TProperty">The type of the property being configured.</typeparam>
+	public static PropertyBuilder<TProperty> IsDateTimeOffsetColumn<TProperty>(this PropertyBuilder<TProperty> builder, int precision = 7)
+		=> builder.HasColumnType(DateTimeOffsetColumnType(precision));
 
 	/// <summary>
-	/// Configures the data type of the column to <c>decimal</c> when targeting a relational database.
+	/// Configures the data type of the column to <c>decimal</c>.
 	/// </summary>
 	/// <param name="builder">The builder for the property being configured.</param>
 	/// <param name="precision">The maximum total number of decimal digits to be stored.</param>
 	/// <param name="scale">The number of decimal digits that are stored to the right of the decimal point.</param>
 	/// <returns>The same builder instance so that multiple calls can be chained.</returns>
-	/// <exception cref="ArgumentOutOfRangeException"></exception>
+	/// <exception cref="ArgumentOutOfRangeException">
+	/// <paramref name="precision"/> is less than 1 or greater than 38, or <paramref name="scale"/>
+	/// is less than 0 or greater than <paramref name="precision"/>.
+	/// </exception>
 	public static PropertyBuilder IsDecimalColumn(this PropertyBuilder builder, int precision = 18, int scale = 2)
-		=> precision is < 1 or > 38
-			? throw new ArgumentOutOfRangeException(nameof(precision), "Must be between 1 and 38.")
-			: scale < 0 || scale > precision
-				? throw new ArgumentOutOfRangeException(nameof(scale), "Must be between 0 and precision.")
-				: builder.HasColumnType($"decimal({precision},{scale})");
+		=> builder.HasColumnType(DecimalColumnType(precision, scale));
+
+	/// <inheritdoc cref="IsDecimalColumn(PropertyBuilder, int, int)"/>
+	/// <typeparam name="TProperty">The type of the property being configured.</typeparam>
+	public static PropertyBuilder<TProperty> IsDecimalColumn<TProperty>(this PropertyBuilder<TProperty> builder, int precision = 18, int scale = 2)
+		=> builder.HasColumnType(DecimalColumnType(precision, scale));
 
 	/// <summary>
-	/// Configures the data type of the column to <b>money</b> when targeting a relational database.
+	/// Configures the data type of the column to <c>money</c> or <c>smallmoney</c>.
 	/// </summary>
 	/// <param name="builder">The builder for the property being configured.</param>
 	/// <param name="small">Indicates if <b>small money</b> should be used.</param>
@@ -99,50 +138,117 @@ public static class PropertyBuilderExtensions
 	public static PropertyBuilder IsMoneyColumn(this PropertyBuilder builder, bool small = false)
 		=> builder.HasColumnType(small ? "smallmoney" : "money");
 
+	/// <inheritdoc cref="IsMoneyColumn(PropertyBuilder, bool)"/>
+	/// <typeparam name="TProperty">The type of the property being configured.</typeparam>
+	public static PropertyBuilder<TProperty> IsMoneyColumn<TProperty>(this PropertyBuilder<TProperty> builder, bool small = false)
+		=> builder.HasColumnType(small ? "smallmoney" : "money");
+
 	/// <summary>
-	/// Configures the data type of the column to <b>sysname</b> when targeting a relational database.
+	/// Configures the data type of the column to <c>sysname</c>.
 	/// </summary>
 	/// <param name="builder">The builder for the property being configured.</param>
 	/// <returns>The same builder instance so that multiple calls can be chained.</returns>
 	public static PropertyBuilder IsSysNameColumn(this PropertyBuilder builder)
 		=> builder.HasColumnType("sysname");
 
+	/// <inheritdoc cref="IsSysNameColumn(PropertyBuilder)"/>
+	/// <typeparam name="TProperty">The type of the property being configured.</typeparam>
+	public static PropertyBuilder<TProperty> IsSysNameColumn<TProperty>(this PropertyBuilder<TProperty> builder)
+		=> builder.HasColumnType("sysname");
+
 	/// <summary>
-	/// Configures the data type of the column to <b>time</b> when targeting a relational database.
+	/// Configures the data type of the column to <c>time</c>.
 	/// </summary>
 	/// <param name="builder">The builder for the property being configured.</param>
 	/// <param name="precision">This can be an integer from 0 to 7.
 	/// The default fractional scale is 7 (100ns).</param>
 	/// <returns>The same builder instance so that multiple calls can be chained.</returns>
+	/// <exception cref="ArgumentOutOfRangeException">
+	/// <paramref name="precision"/> is less than 0 or greater than 7.
+	/// </exception>
 	public static PropertyBuilder IsTimeColumn(this PropertyBuilder builder, int precision = 7)
-		=> precision is < 0 or > 7
-			? throw new ArgumentOutOfRangeException(nameof(precision), "Must be between 0 and 7.")
-			: builder.HasColumnType($"time({precision})");
+		=> builder.HasColumnType(TimeColumnType(precision));
+
+	/// <inheritdoc cref="IsTimeColumn(PropertyBuilder, int)"/>
+	/// <typeparam name="TProperty">The type of the property being configured.</typeparam>
+	public static PropertyBuilder<TProperty> IsTimeColumn<TProperty>(this PropertyBuilder<TProperty> builder, int precision = 7)
+		=> builder.HasColumnType(TimeColumnType(precision));
 
 	/// <summary>
-	/// Configures the data type of the column to <c>uniqueidentifier</c> when targeting a relational database.
+	/// Configures the data type of the column to <c>uniqueidentifier</c>.
 	/// </summary>
 	/// <param name="builder">The builder for the property being configured.</param>
 	/// <returns>The same builder instance so that multiple calls can be chained.</returns>
 	public static PropertyBuilder IsUniqueIdentifierColumn(this PropertyBuilder builder)
 		=> builder.HasColumnType("uniqueidentifier");
 
-	/// <summary>
-	/// Configures the data type of the column to <b>varbinary</b> when targeting a relational database.
-	/// </summary>
-	/// <param name="builder">The builder for the property being configured.</param>
-	/// <param name="length">This can be a value from 0 through 8,000. The default value is 0 (max).</param>
-	/// <returns>The same builder instance so that multiple calls can be chained.</returns>
-	public static PropertyBuilder IsVarbinaryColumn(this PropertyBuilder builder, int length = 0)
-		=> length is < 0 or > 8000
-			? throw new ArgumentOutOfRangeException(nameof(length), "Must be between 0 and 8000.")
-			: builder.HasColumnType(length == 0 ? "varbinary(max)" : $"varbinary({length})");
+	/// <inheritdoc cref="IsUniqueIdentifierColumn(PropertyBuilder)"/>
+	/// <typeparam name="TProperty">The type of the property being configured.</typeparam>
+	public static PropertyBuilder<TProperty> IsUniqueIdentifierColumn<TProperty>(this PropertyBuilder<TProperty> builder)
+		=> builder.HasColumnType("uniqueidentifier");
 
 	/// <summary>
-	/// Configures the data type of the column to <b>xml</b> when targeting a relational database.
+	/// Configures the data type of the column to <c>varbinary</c>.
+	/// </summary>
+	/// <param name="builder">The builder for the property being configured.</param>
+	/// <param name="length">This can be a value from 1 through 8,000, or 0 (the default) for
+	/// <c>varbinary(max)</c>, which stores up to <c>2^31-1</c> bytes. Note that <c>binary</c>
+	/// has no <c>max</c> form, which is why <see cref="IsBinaryColumn(PropertyBuilder, int)"/>
+	/// has no such sentinel.</param>
+	/// <returns>The same builder instance so that multiple calls can be chained.</returns>
+	/// <exception cref="ArgumentOutOfRangeException">
+	/// <paramref name="length"/> is less than 0 or greater than 8,000.
+	/// </exception>
+	public static PropertyBuilder IsVarbinaryColumn(this PropertyBuilder builder, int length = 0)
+		=> builder.HasColumnType(VarbinaryColumnType(length));
+
+	/// <inheritdoc cref="IsVarbinaryColumn(PropertyBuilder, int)"/>
+	/// <typeparam name="TProperty">The type of the property being configured.</typeparam>
+	public static PropertyBuilder<TProperty> IsVarbinaryColumn<TProperty>(this PropertyBuilder<TProperty> builder, int length = 0)
+		=> builder.HasColumnType(VarbinaryColumnType(length));
+
+	/// <summary>
+	/// Configures the data type of the column to <c>xml</c>.
 	/// </summary>
 	/// <param name="builder">The builder for the property being configured.</param>
 	/// <returns>The same builder instance so that multiple calls can be chained.</returns>
 	public static PropertyBuilder IsXmlColumn(this PropertyBuilder builder)
 		=> builder.HasColumnType("xml");
+
+	/// <inheritdoc cref="IsXmlColumn(PropertyBuilder)"/>
+	/// <typeparam name="TProperty">The type of the property being configured.</typeparam>
+	public static PropertyBuilder<TProperty> IsXmlColumn<TProperty>(this PropertyBuilder<TProperty> builder)
+		=> builder.HasColumnType("xml");
+
+	private static string BinaryColumnType(int length)
+		=> length is < 1 or > 8000
+			? throw new ArgumentOutOfRangeException(nameof(length), "Must be between 1 and 8000.")
+			: $"binary({length})";
+
+	private static string DateTime2ColumnType(int precision)
+		=> precision is < 0 or > 7
+			? throw new ArgumentOutOfRangeException(nameof(precision), "Must be between 0 and 7.")
+			: $"datetime2({precision})";
+
+	private static string DateTimeOffsetColumnType(int precision)
+		=> precision is < 0 or > 7
+			? throw new ArgumentOutOfRangeException(nameof(precision), "Must be between 0 and 7.")
+			: $"datetimeoffset({precision})";
+
+	private static string DecimalColumnType(int precision, int scale)
+		=> precision is < 1 or > 38
+			? throw new ArgumentOutOfRangeException(nameof(precision), "Must be between 1 and 38.")
+			: scale < 0 || scale > precision
+				? throw new ArgumentOutOfRangeException(nameof(scale), "Must be between 0 and precision.")
+				: $"decimal({precision},{scale})";
+
+	private static string TimeColumnType(int precision)
+		=> precision is < 0 or > 7
+			? throw new ArgumentOutOfRangeException(nameof(precision), "Must be between 0 and 7.")
+			: $"time({precision})";
+
+	private static string VarbinaryColumnType(int length)
+		=> length is < 0 or > 8000
+			? throw new ArgumentOutOfRangeException(nameof(length), "Must be between 0 and 8000.")
+			: length == 0 ? "varbinary(max)" : $"varbinary({length})";
 }

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/README.md
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/README.md
@@ -90,11 +90,17 @@ protected override void OnModelCreating(ModelBuilder modelBuilder)
 
 ## `PropertyBuilderExtensions`
 
-Extension methods on `PropertyBuilder` that set the SQL Server column type in one call. All methods return the same `PropertyBuilder` for chaining.
+Extension methods that set the SQL Server column type in one call, each in two forms. The generic form extends `PropertyBuilder<TProperty>` and returns it unchanged, so the property type survives the call and anything typed later in the chain — `HasDefaultValue`, `HasConversion`, `HasValueGenerator` — stays compile-time checked. The non-generic form extends `PropertyBuilder` and exists for the `Property(string)` path used by shadow properties. A lambda-based `Property` call picks the generic form automatically.
+
+```csharp
+builder.Property(e => e.Price)      // PropertyBuilder<decimal>
+    .IsDecimalColumn(10, 2)         // PropertyBuilder<decimal> — type kept
+    .HasDefaultValue(0m);           // takes decimal, not object
+```
 
 | Method                              | SQL Server type                   | Parameters                                                       |
 | ----------------------------------- | --------------------------------- | ---------------------------------------------------------------- |
-| `IsBinaryColumn(precision)`         | `binary(n)`                       | `precision`: 1–8000 (default 8000)                               |
+| `IsBinaryColumn(length)`            | `binary(n)`                       | `length`: 1–8000 (default 8000); `binary` has no `max` form      |
 | `IsDateColumn()`                    | `date`                            | —                                                                |
 | `IsDateTimeColumn(small)`           | `datetime` / `smalldatetime`      | `small: false` → `datetime`                                      |
 | `IsDateTime2Column(precision)`      | `datetime2(n)`                    | `precision`: 0–7 (default 7)                                     |
@@ -104,10 +110,10 @@ Extension methods on `PropertyBuilder` that set the SQL Server column type in on
 | `IsSysNameColumn()`                 | `sysname`                         | —                                                                |
 | `IsTimeColumn(precision)`           | `time(n)`                         | `precision`: 0–7 (default 7)                                     |
 | `IsUniqueIdentifierColumn()`        | `uniqueidentifier`                | —                                                                |
-| `IsVarbinaryColumn(precision)`      | `varbinary(n)` / `varbinary(max)` | `precision`: 0–8000; 0 → `varbinary(max)` (default 0)            |
+| `IsVarbinaryColumn(length)`         | `varbinary(n)` / `varbinary(max)` | `length`: 0–8000; 0 → `varbinary(max)` (default 0)               |
 | `IsXmlColumn()`                     | `xml`                             | —                                                                |
 
-Methods with a precision parameter throw `ArgumentOutOfRangeException` when the value is outside the valid range.
+Methods with a precision or length parameter throw `ArgumentOutOfRangeException` when the value is outside the valid range.
 
 ```csharp
 public class OrderConfiguration : IdentityConfiguration<Order>

--- a/tests/BB84.EntityFrameworkCore.Repositories.Tests/PropertyBuilderExtensionsTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Tests/PropertyBuilderExtensionsTests.cs
@@ -1,0 +1,190 @@
+// Copyright: 2024 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using BB84.EntityFrameworkCore.Repositories.SqlServer.Extensions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace BB84.EntityFrameworkCore.Repositories.Tests;
+
+/// <summary>
+/// Verifies the column types produced by <see cref="PropertyBuilderExtensions"/>.
+/// </summary>
+/// <remarks>
+/// These tests build a model in memory and never touch the database, so they do not derive from
+/// <see cref="UnitTestBase"/>. Each test calls the extension through
+/// <see cref="PropertyBuilder{TProperty}"/>, which is what the generic overloads exist for and
+/// what overload resolution picks for a lambda based <c>Property</c> call.
+/// </remarks>
+[TestClass]
+public sealed class PropertyBuilderExtensionsTests
+{
+	[TestMethod]
+	public void IsBinaryColumnShouldUseTheGivenLength()
+		=> AssertColumnType("binary(16)", b => b.Property(e => e.Blob).IsBinaryColumn(16));
+
+	[TestMethod]
+	public void IsBinaryColumnShouldDefaultToTheMaximumLength()
+		=> AssertColumnType("binary(8000)", b => b.Property(e => e.Blob).IsBinaryColumn());
+
+	[TestMethod]
+	[DataRow(0)]
+	[DataRow(8001)]
+	public void IsBinaryColumnShouldThrowOnAnOutOfRangeLength(int length)
+		=> AssertOutOfRange("length", b => b.Property(e => e.Blob).IsBinaryColumn(length));
+
+	[TestMethod]
+	public void IsDateColumnShouldUseDate()
+		=> AssertColumnType("date", b => b.Property(e => e.Date).IsDateColumn());
+
+	[TestMethod]
+	[DataRow(false, "datetime")]
+	[DataRow(true, "smalldatetime")]
+	public void IsDateTimeColumnShouldHonourTheSmallFlag(bool small, string expected)
+		=> AssertColumnType(expected, b => b.Property(e => e.Date).IsDateTimeColumn(small));
+
+	[TestMethod]
+	public void IsDateTime2ColumnShouldUseTheGivenPrecision()
+		=> AssertColumnType("datetime2(3)", b => b.Property(e => e.Date).IsDateTime2Column(3));
+
+	[TestMethod]
+	[DataRow(-1)]
+	[DataRow(8)]
+	public void IsDateTime2ColumnShouldThrowOnAnOutOfRangePrecision(int precision)
+		=> AssertOutOfRange("precision", b => b.Property(e => e.Date).IsDateTime2Column(precision));
+
+	[TestMethod]
+	public void IsDateTimeOffsetColumnShouldUseTheGivenPrecision()
+		=> AssertColumnType("datetimeoffset(0)", b => b.Property(e => e.Offset).IsDateTimeOffsetColumn(0));
+
+	[TestMethod]
+	[DataRow(-1)]
+	[DataRow(8)]
+	public void IsDateTimeOffsetColumnShouldThrowOnAnOutOfRangePrecision(int precision)
+		=> AssertOutOfRange("precision", b => b.Property(e => e.Offset).IsDateTimeOffsetColumn(precision));
+
+	[TestMethod]
+	public void IsDecimalColumnShouldUseTheGivenPrecisionAndScale()
+		=> AssertColumnType("decimal(10,4)", b => b.Property(e => e.Amount).IsDecimalColumn(10, 4));
+
+	[TestMethod]
+	[DataRow(0, 2, "precision")]
+	[DataRow(39, 2, "precision")]
+	[DataRow(10, -1, "scale")]
+	[DataRow(10, 11, "scale")]
+	public void IsDecimalColumnShouldThrowOnAnOutOfRangeArgument(int precision, int scale, string parameterName)
+		=> AssertOutOfRange(parameterName, b => b.Property(e => e.Amount).IsDecimalColumn(precision, scale));
+
+	[TestMethod]
+	[DataRow(false, "money")]
+	[DataRow(true, "smallmoney")]
+	public void IsMoneyColumnShouldHonourTheSmallFlag(bool small, string expected)
+		=> AssertColumnType(expected, b => b.Property(e => e.Amount).IsMoneyColumn(small));
+
+	[TestMethod]
+	public void IsSysNameColumnShouldUseSysName()
+		=> AssertColumnType("sysname", b => b.Property(e => e.Name).IsSysNameColumn());
+
+	[TestMethod]
+	public void IsTimeColumnShouldUseTheGivenPrecision()
+		=> AssertColumnType("time(7)", b => b.Property(e => e.Duration).IsTimeColumn());
+
+	[TestMethod]
+	[DataRow(-1)]
+	[DataRow(8)]
+	public void IsTimeColumnShouldThrowOnAnOutOfRangePrecision(int precision)
+		=> AssertOutOfRange("precision", b => b.Property(e => e.Duration).IsTimeColumn(precision));
+
+	[TestMethod]
+	public void IsUniqueIdentifierColumnShouldUseUniqueIdentifier()
+		=> AssertColumnType("uniqueidentifier", b => b.Property(e => e.Id).IsUniqueIdentifierColumn());
+
+	[TestMethod]
+	public void IsVarbinaryColumnShouldDefaultToMax()
+		=> AssertColumnType("varbinary(max)", b => b.Property(e => e.Blob).IsVarbinaryColumn());
+
+	[TestMethod]
+	public void IsVarbinaryColumnShouldUseTheGivenLength()
+		=> AssertColumnType("varbinary(512)", b => b.Property(e => e.Blob).IsVarbinaryColumn(512));
+
+	[TestMethod]
+	[DataRow(-1)]
+	[DataRow(8001)]
+	public void IsVarbinaryColumnShouldThrowOnAnOutOfRangeLength(int length)
+		=> AssertOutOfRange("length", b => b.Property(e => e.Blob).IsVarbinaryColumn(length));
+
+	[TestMethod]
+	public void IsXmlColumnShouldUseXml()
+		=> AssertColumnType("xml", b => b.Property(e => e.Name).IsXmlColumn());
+
+	/// <summary>
+	/// The generic overloads must return <see cref="PropertyBuilder{TProperty}"/> so that a call
+	/// placed in the middle of a chain does not erase the property type for what follows.
+	/// </summary>
+	/// <remarks>
+	/// This is a compile-time assertion: before the generic overloads existed the extension bound
+	/// through the non-generic base class and the subsequent <c>HasDefaultValue</c> took
+	/// <see cref="object"/> instead of the property type.
+	/// </remarks>
+	[TestMethod]
+	public void GenericOverloadsShouldPreserveThePropertyType()
+	{
+		EntityTypeBuilder<Probe> builder = new ModelBuilder().Entity<Probe>();
+
+		PropertyBuilder<decimal> amount = builder.Property(e => e.Amount)
+			.IsDecimalColumn(10, 4)
+			.HasDefaultValue(1.5m);
+
+		PropertyBuilder<string> name = builder.Property(e => e.Name)
+			.IsSysNameColumn()
+			.HasDefaultValue("dbo");
+
+		Assert.AreEqual("decimal(10,4)", amount.Metadata.GetColumnType());
+		Assert.AreEqual("sysname", name.Metadata.GetColumnType());
+	}
+
+	/// <summary>
+	/// The non-generic overloads must survive, because the shadow property path has no property
+	/// type to bind to.
+	/// </summary>
+	[TestMethod]
+	public void NonGenericOverloadsShouldStillApplyToShadowProperties()
+	{
+		EntityTypeBuilder<Probe> builder = new ModelBuilder().Entity<Probe>();
+
+		PropertyBuilder shadow = builder.Property<byte[]>("Shadow")
+			.IsVarbinaryColumn(64);
+
+		Assert.AreEqual("varbinary(64)", shadow.Metadata.GetColumnType());
+	}
+
+	private static void AssertColumnType(string expected, Func<EntityTypeBuilder<Probe>, PropertyBuilder> configure)
+	{
+		PropertyBuilder builder = configure(new ModelBuilder().Entity<Probe>());
+
+		Assert.AreEqual(expected, builder.Metadata.GetColumnType());
+	}
+
+	private static void AssertOutOfRange(string parameterName, Func<EntityTypeBuilder<Probe>, PropertyBuilder> configure)
+	{
+		EntityTypeBuilder<Probe> builder = new ModelBuilder().Entity<Probe>();
+
+		ArgumentOutOfRangeException exception = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => configure(builder));
+
+		Assert.AreEqual(parameterName, exception.ParamName);
+	}
+
+	private sealed class Probe
+	{
+		public Guid Id { get; set; }
+		public string Name { get; set; } = string.Empty;
+		public decimal Amount { get; set; }
+		public DateTime Date { get; set; }
+		public DateTimeOffset Offset { get; set; }
+		public TimeSpan Duration { get; set; }
+		public byte[] Blob { get; set; } = [];
+	}
+}


### PR DESCRIPTION
**Changes:**

- `EntityTypeBuilder<TEntity>.Property(e => e.X)` returns `PropertyBuilder<TProperty>`, but every method in `PropertyBuilderExtensions` extended and returned the non-generic `PropertyBuilder`.
The extension bound through the base class, so the property type was dropped at the first call and could not be recovered: `HasDefaultValue`, `HasConversion` and `HasValueGenerator` further along the chain fell back to `object` and lost their compile-time checking.
- The helpers had to be placed last in a chain, or split into a statement of their own.
- Each of the twelve methods now has a generic overload alongside the existing one.
- No cast is needed — EF Core's own `HasColumnType<TProperty>` already returns the generic builder.
- The non-generic overloads stay, because the `Property(string)` path used by shadow properties has no property type to bind to.
- A lambda-based call picks the generic form automatically, which the test project's configurations now do; the emitted column types are unchanged.
- Range validation moved into private helpers that both overloads share, so each check has one copy rather than two.
- The class and method docs promised configuration "when targeting a relational database", but `sysname`, `smalldatetime`, `smallmoney`, `uniqueidentifier` and `xml` are SQL Server types; the same wording sat on `EntityTypeBuilderExtensions`, whose temporal
tables are equally SQL Server only.
- `IsBinaryColumn` carried a copy-pasted sentence describing a `max` option it rejects — `binary(max)` is not valid T-SQL.
- Only `varbinary` has that form, so the two methods differ for a reason; the sentence is gone and the `0` sentinel on `IsVarbinaryColumn` is documented properly.
- The README table also named both parameters `precision`; they are `length`.
- `PropertyBuilderExtensionsTests` covers every column type, every range throw including its `ParamName`, and two structural cases: the generic form preserving the type through a chain, and the non-generic form still applying to a shadow property.

closes #238 