### PR TITLE
feat(repositories): add constructor null guards and tests for DI safety

### DIFF
--- a/src/BB84.EntityFrameworkCore.Repositories/GenericRepository.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/GenericRepository.cs
@@ -17,11 +17,21 @@ namespace BB84.EntityFrameworkCore.Repositories;
 /// The generic repository implementation.
 /// </summary>
 /// <inheritdoc cref="IGenericRepository{TEntity}"/>
-/// <param name="dbContext">The database context to work with.</param>
-public abstract class GenericRepository<TEntity>(IDbContext dbContext) : IGenericRepository<TEntity>
+public abstract class GenericRepository<TEntity> : IGenericRepository<TEntity>
 	where TEntity : class
 {
-	private readonly DbSet<TEntity> _dbSet = dbContext.Set<TEntity>();
+	private readonly DbSet<TEntity> _dbSet;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="GenericRepository{TEntity}"/> class.
+	/// </summary>
+	/// <param name="dbContext">The database context to work with.</param>
+	protected GenericRepository(IDbContext dbContext)
+	{
+		ArgumentNullException.ThrowIfNull(dbContext, nameof(dbContext));
+
+		_dbSet = dbContext.Set<TEntity>();
+	}
 
 	/// <inheritdoc/>
 	public void Create(TEntity entity)

--- a/src/BB84.EntityFrameworkCore.Repositories/Interceptors/UserAuditedInterceptor.cs
+++ b/src/BB84.EntityFrameworkCore.Repositories/Interceptors/UserAuditedInterceptor.cs
@@ -27,12 +27,22 @@ namespace BB84.EntityFrameworkCore.Repositories.Interceptors;
 /// </para>
 /// </remarks>
 /// <typeparam name="TUser">The type representing the user.</typeparam>
-/// <param name="currentUserProvider">The provider supplying the current user.</param>
 /// <inheritdoc cref="SaveChangesInterceptor"/>
-public class UserAuditedInterceptor<TUser>(ICurrentUserProvider<TUser> currentUserProvider) : SaveChangesInterceptor
+public class UserAuditedInterceptor<TUser> : SaveChangesInterceptor
 	where TUser : notnull
 {
-	private readonly ICurrentUserProvider<TUser> _currentUserProvider = currentUserProvider;
+	private readonly ICurrentUserProvider<TUser> _currentUserProvider;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="UserAuditedInterceptor{TUser}"/> class.
+	/// </summary>
+	/// <param name="currentUserProvider">The provider supplying the current user.</param>
+	public UserAuditedInterceptor(ICurrentUserProvider<TUser> currentUserProvider)
+	{
+		ArgumentNullException.ThrowIfNull(currentUserProvider, nameof(currentUserProvider));
+
+		_currentUserProvider = currentUserProvider;
+	}
 
 	/// <inheritdoc/>
 	public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)

--- a/tests/BB84.EntityFrameworkCore.Repositories.Agnostic.Tests/ConstructorGuardTests.cs
+++ b/tests/BB84.EntityFrameworkCore.Repositories.Agnostic.Tests/ConstructorGuardTests.cs
@@ -1,0 +1,59 @@
+// Copyright: 2024 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using BB84.EntityFrameworkCore.Repositories.Interceptors;
+using BB84.EntityFrameworkCore.TestSupport.Repositories;
+
+namespace BB84.EntityFrameworkCore.Repositories.Agnostic.Tests;
+
+/// <summary>
+/// Covers the constructor guards of the repository ladder and the audit interceptors.
+/// </summary>
+[TestClass]
+public sealed class ConstructorGuardTests
+{
+	/// <summary>
+	/// Every rung of the repository ladder, since each forwards the context through a primary
+	/// constructor and none of them declares a field initializer of its own.
+	/// </summary>
+	[TestMethod]
+	public void RepositoriesShouldRejectANullContext()
+	{
+		AssertRejects("dbContext", () => new PersonJobRepository(null!));
+		AssertRejects("dbContext", () => new SkillRepository(null!));
+		AssertRejects("dbContext", () => new JobRepository(null!));
+		AssertRejects("dbContext", () => new PersonRepository(null!));
+		AssertRejects("dbContext", () => new PersonTypeRepository(null!));
+	}
+
+	[TestMethod]
+	public void UserAuditedInterceptorShouldRejectANullProvider()
+	{
+		AssertRejects("currentUserProvider", () => new UserAuditedInterceptor(null!));
+		AssertRejects("currentUserProvider", () => new UserAuditedInterceptor<string>(null!));
+	}
+
+	/// <summary>
+	/// The deliberate exception to the rule, asserted so that nobody "fixes" it into a guard.
+	/// </summary>
+	/// <remarks>
+	/// The clock is an optional parameter that falls back to <see cref="TimeProvider.System"/>;
+	/// passing nothing is the supported way to construct it.
+	/// </remarks>
+	[TestMethod]
+	public void TimeAuditedInterceptorShouldAcceptANullClock()
+	{
+		TimeAuditedInterceptor interceptor = new(null);
+
+		Assert.IsNotNull(interceptor);
+	}
+
+	private static void AssertRejects(string parameterName, Func<object> construct)
+	{
+		ArgumentNullException exception = Assert.ThrowsExactly<ArgumentNullException>(() => construct());
+
+		Assert.AreEqual(parameterName, exception.ParamName);
+	}
+}


### PR DESCRIPTION
**Changes:**

- Added explicit `ArgumentNullException` guard clauses in `GenericRepository` and `UserAuditedInterceptor` constructors to prevent null dependency issues.
- Introduced `ConstructorGuardTests` to verify correct exception behavior and parameter names, and to confirm `TimeAuditedInterceptor`s null clock allowance.

closes #262 