### PR TITLE
feat(entities): make the concurrency token type a parameter

### DIFF
--- a/src/BB84.EntityFrameworkCore.Entities.Abstractions/Components/IConcurrency.cs
+++ b/src/BB84.EntityFrameworkCore.Entities.Abstractions/Components/IConcurrency.cs
@@ -1,4 +1,4 @@
-﻿// Copyright: 2024 Robert Peter Meyer
+// Copyright: 2024 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -6,17 +6,18 @@
 namespace BB84.EntityFrameworkCore.Entities.Abstractions.Components;
 
 /// <summary>
-/// Defines a contract for entities that support concurrency control through a timestamp.
+/// Defines a contract for entities that support concurrency control through a store generated token.
 /// </summary>
 /// <remarks>
 /// Implementations of this interface typically use the <see cref="Timestamp"/> property to manage
 /// concurrency by ensuring that updates to an entity are based on the most recent version.
 /// This is commonly used in scenarios such as optimistic concurrency control in databases.
 /// </remarks>
-public interface IConcurrency
+/// <typeparam name="TToken">The type of the concurrency token.</typeparam>
+public interface IConcurrency<TToken>
 {
 	/// <summary>
-	/// Gets or sets the timestamp associated with the current entity.
+	/// Gets or sets the concurrency token associated with the current entity.
 	/// </summary>
 	/// <remarks>
 	/// <para>
@@ -33,9 +34,22 @@ public interface IConcurrency
 	/// fail to match.
 	/// </para>
 	/// <para>
-	/// The token is shaped for SQL Server <c>rowversion</c>. Providers without an eight byte row
-	/// version need their own mapping for this property.
+	/// The token type is the provider's business: <see cref="byte"/> array for a SQL Server
+	/// <c>rowversion</c>, <see cref="uint"/> for a PostgreSQL <c>xmin</c>, or a <see cref="Guid"/>
+	/// or incrementing <see cref="int"/> rotated by the application. Whatever is chosen, the store
+	/// has to be told to generate it — see the entity type configuration base classes of the
+	/// <c>BB84.EntityFrameworkCore.Repositories</c> package.
 	/// </para>
 	/// </remarks>
-	byte[] Timestamp { get; set; }
+	TToken Timestamp { get; set; }
 }
+
+/// <summary>
+/// Defines a contract for entities that support concurrency control through a store generated token.
+/// </summary>
+/// <remarks>
+/// The token is a <see cref="byte"/> array, shaped for SQL Server <c>rowversion</c>. Providers
+/// without an eight byte row version should name their own token type through
+/// <see cref="IConcurrency{TToken}"/> rather than mapping something else onto this one.
+/// </remarks>
+public interface IConcurrency : IConcurrency<byte[]>;

--- a/src/BB84.EntityFrameworkCore.Entities.Abstractions/Components/IIdentity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities.Abstractions/Components/IIdentity.cs
@@ -18,5 +18,4 @@ public interface IIdentity<TKey> where TKey : IEquatable<TKey>
 }
 
 /// <inheritdoc cref="IIdentity{TKey}"/>
-public interface IIdentity : IIdentity<Guid>
-{ }
+public interface IIdentity : IIdentity<Guid>;

--- a/src/BB84.EntityFrameworkCore.Entities.Abstractions/Components/IUserAudited.cs
+++ b/src/BB84.EntityFrameworkCore.Entities.Abstractions/Components/IUserAudited.cs
@@ -26,5 +26,4 @@ public interface IUserAudited<TCreator, TEditor>
 }
 
 /// <inheritdoc cref="IUserAudited{TCreator, TEditor}"/>
-public interface IUserAudited : IUserAudited<string, string?>
-{ }
+public interface IUserAudited : IUserAudited<string, string?>;

--- a/src/BB84.EntityFrameworkCore.Entities.Abstractions/IAuditedCompositeEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities.Abstractions/IAuditedCompositeEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright: 2024 Robert Peter Meyer
+// Copyright: 2024 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -13,13 +13,22 @@ namespace BB84.EntityFrameworkCore.Entities.Abstractions;
 /// </summary>
 /// <typeparam name="TCreator">The type of the user or entity responsible for creating the entity.</typeparam>
 /// <typeparam name="TEditor">The type of the user or entity responsible for editing or modifying the entity.</typeparam>
-public interface IAuditedCompositeEntity<TCreator, TEditor> : IConcurrency, IUserAudited<TCreator, TEditor>
-	where TCreator : notnull
-{ }
+/// <typeparam name="TToken">The type of the concurrency token.</typeparam>
+public interface IAuditedCompositeEntity<TCreator, TEditor, TToken> : IConcurrency<TToken>, IUserAudited<TCreator, TEditor>
+	where TCreator : notnull;
 
-/// <inheritdoc cref="IAuditedCompositeEntity{TCreator, TEditor}"/>
+/// <inheritdoc cref="IAuditedCompositeEntity{TCreator, TEditor, TToken}"/>
 /// <remarks>
-/// The creator and editor types default to <see cref="string"/>.
+/// The creator and editor types are supplied; <c>TToken</c> defaults to a <see cref="byte"/> array.
+/// For a custom token type use <see cref="IAuditedCompositeEntity{TCreator, TEditor, TToken}"/>
+/// and name all three.
 /// </remarks>
-public interface IAuditedCompositeEntity : IAuditedCompositeEntity<string, string?>
-{ }
+public interface IAuditedCompositeEntity<TCreator, TEditor> : IAuditedCompositeEntity<TCreator, TEditor, byte[]>, IConcurrency
+	where TCreator : notnull;
+
+/// <inheritdoc cref="IAuditedCompositeEntity{TCreator, TEditor, TToken}"/>
+/// <remarks>
+/// The creator and editor types default to <see cref="string"/> and the token to a
+/// <see cref="byte"/> array.
+/// </remarks>
+public interface IAuditedCompositeEntity : IAuditedCompositeEntity<string, string?>, IUserAudited;

--- a/src/BB84.EntityFrameworkCore.Entities.Abstractions/IAuditedEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities.Abstractions/IAuditedEntity.cs
@@ -14,25 +14,35 @@ namespace BB84.EntityFrameworkCore.Entities.Abstractions;
 /// <typeparam name="TKey">The type of the unique identifier for the entity.</typeparam>
 /// <typeparam name="TCreator">The type representing the user or entity that created this entity.</typeparam>
 /// <typeparam name="TEditor">The type representing the user or entity that last modified this entity.</typeparam>
-public interface IAuditedEntity<TKey, TCreator, TEditor> : IIdentityEntity<TKey>, IUserAudited<TCreator, TEditor>
+/// <typeparam name="TToken">The type of the concurrency token.</typeparam>
+public interface IAuditedEntity<TKey, TCreator, TEditor, TToken> : IIdentityEntity<TKey, TToken>, IUserAudited<TCreator, TEditor>
 	where TKey : IEquatable<TKey>
-	where TCreator : notnull
-{ }
+	where TCreator : notnull;
 
-/// <inheritdoc cref="IAuditedEntity{TKey, TCreator, TEditor}"/>
+/// <inheritdoc cref="IAuditedEntity{TKey, TCreator, TEditor, TToken}"/>
 /// <remarks>
-/// <typeparamref name="TKey"/> is supplied; <c>TCreator</c> defaults to <see cref="string"/>
-/// and <c>TEditor</c> to <see cref="string"/>. For a custom creator or editor type use
-/// <see cref="IAuditedEntity{TKey, TCreator, TEditor}"/> and name all three.
+/// The key, creator and editor types are supplied; <c>TToken</c> defaults to a <see cref="byte"/>
+/// array. For a custom token type use <see cref="IAuditedEntity{TKey, TCreator, TEditor, TToken}"/>
+/// and name all four.
+/// </remarks>
+public interface IAuditedEntity<TKey, TCreator, TEditor> : IAuditedEntity<TKey, TCreator, TEditor, byte[]>, IIdentityEntity<TKey>
+	where TKey : IEquatable<TKey>
+	where TCreator : notnull;
+
+/// <inheritdoc cref="IAuditedEntity{TKey, TCreator, TEditor, TToken}"/>
+/// <remarks>
+/// <typeparamref name="TKey"/> is supplied; <c>TCreator</c> defaults to <see cref="string"/>,
+/// <c>TEditor</c> to <see cref="string"/> and <c>TToken</c> to a <see cref="byte"/> array. For a
+/// custom creator or editor type use <see cref="IAuditedEntity{TKey, TCreator, TEditor}"/> and
+/// name all three.
 /// </remarks>
 public interface IAuditedEntity<TKey> : IAuditedEntity<TKey, string, string?>, IUserAudited
-	where TKey : IEquatable<TKey>
-{ }
+	where TKey : IEquatable<TKey>;
 
-/// <inheritdoc cref="IAuditedEntity{TKey, TCreator, TEditor}"/>
+/// <inheritdoc cref="IAuditedEntity{TKey, TCreator, TEditor, TToken}"/>
 /// <remarks>
 /// Nothing is supplied; <c>TKey</c> defaults to <see cref="Guid"/>, <c>TCreator</c> to
-/// <see cref="string"/> and <c>TEditor</c> to <see cref="string"/>.
+/// <see cref="string"/>, <c>TEditor</c> to <see cref="string"/> and <c>TToken</c> to a
+/// <see cref="byte"/> array.
 /// </remarks>
-public interface IAuditedEntity : IAuditedEntity<Guid, string, string?>, IIdentityEntity, IUserAudited
-{ }
+public interface IAuditedEntity : IAuditedEntity<Guid, string, string?>, IIdentityEntity, IUserAudited;

--- a/src/BB84.EntityFrameworkCore.Entities.Abstractions/ICompositeEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities.Abstractions/ICompositeEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright: 2024 Robert Peter Meyer
+// Copyright: 2024 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -12,8 +12,15 @@ namespace BB84.EntityFrameworkCore.Entities.Abstractions;
 /// </summary>
 /// <remarks>
 /// This interface is typically implemented by entities that aggregate other entities or components
-/// into a single cohesive unit. It extends the <see cref="IConcurrency"/> interface, indicating that
-/// implementations may also support concurrency-related operations.
+/// into a single cohesive unit. It extends the <see cref="IConcurrency{TToken}"/> interface, indicating
+/// that implementations may also support concurrency-related operations.
 /// </remarks>
-public interface ICompositeEntity : IConcurrency
-{ }
+/// <typeparam name="TToken">The type of the concurrency token.</typeparam>
+public interface ICompositeEntity<TToken> : IConcurrency<TToken>;
+
+/// <inheritdoc cref="ICompositeEntity{TToken}"/>
+/// <remarks>
+/// The token is a <see cref="byte"/> array. For a custom token type use
+/// <see cref="ICompositeEntity{TToken}"/> and name it.
+/// </remarks>
+public interface ICompositeEntity : ICompositeEntity<byte[]>, IConcurrency;

--- a/src/BB84.EntityFrameworkCore.Entities.Abstractions/IEnumeratorEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities.Abstractions/IEnumeratorEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright: 2024 Robert Peter Meyer
+// Copyright: 2024 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -13,10 +13,20 @@ namespace BB84.EntityFrameworkCore.Entities.Abstractions;
 /// soft deletion functionality.
 /// </summary>
 /// <typeparam name="TKey">The type of the unique identifier for the entity.</typeparam>
-public interface IEnumeratorEntity<TKey> : IIdentityEntity<TKey>, IEnumeration, ISoftDeletable
-	where TKey : IEquatable<TKey>
-{ }
+/// <typeparam name="TToken">The type of the concurrency token.</typeparam>
+public interface IEnumeratorEntity<TKey, TToken> : IIdentityEntity<TKey, TToken>, IEnumeration, ISoftDeletable
+	where TKey : IEquatable<TKey>;
 
-/// <inheritdoc cref="IEnumeratorEntity{TKey}"/>
-public interface IEnumeratorEntity : IEnumeratorEntity<int>
-{ }
+/// <inheritdoc cref="IEnumeratorEntity{TKey, TToken}"/>
+/// <remarks>
+/// <typeparamref name="TKey"/> is supplied; <c>TToken</c> defaults to a <see cref="byte"/> array.
+/// For a custom token type use <see cref="IEnumeratorEntity{TKey, TToken}"/> and name both.
+/// </remarks>
+public interface IEnumeratorEntity<TKey> : IEnumeratorEntity<TKey, byte[]>, IIdentityEntity<TKey>
+	where TKey : IEquatable<TKey>;
+
+/// <inheritdoc cref="IEnumeratorEntity{TKey, TToken}"/>
+/// <remarks>
+/// The unique identifier is of type <see cref="int"/> and the token a <see cref="byte"/> array.
+/// </remarks>
+public interface IEnumeratorEntity : IEnumeratorEntity<int>;

--- a/src/BB84.EntityFrameworkCore.Entities.Abstractions/IFullAuditedEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities.Abstractions/IFullAuditedEntity.cs
@@ -14,25 +14,35 @@ namespace BB84.EntityFrameworkCore.Entities.Abstractions;
 /// <typeparam name="TKey">The type of the unique identifier for the entity.</typeparam>
 /// <typeparam name="TCreator">The type representing the creator of the entity.</typeparam>
 /// <typeparam name="TEditor">The type representing the last editor of the entity.</typeparam>
-public interface IFullAuditedEntity<TKey, TCreator, TEditor> : IIdentityEntity<TKey>, IUserAudited<TCreator, TEditor>, ITimeAudited
+/// <typeparam name="TToken">The type of the concurrency token.</typeparam>
+public interface IFullAuditedEntity<TKey, TCreator, TEditor, TToken> : IIdentityEntity<TKey, TToken>, IUserAudited<TCreator, TEditor>, ITimeAudited
 	where TKey : IEquatable<TKey>
-	where TCreator : notnull
-{ }
+	where TCreator : notnull;
 
-/// <inheritdoc cref="IFullAuditedEntity{TKey, TCreator, TEditor}"/>
+/// <inheritdoc cref="IFullAuditedEntity{TKey, TCreator, TEditor, TToken}"/>
 /// <remarks>
-/// <typeparamref name="TKey"/> is supplied; <c>TCreator</c> defaults to <see cref="string"/>
-/// and <c>TEditor</c> to <see cref="string"/>. For a custom creator or editor type use
-/// <see cref="IFullAuditedEntity{TKey, TCreator, TEditor}"/> and name all three.
+/// The key, creator and editor types are supplied; <c>TToken</c> defaults to a <see cref="byte"/>
+/// array. For a custom token type use
+/// <see cref="IFullAuditedEntity{TKey, TCreator, TEditor, TToken}"/> and name all four.
+/// </remarks>
+public interface IFullAuditedEntity<TKey, TCreator, TEditor> : IFullAuditedEntity<TKey, TCreator, TEditor, byte[]>, IIdentityEntity<TKey>
+	where TKey : IEquatable<TKey>
+	where TCreator : notnull;
+
+/// <inheritdoc cref="IFullAuditedEntity{TKey, TCreator, TEditor, TToken}"/>
+/// <remarks>
+/// <typeparamref name="TKey"/> is supplied; <c>TCreator</c> defaults to <see cref="string"/>,
+/// <c>TEditor</c> to <see cref="string"/> and <c>TToken</c> to a <see cref="byte"/> array. For a
+/// custom creator or editor type use <see cref="IFullAuditedEntity{TKey, TCreator, TEditor}"/>
+/// and name all three.
 /// </remarks>
 public interface IFullAuditedEntity<TKey> : IFullAuditedEntity<TKey, string, string?>, IUserAudited
-	where TKey : IEquatable<TKey>
-{ }
+	where TKey : IEquatable<TKey>;
 
-/// <inheritdoc cref="IFullAuditedEntity{TKey, TCreator, TEditor}"/>
+/// <inheritdoc cref="IFullAuditedEntity{TKey, TCreator, TEditor, TToken}"/>
 /// <remarks>
 /// Nothing is supplied; <c>TKey</c> defaults to <see cref="Guid"/>, <c>TCreator</c> to
-/// <see cref="string"/> and <c>TEditor</c> to <see cref="string"/>.
+/// <see cref="string"/>, <c>TEditor</c> to <see cref="string"/> and <c>TToken</c> to a
+/// <see cref="byte"/> array.
 /// </remarks>
-public interface IFullAuditedEntity : IFullAuditedEntity<Guid, string, string?>, IIdentityEntity, IUserAudited
-{ }
+public interface IFullAuditedEntity : IFullAuditedEntity<Guid, string, string?>, IIdentityEntity, IUserAudited;

--- a/src/BB84.EntityFrameworkCore.Entities.Abstractions/IIdentityEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities.Abstractions/IIdentityEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright: 2024 Robert Peter Meyer
+// Copyright: 2024 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -11,12 +11,20 @@ namespace BB84.EntityFrameworkCore.Entities.Abstractions;
 /// Represents an entity contract with a unique identifier and concurrency control.
 /// </summary>
 /// <typeparam name="TKey">The type of the unique identifier for the entity.</typeparam>
-public interface IIdentityEntity<TKey> : IIdentity<TKey>, IConcurrency where TKey : IEquatable<TKey>
-{ }
+/// <typeparam name="TToken">The type of the concurrency token.</typeparam>
+public interface IIdentityEntity<TKey, TToken> : IIdentity<TKey>, IConcurrency<TToken>
+	where TKey : IEquatable<TKey>;
 
-/// <inheritdoc cref="IIdentityEntity{TKey}"/>
+/// <inheritdoc cref="IIdentityEntity{TKey, TToken}"/>
 /// <remarks>
-/// The unique identifier is of type <see cref="Guid"/>.
+/// <typeparamref name="TKey"/> is supplied; <c>TToken</c> defaults to a <see cref="byte"/> array.
+/// For a custom token type use <see cref="IIdentityEntity{TKey, TToken}"/> and name both.
 /// </remarks>
-public interface IIdentityEntity : IIdentityEntity<Guid>
-{ }
+public interface IIdentityEntity<TKey> : IIdentityEntity<TKey, byte[]>, IConcurrency
+	where TKey : IEquatable<TKey>;
+
+/// <inheritdoc cref="IIdentityEntity{TKey, TToken}"/>
+/// <remarks>
+/// The unique identifier is of type <see cref="Guid"/> and the token a <see cref="byte"/> array.
+/// </remarks>
+public interface IIdentityEntity : IIdentityEntity<Guid>;

--- a/src/BB84.EntityFrameworkCore.Entities.Abstractions/README.md
+++ b/src/BB84.EntityFrameworkCore.Entities.Abstractions/README.md
@@ -18,7 +18,8 @@ These fine-grained interfaces are the building blocks composed by the entity-lev
 | Interface                         | Members                                                |
 | --------------------------------- | ------------------------------------------------------ |
 | `IIdentity<TKey>`                 | `TKey Id`                                              |
-| `IConcurrency`                    | `byte[] Timestamp` (rowversion)                        |
+| `IConcurrency<TToken>`            | `TToken Timestamp`                                     |
+| `IConcurrency`                    | Shorthand: `IConcurrency<byte[]>` (rowversion)         |
 | `ITimeAudited`                    | `DateTimeOffset CreatedAt`, `DateTimeOffset? EditedAt` |
 | `IUserAudited<TCreator, TEditor>` | `TCreator CreatedBy`, `TEditor EditedBy`               |
 | `IUserAudited`                    | Shorthand: `IUserAudited<string, string?>`             |
@@ -29,13 +30,16 @@ These fine-grained interfaces are the building blocks composed by the entity-lev
 
 Each entity interface composes the component interfaces above. Convenience overloads default `TKey` to `Guid` and `TCreator`/`TEditor` to `string`/`string?`.
 
-### `IIdentityEntity<TKey>` / `IIdentityEntity`
+### `IIdentityEntity<TKey, TToken>` and overloads
 
-Inherits `IIdentity<TKey>` and `IConcurrency`. The base for all identity-keyed entities. The non-generic overload defaults `TKey` to `Guid`.
+Inherits `IIdentity<TKey>` and `IConcurrency<TToken>`. The base for all identity-keyed entities. The overloads default `TToken` to `byte[]` and `TKey` to `Guid`.
 
 ```csharp
-public interface IIdentityEntity<TKey> : IIdentity<TKey>, IConcurrency
+public interface IIdentityEntity<TKey, TToken> : IIdentity<TKey>, IConcurrency<TToken>
     where TKey : IEquatable<TKey>
+public interface IIdentityEntity<TKey> : IIdentityEntity<TKey, byte[]>
+    where TKey : IEquatable<TKey>
+public interface IIdentityEntity : IIdentityEntity<Guid>
 ```
 
 ### `IAuditedEntity<TKey, TCreator, TEditor>` and overloads
@@ -66,12 +70,13 @@ public interface IFullAuditedEntity<TKey> : IFullAuditedEntity<TKey, string, str
 public interface IFullAuditedEntity : IFullAuditedEntity<Guid, string, string?>
 ```
 
-### `ICompositeEntity`
+### `ICompositeEntity<TToken>` / `ICompositeEntity`
 
-For entities with composite primary keys — inherits only `IConcurrency`.
+For entities with composite primary keys — inherits only `IConcurrency<TToken>`.
 
 ```csharp
-public interface ICompositeEntity : IConcurrency
+public interface ICompositeEntity<TToken> : IConcurrency<TToken>
+public interface ICompositeEntity : ICompositeEntity<byte[]>
 ```
 
 ### `IAuditedCompositeEntity<TCreator, TEditor>` / `IAuditedCompositeEntity`
@@ -83,13 +88,16 @@ Extends `ICompositeEntity` with `IUserAudited`. The non-generic overload default
 Lookup/reference data. Extends `IIdentityEntity<TKey>` with `IEnumeration` and `ISoftDeletable`. The non-generic overload defaults `TKey` to `int`.
 
 ```csharp
-public interface IEnumeratorEntity<TKey> : IIdentityEntity<TKey>, IEnumeration, ISoftDeletable
+public interface IEnumeratorEntity<TKey, TToken> : IIdentityEntity<TKey, TToken>, IEnumeration, ISoftDeletable
     where TKey : IEquatable<TKey>
+public interface IEnumeratorEntity<TKey> : IEnumeratorEntity<TKey, byte[]>
+    where TKey : IEquatable<TKey>
+public interface IEnumeratorEntity : IEnumeratorEntity<int>
 ```
 
 ## Concurrency tokens
 
-`IConcurrency.Timestamp` is settable, which is what makes the disconnected update work. An entity is read, mapped to a DTO, sent over the wire and posted back; assign the original token onto the reconstructed entity before updating it, so it reaches the `WHERE` predicate:
+`IConcurrency<TToken>.Timestamp` is settable, which is what makes the disconnected update work. An entity is read, mapped to a DTO, sent over the wire and posted back; assign the original token onto the reconstructed entity before updating it, so it reaches the `WHERE` predicate:
 
 ```csharp
 OrderEntity entity = new()
@@ -113,9 +121,23 @@ catch (DbUpdateConcurrencyException)
 
 Leave `Timestamp` unset and the update is not guarded — it succeeds regardless of what happened to the row in between. The value is store generated, so never assign it on a newly created entity, and never assign anything other than a value read from the database.
 
-The token is shaped for SQL Server `rowversion`. Providers without an eight byte row version need their own mapping for the property.
+### Choosing the token type
+
+`TToken` is the provider's business. `byte[]` is what the short rungs default to and what SQL Server `rowversion` needs; PostgreSQL `xmin` is a `uint`; a `Guid` or an incrementing `int` rotated by the application works too. Name the type on the widest rung of the ladder to pick something else:
+
+```csharp
+// rowversion, the default
+public sealed class OrderEntity : IdentityEntity { }
+
+// a Guid token instead
+public sealed class OrderEntity : IdentityEntity<Guid, Guid> { }
+```
+
+Whatever the type, the store has to be told to generate it. The configuration base classes in `BB84.EntityFrameworkCore.Repositories` take a matching `TToken` and mark the property as a concurrency token generated on add or update — which is right for `rowversion` and for `xmin`, but not for a token the application rotates itself. Override the generation strategy after calling `base.Configure(builder)` in that case.
 
 > **Changed in 5.0:** `Timestamp` was get-only before, so the original value could not be restored on a detached entity and optimistic concurrency never fired for the case it exists for. Hand-written implementations of `IConcurrency` need a setter added. The shipped entities also start out with an empty array rather than `null`.
+
+> **Changed in 5.0:** the token type is a type parameter — `IConcurrency<TToken>`, with `IConcurrency` kept as the `byte[]` shorthand. Code naming `IConcurrency` is unaffected; the entity and configuration ladders each gained a rung that names the token type.
 
 ## Usage
 

--- a/src/BB84.EntityFrameworkCore.Entities/AuditedCompositeEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities/AuditedCompositeEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright: 2024 Robert Peter Meyer
+// Copyright: 2024 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -10,15 +10,16 @@ namespace BB84.EntityFrameworkCore.Entities;
 /// <summary>
 /// This abstract class provides a base implementation for entities that are composed
 /// of multiple related components and require auditing information, including the creator,
-/// editor, and a concurrency timestamp.
+/// editor, and a concurrency token.
 /// </summary>
 /// <typeparam name="TCreator">The type of the entity or user responsible for creating the entity.</typeparam>
 /// <typeparam name="TEditor">The type of the entity or user responsible for editing the entity.</typeparam>
-public abstract class AuditedCompositeEntity<TCreator, TEditor> : IAuditedCompositeEntity<TCreator, TEditor>
+/// <typeparam name="TToken">The type of the concurrency token.</typeparam>
+public abstract class AuditedCompositeEntity<TCreator, TEditor, TToken> : IAuditedCompositeEntity<TCreator, TEditor, TToken>
 	where TCreator : notnull
 {
 	/// <inheritdoc/>
-	public byte[] Timestamp { get; set; } = [];
+	public TToken Timestamp { get; set; } = default!;
 
 	/// <inheritdoc/>
 	public TCreator CreatedBy { get; set; } = default!;
@@ -27,9 +28,26 @@ public abstract class AuditedCompositeEntity<TCreator, TEditor> : IAuditedCompos
 	public TEditor EditedBy { get; set; } = default!;
 }
 
-/// <inheritdoc cref="AuditedCompositeEntity{TCreator, TEditor}"/>
+/// <inheritdoc cref="AuditedCompositeEntity{TCreator, TEditor, TToken}"/>
 /// <remarks>
-/// The creator and editor types default to <see cref="string"/>.
+/// The creator and editor types are supplied; <c>TToken</c> defaults to a <see cref="byte"/> array.
+/// For a custom token type use <see cref="AuditedCompositeEntity{TCreator, TEditor, TToken}"/>
+/// and name all three.
 /// </remarks>
-public abstract class AuditedCompositeEntity : AuditedCompositeEntity<string, string?>, IAuditedCompositeEntity
-{ }
+public abstract class AuditedCompositeEntity<TCreator, TEditor> : AuditedCompositeEntity<TCreator, TEditor, byte[]>, IAuditedCompositeEntity<TCreator, TEditor>
+	where TCreator : notnull
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="AuditedCompositeEntity{TCreator, TEditor}"/> class.
+	/// </summary>
+	/// <inheritdoc cref="IdentityEntity{TKey}()" path="/remarks"/>
+	protected AuditedCompositeEntity()
+		=> Timestamp = [];
+}
+
+/// <inheritdoc cref="AuditedCompositeEntity{TCreator, TEditor, TToken}"/>
+/// <remarks>
+/// The creator and editor types default to <see cref="string"/> and the token to a
+/// <see cref="byte"/> array.
+/// </remarks>
+public abstract class AuditedCompositeEntity : AuditedCompositeEntity<string, string?>, IAuditedCompositeEntity;

--- a/src/BB84.EntityFrameworkCore.Entities/AuditedEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities/AuditedEntity.cs
@@ -9,13 +9,13 @@ namespace BB84.EntityFrameworkCore.Entities;
 
 /// <summary>
 /// This abstract class provides a base implementation for entities that track auditing information,
-/// including the creator and the last editor, a unique identifier and a timestamp for concurrency
-/// control.
+/// including the creator and the last editor, a unique identifier and a concurrency token.
 /// </summary>
 /// <typeparam name="TKey">The type of the unique identifier for the entity.</typeparam>
 /// <typeparam name="TCreator">The type representing the creator of the entity.</typeparam>
 /// <typeparam name="TEditor">The type representing the last editor of the entity.</typeparam>
-public abstract class AuditedEntity<TKey, TCreator, TEditor> : IdentityEntity<TKey>, IAuditedEntity<TKey, TCreator, TEditor>
+/// <typeparam name="TToken">The type of the concurrency token.</typeparam>
+public abstract class AuditedEntity<TKey, TCreator, TEditor, TToken> : IdentityEntity<TKey, TToken>, IAuditedEntity<TKey, TCreator, TEditor, TToken>
 	where TKey : IEquatable<TKey>
 	where TCreator : notnull
 {
@@ -26,20 +26,38 @@ public abstract class AuditedEntity<TKey, TCreator, TEditor> : IdentityEntity<TK
 	public TEditor EditedBy { get; set; } = default!;
 }
 
-/// <inheritdoc cref="AuditedEntity{TKey, TCreator, TEditor}"/>
+/// <inheritdoc cref="AuditedEntity{TKey, TCreator, TEditor, TToken}"/>
 /// <remarks>
-/// <typeparamref name="TKey"/> is supplied; <c>TCreator</c> defaults to <see cref="string"/>
-/// and <c>TEditor</c> to <see cref="string"/>. For a custom creator or editor type use
-/// <see cref="AuditedEntity{TKey, TCreator, TEditor}"/> and name all three.
+/// The key, creator and editor types are supplied; <c>TToken</c> defaults to a <see cref="byte"/>
+/// array. For a custom token type use <see cref="AuditedEntity{TKey, TCreator, TEditor, TToken}"/>
+/// and name all four.
+/// </remarks>
+public abstract class AuditedEntity<TKey, TCreator, TEditor> : AuditedEntity<TKey, TCreator, TEditor, byte[]>, IAuditedEntity<TKey, TCreator, TEditor>
+	where TKey : IEquatable<TKey>
+	where TCreator : notnull
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="AuditedEntity{TKey, TCreator, TEditor}"/> class.
+	/// </summary>
+	/// <inheritdoc cref="IdentityEntity{TKey}()" path="/remarks"/>
+	protected AuditedEntity()
+		=> Timestamp = [];
+}
+
+/// <inheritdoc cref="AuditedEntity{TKey, TCreator, TEditor, TToken}"/>
+/// <remarks>
+/// <typeparamref name="TKey"/> is supplied; <c>TCreator</c> defaults to <see cref="string"/>,
+/// <c>TEditor</c> to <see cref="string"/> and <c>TToken</c> to a <see cref="byte"/> array. For a
+/// custom creator or editor type use <see cref="AuditedEntity{TKey, TCreator, TEditor}"/> and
+/// name all three.
 /// </remarks>
 public abstract class AuditedEntity<TKey> : AuditedEntity<TKey, string, string?>, IAuditedEntity<TKey>
-	where TKey : IEquatable<TKey>
-{ }
+	where TKey : IEquatable<TKey>;
 
-/// <inheritdoc cref="AuditedEntity{TKey, TCreator, TEditor}"/>
+/// <inheritdoc cref="AuditedEntity{TKey, TCreator, TEditor, TToken}"/>
 /// <remarks>
 /// Nothing is supplied; <c>TKey</c> defaults to <see cref="Guid"/>, <c>TCreator</c> to
-/// <see cref="string"/> and <c>TEditor</c> to <see cref="string"/>.
+/// <see cref="string"/>, <c>TEditor</c> to <see cref="string"/> and <c>TToken</c> to a
+/// <see cref="byte"/> array.
 /// </remarks>
-public abstract class AuditedEntity : AuditedEntity<Guid, string, string?>, IAuditedEntity
-{ }
+public abstract class AuditedEntity : AuditedEntity<Guid, string, string?>, IAuditedEntity;

--- a/src/BB84.EntityFrameworkCore.Entities/CompositeEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities/CompositeEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright: 2024 Robert Peter Meyer
+// Copyright: 2024 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -11,8 +11,24 @@ namespace BB84.EntityFrameworkCore.Entities;
 /// This abstract class provides a base implementation for entities that are
 /// composed of multiple related components.
 /// </summary>
-public abstract class CompositeEntity : ICompositeEntity
+/// <typeparam name="TToken">The type of the concurrency token.</typeparam>
+public abstract class CompositeEntity<TToken> : ICompositeEntity<TToken>
 {
 	/// <inheritdoc/>
-	public byte[] Timestamp { get; set; } = [];
+	public TToken Timestamp { get; set; } = default!;
+}
+
+/// <inheritdoc cref="CompositeEntity{TToken}"/>
+/// <remarks>
+/// The token is a <see cref="byte"/> array. For a custom token type use
+/// <see cref="CompositeEntity{TToken}"/> and name it.
+/// </remarks>
+public abstract class CompositeEntity : CompositeEntity<byte[]>, ICompositeEntity
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="CompositeEntity"/> class.
+	/// </summary>
+	/// <inheritdoc cref="IdentityEntity{TKey}()" path="/remarks"/>
+	protected CompositeEntity()
+		=> Timestamp = [];
 }

--- a/src/BB84.EntityFrameworkCore.Entities/EnumeratorEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities/EnumeratorEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright: 2024 Robert Peter Meyer
+// Copyright: 2024 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -13,14 +13,15 @@ namespace BB84.EntityFrameworkCore.Entities;
 /// support for soft deletion functionality.
 /// </summary>
 /// <typeparam name="TKey">The type of the unique identifier for the entity.</typeparam>
-public abstract class EnumeratorEntity<TKey> : IEnumeratorEntity<TKey>
+/// <typeparam name="TToken">The type of the concurrency token.</typeparam>
+public abstract class EnumeratorEntity<TKey, TToken> : IEnumeratorEntity<TKey, TToken>
 	where TKey : IEquatable<TKey>
 {
 	/// <inheritdoc/>
 	public TKey Id { get; set; } = default!;
 
 	/// <inheritdoc/>
-	public byte[] Timestamp { get; set; } = [];
+	public TToken Timestamp { get; set; } = default!;
 
 	/// <inheritdoc/>
 	public required string Name { get; set; }
@@ -32,9 +33,25 @@ public abstract class EnumeratorEntity<TKey> : IEnumeratorEntity<TKey>
 	public bool IsDeleted { get; set; }
 }
 
-/// <inheritdoc cref="EnumeratorEntity{TKey}"/>
+/// <inheritdoc cref="EnumeratorEntity{TKey, TToken}"/>
 /// <remarks>
-/// The unique identifier type defaults to <see cref="int"/>.
+/// <typeparamref name="TKey"/> is supplied; <c>TToken</c> defaults to a <see cref="byte"/> array.
+/// For a custom token type use <see cref="EnumeratorEntity{TKey, TToken}"/> and name both.
 /// </remarks>
-public abstract class EnumeratorEntity : EnumeratorEntity<int>, IEnumeratorEntity
-{ }
+public abstract class EnumeratorEntity<TKey> : EnumeratorEntity<TKey, byte[]>, IEnumeratorEntity<TKey>
+	where TKey : IEquatable<TKey>
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="EnumeratorEntity{TKey}"/> class.
+	/// </summary>
+	/// <inheritdoc cref="IdentityEntity{TKey}()" path="/remarks"/>
+	protected EnumeratorEntity()
+		=> Timestamp = [];
+}
+
+/// <inheritdoc cref="EnumeratorEntity{TKey, TToken}"/>
+/// <remarks>
+/// The unique identifier type defaults to <see cref="int"/> and the token to a
+/// <see cref="byte"/> array.
+/// </remarks>
+public abstract class EnumeratorEntity : EnumeratorEntity<int>, IEnumeratorEntity;

--- a/src/BB84.EntityFrameworkCore.Entities/FullAuditedEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities/FullAuditedEntity.cs
@@ -14,7 +14,8 @@ namespace BB84.EntityFrameworkCore.Entities;
 /// <typeparam name="TKey">The type of the unique identifier for the entity.</typeparam>
 /// <typeparam name="TCreator">The type representing the creator of the entity.</typeparam>
 /// <typeparam name="TEditor">The type representing the editor of the entity.</typeparam>
-public abstract class FullAuditedEntity<TKey, TCreator, TEditor> : IdentityEntity<TKey>, IFullAuditedEntity<TKey, TCreator, TEditor>
+/// <typeparam name="TToken">The type of the concurrency token.</typeparam>
+public abstract class FullAuditedEntity<TKey, TCreator, TEditor, TToken> : IdentityEntity<TKey, TToken>, IFullAuditedEntity<TKey, TCreator, TEditor, TToken>
 	where TKey : IEquatable<TKey>
 	where TCreator : notnull
 {
@@ -28,20 +29,38 @@ public abstract class FullAuditedEntity<TKey, TCreator, TEditor> : IdentityEntit
 	public DateTimeOffset? EditedAt { get; set; } = default!;
 }
 
-/// <inheritdoc cref="FullAuditedEntity{TKey, TCreator, TEditor}"/>
+/// <inheritdoc cref="FullAuditedEntity{TKey, TCreator, TEditor, TToken}"/>
 /// <remarks>
-/// <typeparamref name="TKey"/> is supplied; <c>TCreator</c> defaults to <see cref="string"/>
-/// and <c>TEditor</c> to <see cref="string"/>. For a custom creator or editor type use
-/// <see cref="FullAuditedEntity{TKey, TCreator, TEditor}"/> and name all three.
+/// The key, creator and editor types are supplied; <c>TToken</c> defaults to a <see cref="byte"/>
+/// array. For a custom token type use
+/// <see cref="FullAuditedEntity{TKey, TCreator, TEditor, TToken}"/> and name all four.
+/// </remarks>
+public abstract class FullAuditedEntity<TKey, TCreator, TEditor> : FullAuditedEntity<TKey, TCreator, TEditor, byte[]>, IFullAuditedEntity<TKey, TCreator, TEditor>
+	where TKey : IEquatable<TKey>
+	where TCreator : notnull
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="FullAuditedEntity{TKey, TCreator, TEditor}"/> class.
+	/// </summary>
+	/// <inheritdoc cref="IdentityEntity{TKey}()" path="/remarks"/>
+	protected FullAuditedEntity()
+		=> Timestamp = [];
+}
+
+/// <inheritdoc cref="FullAuditedEntity{TKey, TCreator, TEditor, TToken}"/>
+/// <remarks>
+/// <typeparamref name="TKey"/> is supplied; <c>TCreator</c> defaults to <see cref="string"/>,
+/// <c>TEditor</c> to <see cref="string"/> and <c>TToken</c> to a <see cref="byte"/> array. For a
+/// custom creator or editor type use <see cref="FullAuditedEntity{TKey, TCreator, TEditor}"/> and
+/// name all three.
 /// </remarks>
 public abstract class FullAuditedEntity<TKey> : FullAuditedEntity<TKey, string, string?>, IFullAuditedEntity<TKey>
-	where TKey : IEquatable<TKey>
-{ }
+	where TKey : IEquatable<TKey>;
 
-/// <inheritdoc cref="FullAuditedEntity{TKey, TCreator, TEditor}"/>
+/// <inheritdoc cref="FullAuditedEntity{TKey, TCreator, TEditor, TToken}"/>
 /// <remarks>
 /// Nothing is supplied; <c>TKey</c> defaults to <see cref="Guid"/>, <c>TCreator</c> to
-/// <see cref="string"/> and <c>TEditor</c> to <see cref="string"/>.
+/// <see cref="string"/>, <c>TEditor</c> to <see cref="string"/> and <c>TToken</c> to a
+/// <see cref="byte"/> array.
 /// </remarks>
-public abstract class FullAuditedEntity : FullAuditedEntity<Guid, string, string?>, IFullAuditedEntity
-{ }
+public abstract class FullAuditedEntity : FullAuditedEntity<Guid, string, string?>, IFullAuditedEntity;

--- a/src/BB84.EntityFrameworkCore.Entities/IdentityEntity.cs
+++ b/src/BB84.EntityFrameworkCore.Entities/IdentityEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright: 2024 Robert Peter Meyer
+// Copyright: 2024 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -9,22 +9,42 @@ namespace BB84.EntityFrameworkCore.Entities;
 
 /// <summary>
 /// This abstract class provides a base implementation for entities that require a unique
-/// identifier and a timestamp for concurrency control.
+/// identifier and a concurrency token.
 /// </summary>
 /// <typeparam name="TKey">The type of the unique identifier for the entity.</typeparam>
-public abstract class IdentityEntity<TKey> : IIdentityEntity<TKey>
+/// <typeparam name="TToken">The type of the concurrency token.</typeparam>
+public abstract class IdentityEntity<TKey, TToken> : IIdentityEntity<TKey, TToken>
 	where TKey : IEquatable<TKey>
 {
 	/// <inheritdoc/>
 	public TKey Id { get; set; } = default!;
 
 	/// <inheritdoc/>
-	public byte[] Timestamp { get; set; } = [];
+	public TToken Timestamp { get; set; } = default!;
 }
 
-/// <inheritdoc cref="IdentityEntity{TKey}"/>
+/// <inheritdoc cref="IdentityEntity{TKey, TToken}"/>
 /// <remarks>
-/// The unique identifier is of type <see cref="Guid"/>.
+/// <typeparamref name="TKey"/> is supplied; <c>TToken</c> defaults to a <see cref="byte"/> array.
+/// For a custom token type use <see cref="IdentityEntity{TKey, TToken}"/> and name both.
 /// </remarks>
-public abstract class IdentityEntity : IdentityEntity<Guid>, IIdentityEntity
-{ }
+public abstract class IdentityEntity<TKey> : IdentityEntity<TKey, byte[]>, IIdentityEntity<TKey>
+	where TKey : IEquatable<TKey>
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="IdentityEntity{TKey}"/> class.
+	/// </summary>
+	/// <remarks>
+	/// The token starts out as an empty array rather than <see langword="null"/>. The generic base
+	/// cannot express that for an arbitrary token type, so the <see cref="byte"/> array rungs
+	/// restore it here — the property was never null before the token type became a parameter.
+	/// </remarks>
+	protected IdentityEntity()
+		=> Timestamp = [];
+}
+
+/// <inheritdoc cref="IdentityEntity{TKey, TToken}"/>
+/// <remarks>
+/// The unique identifier is of type <see cref="Guid"/> and the token a <see cref="byte"/> array.
+/// </remarks>
+public abstract class IdentityEntity : IdentityEntity<Guid>, IIdentityEntity;

--- a/src/BB84.EntityFrameworkCore.Entities/README.md
+++ b/src/BB84.EntityFrameworkCore.Entities/README.md
@@ -13,23 +13,29 @@ dotnet add package BB84.EntityFrameworkCore.Entities
 
 ## Implementations
 
-Each abstract class mirrors the interface hierarchy. Convenience overloads follow the same defaulting pattern as the interfaces (`TKey` → `Guid`, `TCreator`/`TEditor` → `string`/`string?`).
+Each abstract class mirrors the interface hierarchy. Convenience overloads follow the same defaulting pattern as the interfaces (`TToken` → `byte[]`, `TKey` → `Guid`, `TCreator`/`TEditor` → `string`/`string?`).
 
-| Abstract class                               | Implements                                    | Notes                                     |
-| -------------------------------------------- | --------------------------------------------- | ----------------------------------------- |
-| `IdentityEntity<TKey>`                       | `IIdentityEntity<TKey>`                       |                                           |
-| `IdentityEntity`                             | `IIdentityEntity`                             | `TKey` = `Guid`                           |
-| `AuditedEntity<TKey, TCreator, TEditor>`     | `IAuditedEntity<TKey, TCreator, TEditor>`     |                                           |
-| `AuditedEntity<TKey>`                        | `IAuditedEntity<TKey>`                        | `TCreator`/`TEditor` = `string`/`string?` |
-| `AuditedEntity`                              | `IAuditedEntity`                              | `TKey` = `Guid`                           |
-| `FullAuditedEntity<TKey, TCreator, TEditor>` | `IFullAuditedEntity<TKey, TCreator, TEditor>` | Adds `CreatedAt`, `EditedAt`              |
-| `FullAuditedEntity<TKey>`                    | `IFullAuditedEntity<TKey>`                    |                                           |
-| `FullAuditedEntity`                          | `IFullAuditedEntity`                          | `TKey` = `Guid`                           |
-| `CompositeEntity`                            | `ICompositeEntity`                            |                                           |
-| `AuditedCompositeEntity<TCreator, TEditor>`  | `IAuditedCompositeEntity<TCreator, TEditor>`  |                                           |
-| `AuditedCompositeEntity`                     | `IAuditedCompositeEntity`                     | `TCreator`/`TEditor` = `string`/`string?` |
-| `EnumeratorEntity<TKey>`                     | `IEnumeratorEntity<TKey>`                     |                                           |
-| `EnumeratorEntity`                           | `IEnumeratorEntity`                           | `TKey` = `int`                            |
+| Abstract class                                       | Implements                                            | Notes                                     |
+| ---------------------------------------------------- | ----------------------------------------------------- | ----------------------------------------- |
+| `IdentityEntity<TKey, TToken>`                       | `IIdentityEntity<TKey, TToken>`                       |                                           |
+| `IdentityEntity<TKey>`                               | `IIdentityEntity<TKey>`                               | `TToken` = `byte[]`                       |
+| `IdentityEntity`                                     | `IIdentityEntity`                                     | `TKey` = `Guid`                           |
+| `AuditedEntity<TKey, TCreator, TEditor, TToken>`     | `IAuditedEntity<TKey, TCreator, TEditor, TToken>`     |                                           |
+| `AuditedEntity<TKey, TCreator, TEditor>`             | `IAuditedEntity<TKey, TCreator, TEditor>`             | `TToken` = `byte[]`                       |
+| `AuditedEntity<TKey>`                                | `IAuditedEntity<TKey>`                                | `TCreator`/`TEditor` = `string`/`string?` |
+| `AuditedEntity`                                      | `IAuditedEntity`                                      | `TKey` = `Guid`                           |
+| `FullAuditedEntity<TKey, TCreator, TEditor, TToken>` | `IFullAuditedEntity<TKey, TCreator, TEditor, TToken>` | Adds `CreatedAt`, `EditedAt`              |
+| `FullAuditedEntity<TKey, TCreator, TEditor>`         | `IFullAuditedEntity<TKey, TCreator, TEditor>`         | `TToken` = `byte[]`                       |
+| `FullAuditedEntity<TKey>`                            | `IFullAuditedEntity<TKey>`                            |                                           |
+| `FullAuditedEntity`                                  | `IFullAuditedEntity`                                  | `TKey` = `Guid`                           |
+| `CompositeEntity<TToken>`                            | `ICompositeEntity<TToken>`                            |                                           |
+| `CompositeEntity`                                    | `ICompositeEntity`                                    | `TToken` = `byte[]`                       |
+| `AuditedCompositeEntity<TCreator, TEditor, TToken>`  | `IAuditedCompositeEntity<TCreator, TEditor, TToken>`  |                                           |
+| `AuditedCompositeEntity<TCreator, TEditor>`          | `IAuditedCompositeEntity<TCreator, TEditor>`          | `TToken` = `byte[]`                       |
+| `AuditedCompositeEntity`                             | `IAuditedCompositeEntity`                             | `TCreator`/`TEditor` = `string`/`string?` |
+| `EnumeratorEntity<TKey, TToken>`                     | `IEnumeratorEntity<TKey, TToken>`                     |                                           |
+| `EnumeratorEntity<TKey>`                             | `IEnumeratorEntity<TKey>`                             | `TToken` = `byte[]`                       |
+| `EnumeratorEntity`                                   | `IEnumeratorEntity`                                   | `TKey` = `int`                            |
 
 ## Usage
 

--- a/src/BB84.EntityFrameworkCore.Repositories.Abstractions/README.md
+++ b/src/BB84.EntityFrameworkCore.Repositories.Abstractions/README.md
@@ -70,11 +70,11 @@ IReadOnlyList<Person> firstPage = repository.GetList(active with { Take = 25 });
 
 Each repository abstraction exists as two halves plus a composed alias:
 
-| Read                                       | Write                                       | Composed                                |
-| ------------------------------------------- | -------------------------------------------- | ---------------------------------------- |
-| `IReadRepository<TEntity>`                 | `IWriteRepository<TEntity>`                 | `IGenericRepository<TEntity>`           |
-| `IReadIdentityRepository<TEntity, TKey>`   | `IWriteIdentityRepository<TEntity, TKey>`   | `IIdentityRepository<TEntity, TKey>`    |
-| `IReadEnumeratorRepository<TEntity, TKey>` | —                                           | `IEnumeratorRepository<TEntity, TKey>`  |
+| Read                                       | Write                                     | Composed                               |
+| ------------------------------------------ | ----------------------------------------- | -------------------------------------- |
+| `IReadRepository<TEntity>`                 | `IWriteRepository<TEntity>`               | `IGenericRepository<TEntity>`          |
+| `IReadIdentityRepository<TEntity, TKey>`   | `IWriteIdentityRepository<TEntity, TKey>` | `IIdentityRepository<TEntity, TKey>`   |
+| `IReadEnumeratorRepository<TEntity, TKey>` | —                                         | `IEnumeratorRepository<TEntity, TKey>` |
 
 Depend on a half wherever a component only reads or only writes — a query handler, a reporting service, an importer, either side of a CQRS split. The dependency then states in its type what it is allowed to do, and a hand written test double only has to implement the half it needs.
 
@@ -89,7 +89,7 @@ public sealed class PriceReport(IReadRepository<Product> products)
 
 The composed interfaces add no members of their own, so nothing is reachable only through them. `GenericRepository<TEntity>` and its derivatives still implement the composed interfaces, and existing `IGenericRepository<TEntity>` consumers are unaffected.
 
-There is no `IWriteEnumeratorRepository`: an enumerator repository adds only name based *reads* on top of the identity repository, so its write half is exactly the inherited one.
+There is no `IWriteEnumeratorRepository`: an enumerator repository adds only name based _reads_ on top of the identity repository, so its write half is exactly the inherited one.
 
 ## `IGenericRepository<TEntity>`
 

--- a/src/BB84.EntityFrameworkCore.Repositories.SqlServer/README.md
+++ b/src/BB84.EntityFrameworkCore.Repositories.SqlServer/README.md
@@ -45,6 +45,8 @@ Inherit from these in your `IEntityTypeConfiguration<TEntity>` implementations a
 | `AuditedCompositeConfiguration<TEntity, TCreator, TEditor>`  | `IAuditedCompositeEntity<TCreator, TEditor>`  | Above + audit user columns                                                                                                                                            |
 | `EnumeratorConfiguration<TEntity, TKey>`                     | `IEnumeratorEntity<TKey>`                     | Non-clustered PK, `Name` (`nvarchar(64)`, unique index, non-unicode), `Description` (`nvarchar(256)`), `IsDeleted` default `false`; `int` overload uses clustered PK  |
 
+These stop at the `byte[]` rung on purpose. The token type is a parameter on the agnostic bases in `BB84.EntityFrameworkCore.Repositories`, but on SQL Server the concurrency token is a `rowversion` and a `rowversion` is eight bytes — there is nothing here for another type to map onto. An entity with a different token type belongs on the agnostic configuration bases.
+
 ```csharp
 public class ProductConfiguration : IdentityConfiguration<Product>
 {

--- a/src/BB84.EntityFrameworkCore.Repositories/Configurations/AuditedCompositeConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Configurations/AuditedCompositeConfiguration.cs
@@ -12,7 +12,7 @@ namespace BB84.EntityFrameworkCore.Repositories.Configurations;
 
 /// <summary>
 /// Provides a base configuration for entities that implement the
-/// <see cref="IAuditedCompositeEntity{TCreator, TEditor}"/> interface.
+/// <see cref="IAuditedCompositeEntity{TCreator, TEditor, TToken}"/> interface.
 /// </summary>
 /// <remarks>
 /// This abstract class provides a reusable configuration for audited composite entities,
@@ -24,19 +24,33 @@ namespace BB84.EntityFrameworkCore.Repositories.Configurations;
 /// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
 /// <typeparam name="TCreator">The type representing the creator of the entity.</typeparam>
 /// <typeparam name="TEditor">The type representing the editor of the entity.</typeparam>
-public abstract class AuditedCompositeConfiguration<TEntity, TCreator, TEditor> : IEntityTypeConfiguration<TEntity>
-	where TEntity : class, IAuditedCompositeEntity<TCreator, TEditor>
+/// <typeparam name="TToken">The type of the concurrency token.</typeparam>
+public abstract class AuditedCompositeConfiguration<TEntity, TCreator, TEditor, TToken> : IEntityTypeConfiguration<TEntity>
+	where TEntity : class, IAuditedCompositeEntity<TCreator, TEditor, TToken>
 	where TCreator : notnull
 {
 	/// <inheritdoc/>
 	public virtual void Configure(EntityTypeBuilder<TEntity> builder)
 	{
-		EntityTypeBuilderDefaults.ApplyConcurrencyToken(builder, columnOrder: 3);
+		EntityTypeBuilderDefaults.ApplyConcurrencyToken<TEntity, TToken>(builder, columnOrder: 3);
 		EntityTypeBuilderDefaults.ApplyUserAuditColumns<TEntity, TCreator, TEditor>(builder, createdByOrder: 4, editedByOrder: 5);
 	}
 }
 
-/// <inheritdoc cref="AuditedCompositeConfiguration{TEntity, TCreator, TEditor}"/>
+/// <inheritdoc cref="AuditedCompositeConfiguration{TEntity, TCreator, TEditor, TToken}"/>
+/// <remarks>
+/// The creator and editor types are supplied; <c>TToken</c> defaults to a <see cref="byte"/> array.
+/// For a custom token type use
+/// <see cref="AuditedCompositeConfiguration{TEntity, TCreator, TEditor, TToken}"/> and name all four.
+/// </remarks>
+public abstract class AuditedCompositeConfiguration<TEntity, TCreator, TEditor> : AuditedCompositeConfiguration<TEntity, TCreator, TEditor, byte[]>, IEntityTypeConfiguration<TEntity>
+	where TEntity : class, IAuditedCompositeEntity<TCreator, TEditor>
+	where TCreator : notnull;
+
+/// <inheritdoc cref="AuditedCompositeConfiguration{TEntity, TCreator, TEditor, TToken}"/>
+/// <remarks>
+/// The creator and editor types default to <see cref="string"/> and the token to a
+/// <see cref="byte"/> array.
+/// </remarks>
 public abstract class AuditedCompositeConfiguration<TEntity> : AuditedCompositeConfiguration<TEntity, string, string?>, IEntityTypeConfiguration<TEntity>
-	where TEntity : class, IAuditedCompositeEntity
-{ }
+	where TEntity : class, IAuditedCompositeEntity;

--- a/src/BB84.EntityFrameworkCore.Repositories/Configurations/AuditedConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Configurations/AuditedConfiguration.cs
@@ -12,7 +12,7 @@ namespace BB84.EntityFrameworkCore.Repositories.Configurations;
 
 /// <summary>
 /// Represents an abstract base class for configuring the entities of type
-/// <see cref="IAuditedEntity{TKey, TCreator, TEditor}"/> for identity-related and time audited
+/// <see cref="IAuditedEntity{TKey, TCreator, TEditor, TToken}"/> for identity-related and time audited
 /// entities in the Entity Framework Core model.
 /// </summary>
 /// <remarks>
@@ -24,8 +24,9 @@ namespace BB84.EntityFrameworkCore.Repositories.Configurations;
 /// <typeparam name="TKey">The type of the primary key for the entity.</typeparam>
 /// <typeparam name="TCreator">The type representing the creator of the entity.</typeparam>
 /// <typeparam name="TEditor">The type representing the editor of the entity.</typeparam>
-public abstract class AuditedConfiguration<TEntity, TKey, TCreator, TEditor> : IEntityTypeConfiguration<TEntity>
-	where TEntity : class, IAuditedEntity<TKey, TCreator, TEditor>
+/// <typeparam name="TToken">The type of the concurrency token.</typeparam>
+public abstract class AuditedConfiguration<TEntity, TKey, TCreator, TEditor, TToken> : IEntityTypeConfiguration<TEntity>
+	where TEntity : class, IAuditedEntity<TKey, TCreator, TEditor, TToken>
 	where TKey : IEquatable<TKey>
 	where TCreator : notnull
 {
@@ -33,27 +34,38 @@ public abstract class AuditedConfiguration<TEntity, TKey, TCreator, TEditor> : I
 	public virtual void Configure(EntityTypeBuilder<TEntity> builder)
 	{
 		EntityTypeBuilderDefaults.ApplyIdentityKey<TEntity, TKey>(builder);
-		EntityTypeBuilderDefaults.ApplyConcurrencyToken(builder, columnOrder: 2);
+		EntityTypeBuilderDefaults.ApplyConcurrencyToken<TEntity, TToken>(builder, columnOrder: 2);
 		EntityTypeBuilderDefaults.ApplyUserAuditColumns<TEntity, TCreator, TEditor>(builder, createdByOrder: 3, editedByOrder: 4);
 	}
 }
 
-/// <inheritdoc cref="AuditedConfiguration{TEntity, TKey, TCreator, TEditor}"/>
+/// <inheritdoc cref="AuditedConfiguration{TEntity, TKey, TCreator, TEditor, TToken}"/>
 /// <remarks>
-/// <typeparamref name="TKey"/> is supplied; <c>TCreator</c> defaults to <see cref="string"/>
-/// and <c>TEditor</c> to <see cref="string"/>. For a custom creator or editor type use
+/// The key, creator and editor types are supplied; <c>TToken</c> defaults to a <see cref="byte"/>
+/// array. For a custom token type use
+/// <see cref="AuditedConfiguration{TEntity, TKey, TCreator, TEditor, TToken}"/> and name all five.
+/// </remarks>
+public abstract class AuditedConfiguration<TEntity, TKey, TCreator, TEditor> : AuditedConfiguration<TEntity, TKey, TCreator, TEditor, byte[]>, IEntityTypeConfiguration<TEntity>
+	where TEntity : class, IAuditedEntity<TKey, TCreator, TEditor>
+	where TKey : IEquatable<TKey>
+	where TCreator : notnull;
+
+/// <inheritdoc cref="AuditedConfiguration{TEntity, TKey, TCreator, TEditor, TToken}"/>
+/// <remarks>
+/// <typeparamref name="TKey"/> is supplied; <c>TCreator</c> defaults to <see cref="string"/>,
+/// <c>TEditor</c> to <see cref="string"/> and <c>TToken</c> to a <see cref="byte"/> array. For a
+/// custom creator or editor type use
 /// <see cref="AuditedConfiguration{TEntity, TKey, TCreator, TEditor}"/> and name all four.
 /// </remarks>
 public abstract class AuditedConfiguration<TEntity, TKey> : AuditedConfiguration<TEntity, TKey, string, string?>, IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IAuditedEntity<TKey>
-	where TKey : IEquatable<TKey>
-{ }
+	where TKey : IEquatable<TKey>;
 
-/// <inheritdoc cref="AuditedConfiguration{TEntity, TKey, TCreator, TEditor}"/>
+/// <inheritdoc cref="AuditedConfiguration{TEntity, TKey, TCreator, TEditor, TToken}"/>
 /// <remarks>
 /// Only <typeparamref name="TEntity"/> is supplied; <c>TKey</c> defaults to <see cref="Guid"/>,
-/// <c>TCreator</c> to <see cref="string"/> and <c>TEditor</c> to <see cref="string"/>.
+/// <c>TCreator</c> to <see cref="string"/>, <c>TEditor</c> to <see cref="string"/> and
+/// <c>TToken</c> to a <see cref="byte"/> array.
 /// </remarks>
 public abstract class AuditedConfiguration<TEntity> : AuditedConfiguration<TEntity, Guid, string, string?>,
-	IEntityTypeConfiguration<TEntity> where TEntity : class, IAuditedEntity
-{ }
+	IEntityTypeConfiguration<TEntity> where TEntity : class, IAuditedEntity;

--- a/src/BB84.EntityFrameworkCore.Repositories/Configurations/CompositeConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Configurations/CompositeConfiguration.cs
@@ -12,7 +12,7 @@ namespace BB84.EntityFrameworkCore.Repositories.Configurations;
 
 /// <summary>
 /// Represents an abstract base class for configuring entity types that implement the
-/// <see cref="ICompositeEntity"/> interface.
+/// <see cref="ICompositeEntity{TToken}"/> interface.
 /// </summary>
 /// <remarks>
 /// This class is intended to be used as a base for defining entity type configurations in
@@ -20,10 +20,19 @@ namespace BB84.EntityFrameworkCore.Repositories.Configurations;
 /// such as the <c>Timestamp</c> property.
 /// </remarks>
 /// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
-public abstract class CompositeConfiguration<TEntity> : IEntityTypeConfiguration<TEntity>
-	where TEntity : class, ICompositeEntity
+/// <typeparam name="TToken">The type of the concurrency token.</typeparam>
+public abstract class CompositeConfiguration<TEntity, TToken> : IEntityTypeConfiguration<TEntity>
+	where TEntity : class, ICompositeEntity<TToken>
 {
 	/// <inheritdoc/>
 	public virtual void Configure(EntityTypeBuilder<TEntity> builder)
-		=> EntityTypeBuilderDefaults.ApplyConcurrencyToken(builder, columnOrder: 3);
+		=> EntityTypeBuilderDefaults.ApplyConcurrencyToken<TEntity, TToken>(builder, columnOrder: 3);
 }
+
+/// <inheritdoc cref="CompositeConfiguration{TEntity, TToken}"/>
+/// <remarks>
+/// The token is a <see cref="byte"/> array. For a custom token type use
+/// <see cref="CompositeConfiguration{TEntity, TToken}"/> and name both.
+/// </remarks>
+public abstract class CompositeConfiguration<TEntity> : CompositeConfiguration<TEntity, byte[]>, IEntityTypeConfiguration<TEntity>
+	where TEntity : class, ICompositeEntity;

--- a/src/BB84.EntityFrameworkCore.Repositories/Configurations/EntityTypeBuilderDefaults.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Configurations/EntityTypeBuilderDefaults.cs
@@ -43,11 +43,16 @@ internal static class EntityTypeBuilderDefaults
 	/// <summary>
 	/// Configures the concurrency token of the entity.
 	/// </summary>
+	/// <remarks>
+	/// The token type has to be named explicitly — it appears nowhere in the parameter list, so
+	/// there is nothing for the compiler to infer it from.
+	/// </remarks>
 	/// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
+	/// <typeparam name="TToken">The type of the concurrency token.</typeparam>
 	/// <param name="builder">The builder for the entity type being configured.</param>
 	/// <param name="columnOrder">The zero based ordering of the column within the table.</param>
-	internal static void ApplyConcurrencyToken<TEntity>(EntityTypeBuilder<TEntity> builder, int columnOrder)
-		where TEntity : class, IConcurrency
+	internal static void ApplyConcurrencyToken<TEntity, TToken>(EntityTypeBuilder<TEntity> builder, int columnOrder)
+		where TEntity : class, IConcurrency<TToken>
 	{
 		builder.Property(e => e.Timestamp)
 			.HasColumnOrder(columnOrder)

--- a/src/BB84.EntityFrameworkCore.Repositories/Configurations/EnumeratorConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Configurations/EnumeratorConfiguration.cs
@@ -14,7 +14,7 @@ namespace BB84.EntityFrameworkCore.Repositories.Configurations;
 
 /// <summary>
 /// Represents an abstract base class for configuring entity types that implement the
-/// <see cref="IEnumeratorEntity{Tkey}"/> interface.
+/// <see cref="IEnumeratorEntity{TKey, TToken}"/> interface.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -36,9 +36,10 @@ namespace BB84.EntityFrameworkCore.Repositories.Configurations;
 /// </remarks>
 /// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
 /// <typeparam name="TKey">The type of the key for the entity.</typeparam>
+/// <typeparam name="TToken">The type of the concurrency token.</typeparam>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
-public abstract class EnumeratorConfiguration<TEntity, TKey> : IEntityTypeConfiguration<TEntity>
-	where TEntity : class, IEnumeratorEntity<TKey>
+public abstract class EnumeratorConfiguration<TEntity, TKey, TToken> : IEntityTypeConfiguration<TEntity>
+	where TEntity : class, IEnumeratorEntity<TKey, TToken>
 	where TKey : IEquatable<TKey>
 {
 	/// <inheritdoc/>
@@ -50,7 +51,7 @@ public abstract class EnumeratorConfiguration<TEntity, TKey> : IEntityTypeConfig
 			.HasColumnOrder(1)
 			.IsRequired();
 
-		EntityTypeBuilderDefaults.ApplyConcurrencyToken(builder, columnOrder: 2);
+		EntityTypeBuilderDefaults.ApplyConcurrencyToken<TEntity, TToken>(builder, columnOrder: 2);
 
 		builder.Property(e => e.Name)
 			.HasColumnOrder(3)
@@ -75,10 +76,19 @@ public abstract class EnumeratorConfiguration<TEntity, TKey> : IEntityTypeConfig
 	}
 }
 
-/// <inheritdoc cref="EnumeratorConfiguration{TEntity, TKey}"/>
+/// <inheritdoc cref="EnumeratorConfiguration{TEntity, TKey, TToken}"/>
 /// <remarks>
-/// The identity column is of type <see cref="int"/>.
+/// <typeparamref name="TKey"/> is supplied; <c>TToken</c> defaults to a <see cref="byte"/> array.
+/// For a custom token type use <see cref="EnumeratorConfiguration{TEntity, TKey, TToken}"/> and
+/// name all three.
+/// </remarks>
+public abstract class EnumeratorConfiguration<TEntity, TKey> : EnumeratorConfiguration<TEntity, TKey, byte[]>
+	where TEntity : class, IEnumeratorEntity<TKey>
+	where TKey : IEquatable<TKey>;
+
+/// <inheritdoc cref="EnumeratorConfiguration{TEntity, TKey, TToken}"/>
+/// <remarks>
+/// The identity column is of type <see cref="int"/> and the token a <see cref="byte"/> array.
 /// </remarks>
 public abstract class EnumeratorConfiguration<TEntity> : EnumeratorConfiguration<TEntity, int>
-	where TEntity : class, IEnumeratorEntity
-{ }
+	where TEntity : class, IEnumeratorEntity;

--- a/src/BB84.EntityFrameworkCore.Repositories/Configurations/FullAuditedConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Configurations/FullAuditedConfiguration.cs
@@ -14,7 +14,7 @@ namespace BB84.EntityFrameworkCore.Repositories.Configurations;
 
 /// <summary>
 /// Provides a base configuration for entities that implement the
-/// <see cref="IFullAuditedEntity{TKey, TCreator, TEditor}"/> interface.
+/// <see cref="IFullAuditedEntity{TKey, TCreator, TEditor, TToken}"/> interface.
 /// </summary>
 /// <remarks>
 /// This configuration defines common properties for audited entities, including primary key,
@@ -25,9 +25,10 @@ namespace BB84.EntityFrameworkCore.Repositories.Configurations;
 /// <typeparam name="TKey">The type of the primary key for the entity.</typeparam>
 /// <typeparam name="TCreator">The type representing the creator of the entity.</typeparam>
 /// <typeparam name="TEditor">The type representing the editor of the entity.</typeparam>
+/// <typeparam name="TToken">The type of the concurrency token.</typeparam>
 [SuppressMessage("Style", "IDE0058", Justification = "Not relevant here, entity type configuration.")]
-public abstract class FullAuditedConfiguration<TEntity, TKey, TCreator, TEditor> : IEntityTypeConfiguration<TEntity>
-	where TEntity : class, IFullAuditedEntity<TKey, TCreator, TEditor>
+public abstract class FullAuditedConfiguration<TEntity, TKey, TCreator, TEditor, TToken> : IEntityTypeConfiguration<TEntity>
+	where TEntity : class, IFullAuditedEntity<TKey, TCreator, TEditor, TToken>
 	where TKey : IEquatable<TKey>
 	where TCreator : notnull
 {
@@ -35,7 +36,7 @@ public abstract class FullAuditedConfiguration<TEntity, TKey, TCreator, TEditor>
 	public virtual void Configure(EntityTypeBuilder<TEntity> builder)
 	{
 		EntityTypeBuilderDefaults.ApplyIdentityKey<TEntity, TKey>(builder);
-		EntityTypeBuilderDefaults.ApplyConcurrencyToken(builder, columnOrder: 2);
+		EntityTypeBuilderDefaults.ApplyConcurrencyToken<TEntity, TToken>(builder, columnOrder: 2);
 		EntityTypeBuilderDefaults.ApplyUserAuditColumns<TEntity, TCreator, TEditor>(builder, createdByOrder: 3, editedByOrder: 5);
 
 		builder.Property(p => p.CreatedAt)
@@ -48,22 +49,33 @@ public abstract class FullAuditedConfiguration<TEntity, TKey, TCreator, TEditor>
 	}
 }
 
-/// <inheritdoc cref="FullAuditedConfiguration{TEntity, TKey, TCreator, TEditor}"/>
+/// <inheritdoc cref="FullAuditedConfiguration{TEntity, TKey, TCreator, TEditor, TToken}"/>
 /// <remarks>
-/// <typeparamref name="TKey"/> is supplied; <c>TCreator</c> defaults to <see cref="string"/>
-/// and <c>TEditor</c> to <see cref="string"/>. For a custom creator or editor type use
+/// The key, creator and editor types are supplied; <c>TToken</c> defaults to a <see cref="byte"/>
+/// array. For a custom token type use
+/// <see cref="FullAuditedConfiguration{TEntity, TKey, TCreator, TEditor, TToken}"/> and name all five.
+/// </remarks>
+public abstract class FullAuditedConfiguration<TEntity, TKey, TCreator, TEditor> : FullAuditedConfiguration<TEntity, TKey, TCreator, TEditor, byte[]>, IEntityTypeConfiguration<TEntity>
+	where TEntity : class, IFullAuditedEntity<TKey, TCreator, TEditor>
+	where TKey : IEquatable<TKey>
+	where TCreator : notnull;
+
+/// <inheritdoc cref="FullAuditedConfiguration{TEntity, TKey, TCreator, TEditor, TToken}"/>
+/// <remarks>
+/// <typeparamref name="TKey"/> is supplied; <c>TCreator</c> defaults to <see cref="string"/>,
+/// <c>TEditor</c> to <see cref="string"/> and <c>TToken</c> to a <see cref="byte"/> array. For a
+/// custom creator or editor type use
 /// <see cref="FullAuditedConfiguration{TEntity, TKey, TCreator, TEditor}"/> and name all four.
 /// </remarks>
 public abstract class FullAuditedConfiguration<TEntity, TKey> : FullAuditedConfiguration<TEntity, TKey, string, string?>, IEntityTypeConfiguration<TEntity>
 	where TEntity : class, IFullAuditedEntity<TKey>
-	where TKey : IEquatable<TKey>
-{ }
+	where TKey : IEquatable<TKey>;
 
-/// <inheritdoc cref="FullAuditedConfiguration{TEntity, TKey, TCreator, TEditor}"/>
+/// <inheritdoc cref="FullAuditedConfiguration{TEntity, TKey, TCreator, TEditor, TToken}"/>
 /// <remarks>
 /// Only <typeparamref name="TEntity"/> is supplied; <c>TKey</c> defaults to <see cref="Guid"/>,
-/// <c>TCreator</c> to <see cref="string"/> and <c>TEditor</c> to <see cref="string"/>.
+/// <c>TCreator</c> to <see cref="string"/>, <c>TEditor</c> to <see cref="string"/> and
+/// <c>TToken</c> to a <see cref="byte"/> array.
 /// </remarks>
 public abstract class FullAuditedConfiguration<TEntity> : FullAuditedConfiguration<TEntity, Guid, string, string?>, IEntityTypeConfiguration<TEntity>
-	where TEntity : class, IFullAuditedEntity
-{ }
+	where TEntity : class, IFullAuditedEntity;

--- a/src/BB84.EntityFrameworkCore.Repositories/Configurations/IdentityConfiguration.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Configurations/IdentityConfiguration.cs
@@ -12,7 +12,7 @@ namespace BB84.EntityFrameworkCore.Repositories.Configurations;
 
 /// <summary>
 /// Represents an abstract base class for configuring entity types that implement the
-/// <see cref="IIdentityEntity{Tkey}"/> interface.
+/// <see cref="IIdentityEntity{TKey, TToken}"/> interface.
 /// </summary>
 /// <remarks>
 /// This class defines a default configuration for identity-related entities, including the primary key and
@@ -21,19 +21,32 @@ namespace BB84.EntityFrameworkCore.Repositories.Configurations;
 /// </remarks>
 /// <typeparam name="TEntity">The type of the entity being configured.</typeparam>
 /// <typeparam name="TKey">The type of the primary key for the entity.</typeparam>
-public abstract class IdentityConfiguration<TEntity, TKey> : IEntityTypeConfiguration<TEntity>
-	where TEntity : class, IIdentityEntity<TKey>
+/// <typeparam name="TToken">The type of the concurrency token.</typeparam>
+public abstract class IdentityConfiguration<TEntity, TKey, TToken> : IEntityTypeConfiguration<TEntity>
+	where TEntity : class, IIdentityEntity<TKey, TToken>
 	where TKey : IEquatable<TKey>
 {
 	/// <inheritdoc/>
 	public virtual void Configure(EntityTypeBuilder<TEntity> builder)
 	{
 		EntityTypeBuilderDefaults.ApplyIdentityKey<TEntity, TKey>(builder);
-		EntityTypeBuilderDefaults.ApplyConcurrencyToken(builder, columnOrder: 2);
+		EntityTypeBuilderDefaults.ApplyConcurrencyToken<TEntity, TToken>(builder, columnOrder: 2);
 	}
 }
 
-/// <inheritdoc cref="IdentityConfiguration{TEntity, TKey}"/>
+/// <inheritdoc cref="IdentityConfiguration{TEntity, TKey, TToken}"/>
+/// <remarks>
+/// <typeparamref name="TKey"/> is supplied; <c>TToken</c> defaults to a <see cref="byte"/> array.
+/// For a custom token type use <see cref="IdentityConfiguration{TEntity, TKey, TToken}"/> and
+/// name all three.
+/// </remarks>
+public abstract class IdentityConfiguration<TEntity, TKey> : IdentityConfiguration<TEntity, TKey, byte[]>, IEntityTypeConfiguration<TEntity>
+	where TEntity : class, IIdentityEntity<TKey>
+	where TKey : IEquatable<TKey>;
+
+/// <inheritdoc cref="IdentityConfiguration{TEntity, TKey, TToken}"/>
+/// <remarks>
+/// The primary key is of type <see cref="Guid"/> and the token a <see cref="byte"/> array.
+/// </remarks>
 public abstract class IdentityConfiguration<TEntity> : IdentityConfiguration<TEntity, Guid>, IEntityTypeConfiguration<TEntity>
-	where TEntity : class, IIdentityEntity
-{ }
+	where TEntity : class, IIdentityEntity;

--- a/src/BB84.EntityFrameworkCore.Repositories/README.md
+++ b/src/BB84.EntityFrameworkCore.Repositories/README.md
@@ -108,16 +108,18 @@ await dbContext.SaveChangesAsync(cancellationToken);
 
 Provider-agnostic `IEntityTypeConfiguration<TEntity>` base classes in `BB84.EntityFrameworkCore.Repositories.Configurations`. They apply key declaration, column ordering, the concurrency token, audit columns and — for enumerator entities — the name/description constraints, unique index and soft delete query filter. Everything they do is EF Core or EF Core Relational, so they work on PostgreSQL, SQLite, MySQL and Oracle.
 
-| Configuration class                                          | For entity type                               |
-| ------------------------------------------------------------ | --------------------------------------------- |
-| `IdentityConfiguration<TEntity, TKey>`                       | `IIdentityEntity<TKey>`                       |
-| `AuditedConfiguration<TEntity, TKey, TCreator, TEditor>`     | `IAuditedEntity<TKey, TCreator, TEditor>`     |
-| `FullAuditedConfiguration<TEntity, TKey, TCreator, TEditor>` | `IFullAuditedEntity<TKey, TCreator, TEditor>` |
-| `CompositeConfiguration<TEntity>`                            | `ICompositeEntity`                            |
-| `AuditedCompositeConfiguration<TEntity, TCreator, TEditor>`  | `IAuditedCompositeEntity<TCreator, TEditor>`  |
-| `EnumeratorConfiguration<TEntity, TKey>`                     | `IEnumeratorEntity<TKey>`                     |
+| Configuration class                                                  | For entity type                                       |
+| -------------------------------------------------------------------- | ----------------------------------------------------- |
+| `IdentityConfiguration<TEntity, TKey, TToken>`                       | `IIdentityEntity<TKey, TToken>`                       |
+| `AuditedConfiguration<TEntity, TKey, TCreator, TEditor, TToken>`     | `IAuditedEntity<TKey, TCreator, TEditor, TToken>`     |
+| `FullAuditedConfiguration<TEntity, TKey, TCreator, TEditor, TToken>` | `IFullAuditedEntity<TKey, TCreator, TEditor, TToken>` |
+| `CompositeConfiguration<TEntity, TToken>`                            | `ICompositeEntity<TToken>`                            |
+| `AuditedCompositeConfiguration<TEntity, TCreator, TEditor, TToken>`  | `IAuditedCompositeEntity<TCreator, TEditor, TToken>`  |
+| `EnumeratorConfiguration<TEntity, TKey, TToken>`                     | `IEnumeratorEntity<TKey, TToken>`                     |
 
-Each ladder has narrower generic aliases: one that supplies the key and defaults the creator/editor to `string`, and one that supplies nothing and defaults the key to `Guid` (`int` for the enumerator) as well. There is deliberately no alias that defaults the key alone — pick the full form and name every parameter when the creator or editor type is not `string`.
+Each ladder has narrower generic aliases: one that defaults the concurrency token to `byte[]`, one that supplies the key and defaults the creator/editor to `string`, and one that supplies nothing and defaults the key to `Guid` (`int` for the enumerator) as well. There is deliberately no alias that defaults the key alone — pick the full form and name every parameter when the creator or editor type is not `string`.
+
+The token rung is the one to reach for on a provider without an eight byte row version. It marks the property as a concurrency token generated on add or update, which suits `rowversion` and PostgreSQL's `xmin`; for a token the application rotates itself, override the generation strategy after the `base.Configure(builder)` call.
 
 On SQL Server, use the same type names from `BB84.EntityFrameworkCore.Repositories.SqlServer.Configurations` instead — those derive from these and add clustering, `NEWID()` defaults and `sysname` audit columns.
 

--- a/tests/BB84.EntityFrameworkCore.Repositories.Agnostic.Tests/ConcurrencyTokenTypeTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Agnostic.Tests/ConcurrencyTokenTypeTests.cs
@@ -1,0 +1,92 @@
+// Copyright: 2024 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using BB84.EntityFrameworkCore.Repositories.Agnostic.Tests.Persistence;
+using BB84.EntityFrameworkCore.Repositories.Agnostic.Tests.Persistence.Entities;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace BB84.EntityFrameworkCore.Repositories.Agnostic.Tests;
+
+/// <summary>
+/// Covers a concurrency token that is not a row version.
+/// </summary>
+/// <remarks>
+/// The rest of this suite runs on a <see cref="byte"/> array token propped up by
+/// <see cref="RowVersionEmulation"/>, which is exactly the scaffolding a real consumer does not
+/// get. These tests take the other route the token type parameter opened up: a
+/// <see cref="Guid"/> the writer rotates, needing no emulation at all.
+/// </remarks>
+[TestClass]
+public sealed class ConcurrencyTokenTypeTests : UnitTestBase
+{
+	[TestMethod]
+	public void EntityWithNonRowVersionTokenRoundTrips()
+	{
+		TokenTypeEntity entity = Create("Round tripping");
+
+		using TestDbContext other = CreateContext();
+		TokenTypeEntity loaded = other.Set<TokenTypeEntity>().Single(x => x.Id == entity.Id);
+
+		Assert.AreEqual(entity.Timestamp, loaded.Timestamp);
+		Assert.AreNotEqual(Guid.Empty, loaded.Timestamp);
+	}
+
+	[TestMethod]
+	public void TokenIsMarkedAsAConcurrencyToken()
+	{
+		// The base configuration rung is what applies this, so the assertion is really that the
+		// rung accepted a token type other than the one it defaults to.
+		Microsoft.EntityFrameworkCore.Metadata.IProperty timestamp = DbContext.Model
+			.FindEntityType(typeof(TokenTypeEntity))!
+			.FindProperty(nameof(TokenTypeEntity.Timestamp))!;
+
+		Assert.IsTrue(timestamp.IsConcurrencyToken);
+		Assert.AreEqual(typeof(Guid), timestamp.ClrType);
+	}
+
+	[TestMethod]
+	public void StaleTokenRaisesConcurrencyException()
+	{
+		TokenTypeEntity entity = Create("Contested");
+
+		// A competing writer rotates the token, which the entity tracked here knows nothing about.
+		using (TestDbContext other = CreateContext())
+		{
+			TokenTypeEntity contested = other.Set<TokenTypeEntity>().Single(x => x.Id == entity.Id);
+
+			contested.Name = "Taken.";
+			contested.Timestamp = Guid.NewGuid();
+
+			_ = other.SaveChanges();
+		}
+
+		entity.Name = "Too late.";
+		entity.Timestamp = Guid.NewGuid();
+
+		_ = Assert.ThrowsExactly<DbUpdateConcurrencyException>(() => DbContext.SaveChanges());
+	}
+
+	[TestMethod]
+	public void CurrentTokenAllowsTheUpdate()
+	{
+		TokenTypeEntity entity = Create("Uncontested");
+
+		entity.Name = "Edited.";
+		entity.Timestamp = Guid.NewGuid();
+
+		Assert.AreEqual(1, DbContext.SaveChanges());
+	}
+
+	private TokenTypeEntity Create(string name)
+	{
+		TokenTypeEntity entity = new() { Name = name, Timestamp = Guid.NewGuid() };
+
+		_ = DbContext.Set<TokenTypeEntity>().Add(entity);
+		_ = DbContext.SaveChanges();
+
+		return entity;
+	}
+}

--- a/tests/BB84.EntityFrameworkCore.Repositories.Agnostic.Tests/GenericLadderTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Agnostic.Tests/GenericLadderTests.cs
@@ -78,33 +78,45 @@ public sealed class GenericLadderTests
 
 	// ---- entity ladder -------------------------------------------------------------------
 
+	private sealed class CompositeTokenedProbe : CompositeEntity<Guid>;
 	private sealed class CompositeProbe : CompositeEntity;
+	private sealed class IdentityTokenedProbe : IdentityEntity<int, Guid>;
 	private sealed class IdentityKeyedProbe : IdentityEntity<int>;
 	private sealed class IdentityProbe : IdentityEntity;
+	private sealed class EnumeratorTokenedProbe : EnumeratorEntity<long, Guid>;
 	private sealed class EnumeratorKeyedProbe : EnumeratorEntity<long>;
 	private sealed class EnumeratorProbe : EnumeratorEntity;
+	private sealed class AuditedTokenedProbe : AuditedEntity<int, int, int?, Guid>;
 	private sealed class AuditedFullyNamedProbe : AuditedEntity<int, int, int?>;
 	private sealed class AuditedKeyedProbe : AuditedEntity<int>;
 	private sealed class AuditedProbe : AuditedEntity;
+	private sealed class FullAuditedTokenedProbe : FullAuditedEntity<int, int, int?, Guid>;
 	private sealed class FullAuditedFullyNamedProbe : FullAuditedEntity<int, int, int?>;
 	private sealed class FullAuditedKeyedProbe : FullAuditedEntity<int>;
 	private sealed class FullAuditedProbe : FullAuditedEntity;
+	private sealed class AuditedCompositeTokenedProbe : AuditedCompositeEntity<int, int?, Guid>;
 	private sealed class AuditedCompositeNamedProbe : AuditedCompositeEntity<int, int?>;
 	private sealed class AuditedCompositeProbe : AuditedCompositeEntity;
 
 	// ---- configuration ladder ------------------------------------------------------------
 
+	private abstract class IdentityTokenedConfigurationProbe : IdentityConfiguration<IdentityTokenedProbe, int, Guid>;
 	private abstract class IdentityKeyedConfigurationProbe : IdentityConfiguration<IdentityKeyedProbe, int>;
 	private abstract class IdentityConfigurationProbe : IdentityConfiguration<IdentityProbe>;
+	private abstract class CompositeTokenedConfigurationProbe : CompositeConfiguration<CompositeTokenedProbe, Guid>;
 	private abstract class CompositeConfigurationProbe : CompositeConfiguration<CompositeProbe>;
+	private abstract class EnumeratorTokenedConfigurationProbe : EnumeratorConfiguration<EnumeratorTokenedProbe, long, Guid>;
 	private abstract class EnumeratorKeyedConfigurationProbe : EnumeratorConfiguration<EnumeratorKeyedProbe, long>;
 	private abstract class EnumeratorConfigurationProbe : EnumeratorConfiguration<EnumeratorProbe>;
+	private abstract class AuditedTokenedConfigurationProbe : AuditedConfiguration<AuditedTokenedProbe, int, int, int?, Guid>;
 	private abstract class AuditedFullyNamedConfigurationProbe : AuditedConfiguration<AuditedFullyNamedProbe, int, int, int?>;
 	private abstract class AuditedKeyedConfigurationProbe : AuditedConfiguration<AuditedKeyedProbe, int>;
 	private abstract class AuditedConfigurationProbe : AuditedConfiguration<AuditedProbe>;
+	private abstract class FullAuditedTokenedConfigurationProbe : FullAuditedConfiguration<FullAuditedTokenedProbe, int, int, int?, Guid>;
 	private abstract class FullAuditedFullyNamedConfigurationProbe : FullAuditedConfiguration<FullAuditedFullyNamedProbe, int, int, int?>;
 	private abstract class FullAuditedKeyedConfigurationProbe : FullAuditedConfiguration<FullAuditedKeyedProbe, int>;
 	private abstract class FullAuditedConfigurationProbe : FullAuditedConfiguration<FullAuditedProbe>;
+	private abstract class AuditedCompositeTokenedConfigurationProbe : AuditedCompositeConfiguration<AuditedCompositeTokenedProbe, int, int?, Guid>;
 	private abstract class AuditedCompositeNamedConfigurationProbe : AuditedCompositeConfiguration<AuditedCompositeNamedProbe, int, int?>;
 	private abstract class AuditedCompositeConfigurationProbe : AuditedCompositeConfiguration<AuditedCompositeProbe>;
 

--- a/tests/BB84.EntityFrameworkCore.Repositories.Agnostic.Tests/Persistence/Configurations/TokenTypeConfiguration.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Agnostic.Tests/Persistence/Configurations/TokenTypeConfiguration.cs
@@ -1,0 +1,32 @@
+// Copyright: 2024 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using BB84.EntityFrameworkCore.Repositories.Agnostic.Tests.Persistence.Entities;
+using BB84.EntityFrameworkCore.Repositories.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace BB84.EntityFrameworkCore.Repositories.Agnostic.Tests.Persistence.Configurations;
+
+/// <remarks>
+/// Names the token type on the configuration rung as well as on the entity, which is the pairing
+/// the whole feature comes down to. The base still marks the property as a concurrency token; only
+/// the generation strategy is overridden, because no provider generates a <see cref="Guid"/> row
+/// version by itself and this one is rotated by the writer instead.
+/// </remarks>
+internal sealed class TokenTypeConfiguration : IdentityConfiguration<TokenTypeEntity, Guid, Guid>
+{
+	public override void Configure(EntityTypeBuilder<TokenTypeEntity> builder)
+	{
+		base.Configure(builder);
+
+		_ = builder.Property(e => e.Timestamp)
+			.ValueGeneratedNever();
+
+		_ = builder.Property(e => e.Name)
+			.IsRequired();
+	}
+}

--- a/tests/BB84.EntityFrameworkCore.Repositories.Agnostic.Tests/Persistence/Entities/TokenTypeEntity.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Agnostic.Tests/Persistence/Entities/TokenTypeEntity.cs
@@ -1,0 +1,30 @@
+// Copyright: 2024 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using BB84.EntityFrameworkCore.Entities;
+
+namespace BB84.EntityFrameworkCore.Repositories.Agnostic.Tests.Persistence.Entities;
+
+/// <summary>
+/// An entity whose concurrency token is a <see cref="Guid"/> instead of a row version.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This one lives here rather than in the shared test model on purpose: the shared model is used
+/// by the SQL Server suite as well, where the token is a <c>rowversion</c> and has to stay one.
+/// </para>
+/// <para>
+/// It is the only entity in either suite that does not take the token type the base classes
+/// default to, which is the whole reason it exists — without it nothing would fail if the token
+/// type quietly went back to being fixed.
+/// </para>
+/// </remarks>
+internal sealed class TokenTypeEntity : IdentityEntity<Guid, Guid>
+{
+	/// <summary>
+	/// The name of the entity.
+	/// </summary>
+	public required string Name { get; set; }
+}

--- a/tests/BB84.EntityFrameworkCore.Repositories.Agnostic.Tests/Persistence/RowVersionEmulation.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Agnostic.Tests/Persistence/RowVersionEmulation.cs
@@ -15,6 +15,12 @@ namespace BB84.EntityFrameworkCore.Repositories.Agnostic.Tests.Persistence;
 /// </summary>
 /// <remarks>
 /// <para>
+/// Only <see cref="byte"/> array tokens are emulated. Since the token type became a parameter of
+/// <see cref="IConcurrency{TToken}"/>, an entity is free to use one this class knows nothing about
+/// — <c>randomblob(8)</c> would be the wrong value and the rotating trigger the wrong mechanism —
+/// so anything else is left to its own configuration.
+/// </para>
+/// <para>
 /// The agnostic configurations mark <see cref="IConcurrency.Timestamp"/> as a concurrency token
 /// that is generated on add or update. On SQL Server the <see cref="byte"/> array plus that
 /// combination is convention-mapped to <c>rowversion</c> and the store fills it in. SQLite has no
@@ -55,7 +61,7 @@ internal static class RowVersionEmulation
 		{
 			IMutableProperty? timestamp = entityType.FindProperty(nameof(IConcurrency.Timestamp));
 
-			if (timestamp is null || !timestamp.IsConcurrencyToken)
+			if (timestamp is null || !timestamp.IsConcurrencyToken || timestamp.ClrType != typeof(byte[]))
 				continue;
 
 			timestamp.SetDefaultValueSql(DefaultValueSql);
@@ -82,7 +88,7 @@ internal static class RowVersionEmulation
 
 			IProperty? timestamp = entityType.FindProperty(nameof(IConcurrency.Timestamp));
 
-			if (timestamp is null || !timestamp.IsConcurrencyToken)
+			if (timestamp is null || !timestamp.IsConcurrencyToken || timestamp.ClrType != typeof(byte[]))
 				continue;
 
 			string table = entityType.GetTableName()!;


### PR DESCRIPTION
**Changes:**

- `IConcurrency` hardcoded `byte[]` Timestamp, which is a SQL Server rowversion, in a package whose selling point is having no package references at all.
- Introduce `IConcurrency<TToken>` with `IConcurrency : IConcurrency<byte[]>` as the shorthand, mirroring `IUserAudited`.
- `TToken` goes last on the widest rung of every entity and configuration ladder, so each gained one rung whose parameter list is a prefix-consistent extension of the old one.
- That is what keeps the ladders unambiguous: the confusion removed earlier was between rungs meaning different things at the same arity, which this does not reintroduce.
- The `SqlServer` configurations deliberately stop at the `byte[]` rung.
- A rowversion is eight bytes and there is nothing there for another type to map onto; an entity with a different token belongs on the agnostic bases.

closes #260 