### PR TITLE
chore(build): set the package validation baseline to 5.0.818

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
 		<Deterministic>True</Deterministic>
 		<EnableNETAnalyzers>True</EnableNETAnalyzers>
 		<EnablePackageValidation>True</EnablePackageValidation>
-		<!-- <PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion> -->
+		<PackageValidationBaselineVersion>5.0.818</PackageValidationBaselineVersion>
 		<GenerateAssemblyInfo>True</GenerateAssemblyInfo>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
**Changes:**

- `EnablePackageValidation` has been on for a long time and never validated anything: it compares against a baseline package, and `PackageValidationBaselineVersion` was never set, so with a single target framework there was nothing to compare and pack succeeded in silence.
- `5.0.818` is published, so point the baseline at it. The version is the NuGet-normalised form of `FileVersion` (5.0.0818), not the `5.0.0` placeholder the commented-out line carried.